### PR TITLE
Adapt NEWS.rst to follow Twisted's style more closely

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -1,50 +1,58 @@
 Changelog
 =========
+
 Ldaptor has a new version schema. As a first-party library we now follow Twisted's example.
 
-Release 14.0
-------------
+Release 14.0 (UNRELEASED)
+-------------------------
 
-**License**
-    * Tommi changed Ldaptor's license to the MIT (Expat) license.
-    * Replaced MD4 code with one using BSD 3-clause license.
+License
+^^^^^^^
 
-**API Changes**
-    * Ldaptor client and server: None
-    * Everything having to do with webui and Nevow have been removed
+    - Ldaptor's original author `Tommi Virtanen <https://github.com/tv42>`_ changed the license to the MIT (Expat) license.
+    - ldaptor.md4 has been replaced by a 3-clause BSD version.
 
-**Testing**
-    * Added Travis-CI.
-    * Added test coverage, we're currently at around 75%.
-    * Use Tox build matrix to handle pypy, py26, py27 and twisted version from 10.0 until 14.0
-    * The above passes all existing unit tests, a few "ordering" bugs were fixed in the process.
-    * Added pureldap.LDAPAbandonRequest and extra pureldap.LDAPExtendedRequest test
+API Changes
+^^^^^^^^^^^
 
-**Improved Documentation**
-    * Added, updated and reworked documentation using Sphinx.
-    * Stay tuned to: https://ldaptor.readthedocs.org/
-    * Dia is required for convert diagrams to svg/png, this might change in the future.
+    - Ldaptor client and server: None
+    - Everything having to do with webui and Nevow have been *removed*.
 
-**Bug fixes**
-    * Fix startTLS support, in accordance to RFC2251
-    * Fix for debug logging in ldapclient
-    * Added support for abandon request
-    * Replace string literal exceptions with real Exceptions
-    * Fixes the invocation of dia for diagramm generation in a headless environment
-    * Fixes #526522 ldaptor-ldap2passwd --help throws exception.
-    * Fix unicode problem with add contact
-    * Fixes a small bug in the LDAPExtendedRequest constructor was making the LDAPStartTLSRequest constructor fail
-    * Added very basic, low-level support for SASL credentials in the pureldap module
-    * Fix typo in module name: pureldap -> pureber.
-    * Fix deprecated exception error
-    * Handle additional records in DNS response
-    * Fix dns import
-    * Extend test driver send_multiResponse() to return deferred and throw errors
-    * Reroute errback to deferred returned by search()
-    * Make it possible to specify local address for LDAP client
-    * Added stub for SearchResultReference
-    * Use hashlib and built-in set() instead of deprecated modules
+Features
+^^^^^^^^
 
+    - `Travis CI <https://travis-ci.org/twisted/ldaptor/>`_ is now used for continuous integration.
+    - Test coverage is now measured. We're currently at around 75%.
+    - tox is used now to test ldaptor on all combinations of pypy, Python 2.6, Python 2.7 and Twisted versions from 10.0 until 14.0.
+    - A few ordering bugs that were exposed by that and are fixed now.
+    - ldaptor.protocols.pureldap.LDAPExtendedRequest now has additional tests.
+    - The new ldaptor.protocols.pureldap.LDAPAbandonRequest adds support for abandoning requests.
+    - ldaptor.protocols.pureldap.LDAPBindRequest has basic SASL support now. Higher-level APIs like ldapclient don't expose it yet though.
+
+Bugfixes
+^^^^^^^^
+
+    - ldaptor.protocols.pureldap.LDAPExtendedRequest now correctly handles STARTTLS in accordance to `RFC2251 <http://tools.ietf.org/html/rfc2251>`_.
+    - ldaptor.protocols.ldap.ldapclient's now uses log.msg for it's debug listing instead of the non-Twisted log.debug.
+    - String literal exceptions have been replaced by real Exceptions.
+    - "bin/ldaptor-ldap2passwd --help" now does not throws an exception anymore (`debian bug #526522 <https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=526522>`_).
+    - ldaptor.delta.Modification and ldaptor.protocols.ldap.ldapsyntax.PasswordSetAggregateError that are used for adding contacts now handle unicode arguments properly.
+    - ldaptor.protocols.pureldap.LDAPExtendedRequest's constructor has been fixed so the constructor of ldaptor.protocols.pureldap.LDAPStartTLSRequest doesn't fail anymore.
+    - ldaptor.protocols.ldap.ldapserver.BaseLDAPServer now uses the correct exception module in dataReceived.
+    - ldaptor.protocols.ldap.ldaperrors.LDAPException: "Fix deprecated exception error"
+    - bin/ldaptor-find-server now imports dns from the correct twisted modules.
+    - bin/ldaptor-find-server now only prints SRV records.
+    - ldaptor.protocols.ldap.ldapsyntax.LDAPEntryWithClient now correctly propagates errors on search(). The test suite has been adapted appropriately.
+    - ldaptor.protocols.ldap.ldapconnector.LDAPConnector now supports specifying a local address when connecting to a server.
+    - The new ldaptor.protocols.pureldap.LDAPSearchResultReference now prevents ldaptor from choking on results containing SearchResultReference (usually from Active Directory servers). It is currently only a stub and silently ignored.
+    - hashlib and built-in set() are now used instead of deprecated modules.
+
+Improved Documentation
+^^^^^^^^^^^^^^^^^^^^^^
+
+    - Added, updated and reworked documentation using Sphinx. `Dia <https://wiki.gnome.org/Apps/Dia/>`_ is required for converting diagrams to svg/png, this might change in the future.
+    - Dia is now invoked correctly for diagram generation in a headless environment.
+    - The documentation is now hosted on https://ldaptor.readthedocs.org/.
 
 Prehistory
 ----------


### PR DESCRIPTION
So this is my stab at it.

A couple of notes:
- I have replaced \* by - because that’s what Twisted does in it’s NEWS file.  RST doesn’t care, so I can revert it if desired.
- I have slightly reordered the sections, again inspired by Twisted’s way.
- I have re-written the entries in intending accordance with http://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles so please double-check both conformity and spelling/grammar.
- I have no idea what the point of “Fix deprecated exception error” is.

I can see the :ship: on the horizon.
