### PR TITLE
Server pwdchange

### DIFF
--- a/ldaptor/inmemory.py
+++ b/ldaptor/inmemory.py
@@ -4,8 +4,10 @@ from twisted.python.failure import Failure
 from ldaptor import interfaces, entry, entryhelpers
 from ldaptor.protocols.ldap import distinguishedname, ldaperrors, ldifprotocol
 
+
 class LDAPCannotRemoveRootError(ldaperrors.LDAPNamingViolation):
     """Cannot remove root of LDAP tree"""
+
 
 class ReadOnlyInMemoryLDAPEntry(entry.EditableLDAPEntry,
                                 entryhelpers.DiffTreeMixin,
@@ -55,9 +57,8 @@ class ReadOnlyInMemoryLDAPEntry(entry.EditableLDAPEntry,
         for c in self._children:
             if c.dn.split()[0] == rdn:
                 raise ldaperrors.LDAPEntryAlreadyExists, c.dn
-        dn = distinguishedname.DistinguishedName(listOfRDNs=
-                                                 (rdn,)
-                                                 +self.dn.split())
+        dn = distinguishedname.DistinguishedName(
+            listOfRDNs=(rdn,) + self.dn.split())
         e = ReadOnlyInMemoryLDAPEntry(dn, attributes)
         e._parent = self
         self._children.append(e)
@@ -117,7 +118,8 @@ class ReadOnlyInMemoryLDAPEntry(entry.EditableLDAPEntry,
         return defer.maybeDeferred(self._move, newDN)
 
     def commit(self):
-        return defer.succeed(self)
+        return defer.succeed(True)
+
 
 class InMemoryLDIFProtocol(ldifprotocol.LDIF):
 
@@ -135,7 +137,8 @@ class InMemoryLDIFProtocol(ldifprotocol.LDIF):
     """
 
     def __init__(self):
-        self.db = None #do not access this via db, just to make sure you respect the ordering
+        # Do not access this via db, just to make sure you respect the ordering
+        self.db = None
         self._deferred = defer.Deferred()
         self.completed = defer.Deferred()
 
@@ -166,10 +169,10 @@ class InMemoryLDIFProtocol(ldifprotocol.LDIF):
             self._deferred.addCallback(self._addEntry, entry)
 
     def lookupFailed(self, reason, entry):
-        return reason # pass the error (abort) by default
+        return reason  # pass the error (abort) by default
 
     def addFailed(self, reason, entry):
-        return reason # pass the error (abort) by default
+        return reason  # pass the error (abort) by default
 
     def connectionLost(self, reason):
         super(InMemoryLDIFProtocol, self).connectionLost(reason)
@@ -178,7 +181,8 @@ class InMemoryLDIFProtocol(ldifprotocol.LDIF):
         else:
             self._deferred.chainDeferred(self.completed)
 
-        del self._deferred # invalidate it to flush out bugs
+        del self._deferred  # invalidate it to flush out bugs
+
 
 def fromLDIFFile(f):
     """Read LDIF data from a file."""

--- a/ldaptor/interfaces.py
+++ b/ldaptor/interfaces.py
@@ -1,5 +1,6 @@
 from zope.interface import Interface
 
+
 class ILDAPEntry(Interface):
     """
 
@@ -12,7 +13,6 @@ class ILDAPEntry(Interface):
     ...     })
     >>> o
     LDAPEntry(dn='cn=foo,dc=example,dc=com', attributes={'anAttribute': ['itsValue', 'secondValue'], 'onemore': ['aValue']})
-
     """
 
     def __getitem__(self, key):
@@ -126,6 +126,7 @@ class ILDAPEntry(Interface):
         incorrect.
         """
 
+
 class IEditableLDAPEntry(Interface):
     """Interface definition for editable LDAP entries."""
 
@@ -170,8 +171,8 @@ class IEditableLDAPEntry(Interface):
         """
         Send all pending changes to the LDAP server.
 
-        @returns: a Deferred that tells you whether the
-        operation succeeded or not. (TODO specify how)
+        @returns: a Deferred that fires True (operation succeeded)
+        or False (operation failed).
         """
 
     def move(self, newDN):
@@ -206,19 +207,20 @@ class IEditableLDAPEntry(Interface):
 
         """
 
+
 class IConnectedLDAPEntry(Interface):
-    """Interface definition for LDAP entries that are part of a bigger whole."""
+    """
+    Interface definition for LDAP entries that are part of a bigger
+    whole.
+    """
 
     def namingContext(self):
         """
-
         Return an LDAPEntry for the naming context that contains this object.
-
         """
 
     def fetch(self, *attributes):
         """
-
         Fetch the attributes of this object from the server.
 
         @param attributes: Attributes to fetch. If none, fetch all
@@ -228,7 +230,6 @@ class IConnectedLDAPEntry(Interface):
 
         @return: A Deferred that will complete when the operation is
         done.
-
         """
 
     def search(self,
@@ -333,6 +334,7 @@ class IConnectedLDAPEntry(Interface):
         @return: Boolean.
 
         """
+
 
 class ILDAPConfig(Interface):
     """Generic LDAP configuration retrieval."""

--- a/ldaptor/test/test_inmemory.py
+++ b/ldaptor/test/test_inmemory.py
@@ -1,7 +1,6 @@
 """
 Test cases for ldaptor.inmemory module.
 """
-
 from twisted.trial import unittest
 from cStringIO import StringIO
 from ldaptor import inmemory, delta, testutil
@@ -379,8 +378,6 @@ class TestInMemoryDatabase(unittest.TestCase):
         self.meta['foo'] = ['bar']
         d = self.meta.commit()
         self.failUnless(d.called)
-        d.addCallback(self.assertIdentical, self.meta)
-        return d
 
 class FromLDIF(unittest.TestCase):
     def test_single(self):

--- a/ldaptor/test/test_server.py
+++ b/ldaptor/test/test_server.py
@@ -386,7 +386,7 @@ class LDAPServerTest(unittest.TestCase):
         self.server.dataReceived(
             str(
                 pureldap.LDAPMessage(
-                    pureldap.LDAPDelRequest(str(self.thingie.dn)), i
+                    pureldap.LDAPDelRequest(str(self.thingie.dn)),
                     id=2)))
         self.assertEquals(
             self.server.transport.value(),

--- a/ldaptor/test/test_server.py
+++ b/ldaptor/test/test_server.py
@@ -1,40 +1,56 @@
 """
 Test cases for ldaptor.protocols.ldap.ldapserver module.
 """
-
-from twisted.trial import unittest
-import sets, base64
-from twisted.internet import protocol, address
+from __future__ import print_function
+import base64
+import sets
+import types
+from twisted.internet import address, protocol
 from twisted.python import components
 from ldaptor import inmemory, interfaces, schema, delta, entry
-from ldaptor.protocols.ldap import ldapserver, ldapclient, ldaperrors, fetchschema
+from ldaptor.protocols.ldap import ldapserver, ldapclient, ldaperrors, \
+    fetchschema
 from ldaptor.protocols import pureldap, pureber
-from twisted.test import proto_helpers
 from ldaptor.test import util, test_schema
+from twisted.test import proto_helpers
+from twisted.trial import unittest
+
+
+def wrapCommit(entry, cb, *args, **kwds):
+    bound_commit = entry.commit
+
+    def commit_(self):
+        d = bound_commit()
+        d.addCallback(cb, *args, **kwds)
+        return d
+
+    f = types.MethodType(commit_, entry, entry.__class__)
+    entry.commit = f
+
 
 class LDAPServerTest(unittest.TestCase):
+
     def setUp(self):
         self.root = inmemory.ReadOnlyInMemoryLDAPEntry(
             dn='dc=example,dc=com',
-            attributes={ 'dc': 'example',
-                         })
+            attributes={'dc': 'example'})
         self.stuff = self.root.addChild(
             rdn='ou=stuff',
             attributes={
-            'objectClass': ['a', 'b'],
-            'ou': ['stuff'],
+                'objectClass': ['a', 'b'],
+                'ou': ['stuff'],
             })
         self.thingie = self.stuff.addChild(
             rdn='cn=thingie',
             attributes={
-            'objectClass': ['a', 'b'],
-            'cn': ['thingie'],
+                'objectClass': ['a', 'b'],
+                'cn': ['thingie'],
             })
         self.another = self.stuff.addChild(
             rdn='cn=another',
             attributes={
-            'objectClass': ['a', 'b'],
-            'cn': ['another'],
+                'objectClass': ['a', 'b'],
+                'cn': ['another'],
             })
         server = ldapserver.LDAPServer()
         server.factory = self.root
@@ -43,313 +59,406 @@ class LDAPServerTest(unittest.TestCase):
         self.server = server
 
     def test_bind(self):
-        self.server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=4)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=4)))
+        self.server.dataReceived(
+            str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=4)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPBindResponse(resultCode=0),
+                    id=4)))
 
     def test_bind_success(self):
-        self.thingie['userPassword'] = ['{SSHA}yVLLj62rFf3kDAbzwEU0zYAVvbWrze8='] # "secret"
-        self.server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(
-            dn='cn=thingie,ou=stuff,dc=example,dc=com',
-            auth='secret'), id=4)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPBindResponse(resultCode=0,
-                                      matchedDN='cn=thingie,ou=stuff,dc=example,dc=com'),
-            id=4)))
+        self.thingie['userPassword'] = ['{SSHA}yVLLj62rFf3kDAbzwEU0zYAVvbWrze8=']  # "secret"
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPBindRequest(
+                        dn='cn=thingie,ou=stuff,dc=example,dc=com',
+                        auth='secret'),
+                    id=4)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPBindResponse(
+                        resultCode=0,
+                        matchedDN='cn=thingie,ou=stuff,dc=example,dc=com'),
+                    id=4)))
 
     def test_bind_invalidCredentials_badPassword(self):
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPBindRequest(dn='cn=thingie,ou=stuff,dc=example,dc=com',
-                                     auth='invalid'),
-            id=734)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPBindResponse(
-            resultCode=ldaperrors.LDAPInvalidCredentials.resultCode),
-            id=734)))
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPBindRequest(
+                        dn='cn=thingie,ou=stuff,dc=example,dc=com',
+                        auth='invalid'),
+                    id=734)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPBindResponse(
+                        resultCode=ldaperrors.LDAPInvalidCredentials.resultCode),
+                    id=734)))
 
     def test_bind_invalidCredentials_nonExisting(self):
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPBindRequest(dn='cn=non-existing,dc=example,dc=com',
-                                     auth='invalid'),
-            id=78)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPBindResponse(
-            resultCode=ldaperrors.LDAPInvalidCredentials.resultCode),
-            id=78)))
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPBindRequest(
+                        dn='cn=non-existing,dc=example,dc=com',
+                        auth='invalid'),
+                    id=78)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPBindResponse(
+                        resultCode=ldaperrors.LDAPInvalidCredentials.resultCode),
+                    id=78)))
 
     def test_bind_badVersion_1_anonymous(self):
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPBindRequest(version=1),
-            id=32)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPBindResponse(
-            resultCode=ldaperrors.LDAPProtocolError.resultCode,
-            errorMessage='Version 1 not supported'),
-            id=32)))
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPBindRequest(version=1),
+                    id=32)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPBindResponse(
+                        resultCode=ldaperrors.LDAPProtocolError.resultCode,
+                        errorMessage='Version 1 not supported'),
+                    id=32)))
 
     def test_bind_badVersion_2_anonymous(self):
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPBindRequest(version=2),
-            id=32)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPBindResponse(
-            resultCode=ldaperrors.LDAPProtocolError.resultCode,
-            errorMessage='Version 2 not supported'),
-            id=32)))
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPBindRequest(version=2),
+                    id=32)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPBindResponse(
+                        resultCode=ldaperrors.LDAPProtocolError.resultCode,
+                        errorMessage='Version 2 not supported'),
+                    id=32)))
 
     def test_bind_badVersion_4_anonymous(self):
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPBindRequest(version=4),
-            id=32)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPBindResponse(
-            resultCode=ldaperrors.LDAPProtocolError.resultCode,
-            errorMessage='Version 4 not supported'),
-            id=32)))
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPBindRequest(version=4),
+                    id=32)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPBindResponse(
+                        resultCode=ldaperrors.LDAPProtocolError.resultCode,
+                        errorMessage='Version 4 not supported'),
+                    id=32)))
 
     def test_bind_badVersion_4_nonExisting(self):
         # TODO make a test just like this one that would pass authentication
         # if version was correct, to ensure we don't leak that info either.
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPBindRequest(version=4,
-                                     dn='cn=non-existing,dc=example,dc=com',
-                                     auth='invalid'),
-            id=11)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPBindResponse(
-            resultCode=ldaperrors.LDAPProtocolError.resultCode,
-            errorMessage='Version 4 not supported'),
-            id=11)))
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPBindRequest(
+                        version=4,
+                        dn='cn=non-existing,dc=example,dc=com',
+                        auth='invalid'),
+                    id=11)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPBindResponse(
+                        resultCode=ldaperrors.LDAPProtocolError.resultCode,
+                        errorMessage='Version 4 not supported'),
+                    id=11)))
 
     def test_unbind(self):
-        self.server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPUnbindRequest(), id=7)))
-        self.assertEquals(self.server.transport.value(),
-                          '')
+        self.server.dataReceived(
+            str(pureldap.LDAPMessage(pureldap.LDAPUnbindRequest(), id=7)))
+        self.assertEquals(self.server.transport.value(), '')
 
     def test_search_outOfTree(self):
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchRequest(
-            baseObject='dc=invalid',
-            ), id=2)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchResultDone(resultCode=ldaperrors.LDAPNoSuchObject.resultCode),
-            id=2)),
-                          )
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchRequest(
+                        baseObject='dc=invalid'),
+                    id=2)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchResultDone(
+                        resultCode=ldaperrors.LDAPNoSuchObject.resultCode),
+                    id=2)))
 
     def test_search_matchAll_oneResult(self):
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchRequest(
-            baseObject='cn=thingie,ou=stuff,dc=example,dc=com',
-            ), id=2)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchResultEntry(
-            objectName='cn=thingie,ou=stuff,dc=example,dc=com',
-            attributes=[ ('objectClass', ['a', 'b']),
-                         ('cn', ['thingie']),
-                         ]),
-            id=2))
-                          + str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchResultDone(resultCode=0),
-            id=2)),
-                          )
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchRequest(
+                        baseObject='cn=thingie,ou=stuff,dc=example,dc=com'),
+                    id=2)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchResultEntry(
+                        objectName='cn=thingie,ou=stuff,dc=example,dc=com',
+                        attributes=[
+                            ('objectClass', ['a', 'b']),
+                            ('cn', ['thingie'])]),
+                    id=2)
+            ) + str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchResultDone(resultCode=0),
+                    id=2)))
 
     def test_search_matchAll_manyResults(self):
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchRequest(
-            baseObject='ou=stuff,dc=example,dc=com',
-            ), id=2)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchResultEntry(
-            objectName='ou=stuff,dc=example,dc=com',
-            attributes=[ ('objectClass', ['a', 'b']),
-                         ('ou', ['stuff']),
-                         ]),
-            id=2))
-                          + str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchResultEntry(
-            objectName='cn=another,ou=stuff,dc=example,dc=com',
-            attributes=[ ('objectClass', ['a', 'b']),
-                         ('cn', ['another']),
-                         ]),
-            id=2))
-                          + str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchResultEntry(
-            objectName='cn=thingie,ou=stuff,dc=example,dc=com',
-            attributes=[ ('objectClass', ['a', 'b']),
-                         ('cn', ['thingie']),
-                         ]),
-            id=2))
-                          + str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchResultDone(resultCode=0),
-            id=2)),
-                          )
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchRequest(
+                        baseObject='ou=stuff,dc=example,dc=com'), id=2)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchResultEntry(
+                        objectName='ou=stuff,dc=example,dc=com',
+                        attributes=[
+                            ('objectClass', ['a', 'b']),
+                            ('ou', ['stuff'])]),
+                    id=2)
+            ) + str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchResultEntry(
+                        objectName='cn=another,ou=stuff,dc=example,dc=com',
+                        attributes=[
+                            ('objectClass', ['a', 'b']),
+                            ('cn', ['another'])]),
+                    id=2)
+            ) + str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchResultEntry(
+                        objectName='cn=thingie,ou=stuff,dc=example,dc=com',
+                        attributes=[
+                            ('objectClass', ['a', 'b']),
+                            ('cn', ['thingie'])]),
+                    id=2)
+            ) + str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchResultDone(resultCode=0),
+                    id=2)))
 
     def test_search_scope_oneLevel(self):
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchRequest(
-            baseObject='ou=stuff,dc=example,dc=com',
-            scope=pureldap.LDAP_SCOPE_singleLevel,
-            ), id=2)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchResultEntry(
-            objectName='cn=thingie,ou=stuff,dc=example,dc=com',
-            attributes=[ ('objectClass', ['a', 'b']),
-                         ('cn', ['thingie']),
-                         ]),
-            id=2))
-                          + str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchResultEntry(
-            objectName='cn=another,ou=stuff,dc=example,dc=com',
-            attributes=[ ('objectClass', ['a', 'b']),
-                         ('cn', ['another']),
-                         ]),
-            id=2))
-                          + str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchResultDone(resultCode=0),
-            id=2)),
-                          )
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchRequest(
+                        baseObject='ou=stuff,dc=example,dc=com',
+                        scope=pureldap.LDAP_SCOPE_singleLevel),
+                    id=2)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchResultEntry(
+                        objectName='cn=thingie,ou=stuff,dc=example,dc=com',
+                        attributes=[
+                            ('objectClass', ['a', 'b']),
+                            ('cn', ['thingie'])]),
+                    id=2)
+            ) + str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchResultEntry(
+                        objectName='cn=another,ou=stuff,dc=example,dc=com',
+                        attributes=[
+                            ('objectClass', ['a', 'b']),
+                            ('cn', ['another'])]),
+                    id=2)
+            ) + str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchResultDone(resultCode=0),
+                    id=2)))
 
     def test_search_scope_wholeSubtree(self):
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchRequest(
-            baseObject='ou=stuff,dc=example,dc=com',
-            scope=pureldap.LDAP_SCOPE_wholeSubtree,
-            ), id=2)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchResultEntry(
-            objectName='ou=stuff,dc=example,dc=com',
-            attributes=[ ('objectClass', ['a', 'b']),
-                         ('ou', ['stuff']),
-                         ]),
-            id=2))
-                          + str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchResultEntry(
-            objectName='cn=another,ou=stuff,dc=example,dc=com',
-            attributes=[ ('objectClass', ['a', 'b']),
-                         ('cn', ['another']),
-                         ]),
-            id=2))
-                          + str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchResultEntry(
-            objectName='cn=thingie,ou=stuff,dc=example,dc=com',
-            attributes=[ ('objectClass', ['a', 'b']),
-                         ('cn', ['thingie']),
-                         ]),
-            id=2))
-                          + str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchResultDone(resultCode=0),
-            id=2)),
-                          )
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchRequest(
+                        baseObject='ou=stuff,dc=example,dc=com',
+                        scope=pureldap.LDAP_SCOPE_wholeSubtree),
+                    id=2)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchResultEntry(
+                        objectName='ou=stuff,dc=example,dc=com',
+                        attributes=[
+                            ('objectClass', ['a', 'b']),
+                            ('ou', ['stuff'])]),
+                    id=2)
+            ) + str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchResultEntry(
+                        objectName='cn=another,ou=stuff,dc=example,dc=com',
+                        attributes=[
+                            ('objectClass', ['a', 'b']),
+                            ('cn', ['another'])]),
+                    id=2)
+            ) + str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchResultEntry(
+                        objectName='cn=thingie,ou=stuff,dc=example,dc=com',
+                        attributes=[
+                            ('objectClass', ['a', 'b']),
+                            ('cn', ['thingie'])]),
+                    id=2)
+            ) + str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchResultDone(resultCode=0),
+                    id=2)))
 
     def test_search_scope_baseObject(self):
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchRequest(
-            baseObject='ou=stuff,dc=example,dc=com',
-            scope=pureldap.LDAP_SCOPE_baseObject,
-            ), id=2)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchResultEntry(
-            objectName='ou=stuff,dc=example,dc=com',
-            attributes=[ ('objectClass', ['a', 'b']),
-                         ('ou', ['stuff']),
-                         ]),
-            id=2))
-                          + str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchResultDone(resultCode=0),
-            id=2)),
-                          )
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchRequest(
+                        baseObject='ou=stuff,dc=example,dc=com',
+                        scope=pureldap.LDAP_SCOPE_baseObject),
+                    id=2)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchResultEntry(
+                        objectName='ou=stuff,dc=example,dc=com',
+                        attributes=[
+                            ('objectClass', ['a', 'b']),
+                            ('ou', ['stuff'])]),
+                    id=2)
+            ) + str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchResultDone(resultCode=0),
+                    id=2)))
 
     def test_rootDSE(self):
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchRequest(
-            baseObject='',
-            scope=pureldap.LDAP_SCOPE_baseObject,
-            filter=pureldap.LDAPFilter_present('objectClass'),
-            ), id=2)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchResultEntry(
-            objectName='',
-            attributes=[ ('supportedLDAPVersion', ['3']),
-                         ('namingContexts', ['dc=example,dc=com']),
-                         ('supportedExtension', [
-            pureldap.LDAPPasswordModifyRequest.oid,
-            ]),
-                         ]),
-            id=2))
-                          + str(pureldap.LDAPMessage(
-            pureldap.LDAPSearchResultDone(resultCode=ldaperrors.Success.resultCode),
-            id=2)),
-                          )
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchRequest(
+                        baseObject='',
+                        scope=pureldap.LDAP_SCOPE_baseObject,
+                        filter=pureldap.LDAPFilter_present('objectClass')),
+                    id=2)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchResultEntry(
+                        objectName='',
+                        attributes=[
+                            ('supportedLDAPVersion', ['3']),
+                            ('namingContexts', ['dc=example,dc=com']),
+                            ('supportedExtension',
+                                [pureldap.LDAPPasswordModifyRequest.oid])]),
+                    id=2)
+            ) + str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchResultDone(
+                        resultCode=ldaperrors.Success.resultCode),
+                    id=2)))
 
     def test_delete(self):
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPDelRequest(str(self.thingie.dn)), id=2)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPDelResponse(resultCode=0),
-            id=2)),
-                          )
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPDelRequest(str(self.thingie.dn)), i
+                    id=2)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPDelResponse(resultCode=0),
+                    id=2)))
         d = self.stuff.children()
         d.addCallback(self.assertEquals, [self.another])
         return d
 
     def test_add_success(self):
         dn = 'cn=new,ou=stuff,dc=example,dc=com'
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPAddRequest(entry=dn,
-                                    attributes=[
-            (pureldap.LDAPAttributeDescription("objectClass"),
-             pureber.BERSet(value=[
-            pureldap.LDAPAttributeValue('something'),
-            ])),
-            ]), id=2)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPAddResponse(
-            resultCode=ldaperrors.Success.resultCode),
-            id=2)),
-                          )
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPAddRequest(
+                        entry=dn,
+                        attributes=[
+                            (
+                                pureldap.LDAPAttributeDescription("objectClass"),
+                                pureber.BERSet(
+                                    value=[
+                                        pureldap.LDAPAttributeValue('something')
+                                    ])
+                            )
+                        ]),
+                    id=2)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPAddResponse(
+                        resultCode=ldaperrors.Success.resultCode),
+                    id=2)))
         # tree changed
         d = self.stuff.children()
-        d.addCallback(self.assertEquals, [
-            self.thingie,
-            self.another,
-            inmemory.ReadOnlyInMemoryLDAPEntry(
-            'cn=new,ou=stuff,dc=example,dc=com',
-            {'objectClass': ['something']}),
+        d.addCallback(
+            self.assertEquals,
+            [
+                self.thingie,
+                self.another,
+                inmemory.ReadOnlyInMemoryLDAPEntry(
+                    'cn=new,ou=stuff,dc=example,dc=com',
+                    {'objectClass': ['something']})
             ])
         return d
 
     def test_add_fail_existsAlready(self):
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPAddRequest(entry=str(self.thingie.dn),
-                                    attributes=[
-            (pureldap.LDAPAttributeDescription("objectClass"),
-             pureber.BERSet(value=[
-            pureldap.LDAPAttributeValue('something'),
-            ])),
-            ]), id=2)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPAddResponse(
-            resultCode=ldaperrors.LDAPEntryAlreadyExists.resultCode,
-            errorMessage=str(self.thingie.dn)),
-            id=2)),
-                          )
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPAddRequest(
+                        entry=str(self.thingie.dn),
+                        attributes=[
+                            (
+                                pureldap.LDAPAttributeDescription("objectClass"),
+                                pureber.BERSet(
+                                    value=[
+                                        pureldap.LDAPAttributeValue('something'),
+                                    ])
+                            )
+                        ]),
+                    id=2)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPAddResponse(
+                        resultCode=ldaperrors.LDAPEntryAlreadyExists.resultCode,
+                        errorMessage=str(self.thingie.dn)),
+                    id=2)))
         # tree did not change
         d = self.stuff.children()
         d.addCallback(self.assertEquals, [self.thingie, self.another])
@@ -357,128 +466,171 @@ class LDAPServerTest(unittest.TestCase):
 
     def test_modifyDN_rdnOnly_deleteOldRDN_success(self):
         newrdn = 'cn=thingamagic'
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPModifyDNRequest(entry=self.thingie.dn,
-                                         newrdn=newrdn,
-                                         deleteoldrdn=True),
-            id=2)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPModifyDNResponse(
-            resultCode=ldaperrors.Success.resultCode),
-            id=2)),
-                          )
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPModifyDNRequest(
+                        entry=self.thingie.dn,
+                        newrdn=newrdn,
+                        deleteoldrdn=True),
+                    id=2)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPModifyDNResponse(
+                        resultCode=ldaperrors.Success.resultCode),
+                    id=2)))
         # tree changed
         d = self.stuff.children()
-        d.addCallback(self.assertEquals, [
-            inmemory.ReadOnlyInMemoryLDAPEntry(
-            '%s,ou=stuff,dc=example,dc=com' % newrdn,
-            {'objectClass': ['a', 'b'],
-             'cn': ['thingamagic']}),
-            self.another,
+        d.addCallback(
+            self.assertEquals,
+            [
+                inmemory.ReadOnlyInMemoryLDAPEntry(
+                    '%s,ou=stuff,dc=example,dc=com' % newrdn,
+                    {
+                        'objectClass': ['a', 'b'],
+                        'cn': ['thingamagic']
+                    }),
+                self.another,
             ])
         return d
 
     def test_modifyDN_rdnOnly_noDeleteOldRDN_success(self):
         newrdn = 'cn=thingamagic'
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPModifyDNRequest(entry=self.thingie.dn,
-                                         newrdn=newrdn,
-                                         deleteoldrdn=False),
-            id=2)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPModifyDNResponse(
-            resultCode=ldaperrors.Success.resultCode),
-            id=2)),
-                          )
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPModifyDNRequest(
+                        entry=self.thingie.dn,
+                        newrdn=newrdn,
+                        deleteoldrdn=False),
+                    id=2)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPModifyDNResponse(
+                        resultCode=ldaperrors.Success.resultCode),
+                    id=2)))
         # tree changed
         d = self.stuff.children()
-        d.addCallback(self.assertEquals, sets.Set([
-            self.another,
-            inmemory.ReadOnlyInMemoryLDAPEntry(
-            '%s,ou=stuff,dc=example,dc=com' % newrdn,
-            {'objectClass': ['a', 'b'],
-             'cn': ['thingamagic', 'thingie']}),
-            ]))
+        d.addCallback(
+            self.assertEquals,
+            sets.Set([
+                self.another,
+                inmemory.ReadOnlyInMemoryLDAPEntry(
+                    '%s,ou=stuff,dc=example,dc=com' % newrdn,
+                    {
+                        'objectClass': ['a', 'b'],
+                        'cn': ['thingamagic', 'thingie']
+                    })]))
         return d
     test_modifyDN_rdnOnly_noDeleteOldRDN_success.todo = 'Not supported yet.'
 
     def test_modify(self):
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPModifyRequest(self.stuff.dn,
-                                       modification=[
-            delta.Add('foo', ['bar']).asLDAP(),
-            ],
-                                       ),
-            id=2)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPModifyResponse(
-            resultCode=ldaperrors.Success.resultCode),
-            id=2)),
-                          )
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPModifyRequest(
+                        self.stuff.dn,
+                        modification=[
+                            delta.Add('foo', ['bar']).asLDAP(),
+                        ]),
+                    id=2)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPModifyResponse(
+                        resultCode=ldaperrors.Success.resultCode),
+                    id=2)))
         # tree changed
         self.assertEquals(
             self.stuff,
             inmemory.ReadOnlyInMemoryLDAPEntry(
-            'ou=stuff,dc=example,dc=com',
-            {'objectClass': ['a', 'b'],
-             'ou': ['stuff'],
-             'foo': ['bar']}))
+                'ou=stuff,dc=example,dc=com',
+                {
+                    'objectClass': ['a', 'b'],
+                    'ou': ['stuff'],
+                    'foo': ['bar']
+                }))
 
     def test_extendedRequest_unknown(self):
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPExtendedRequest(requestName='42.42.42',
-                                         requestValue='foo'),
-            id=2)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPExtendedResponse(
-            resultCode=ldaperrors.LDAPProtocolError.resultCode,
-            errorMessage='Unknown extended request: 42.42.42'),
-            id=2)),
-                          )
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPExtendedRequest(
+                        requestName='42.42.42',
+                        requestValue='foo'),
+                    id=2)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPExtendedResponse(
+                        resultCode=ldaperrors.LDAPProtocolError.resultCode,
+                        errorMessage='Unknown extended request: 42.42.42'),
+                    id=2)))
 
     def test_passwordModify_notBound(self):
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPPasswordModifyRequest(
-            userIdentity='cn=thingie,ou=stuff,dc=example,dc=com',
-            newPasswd='hushhush'),
-            id=2)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPExtendedResponse(
-            resultCode=ldaperrors.LDAPStrongAuthRequired.resultCode,
-            responseName=pureldap.LDAPPasswordModifyRequest.oid),
-            id=2)),
-                          )
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPPasswordModifyRequest(
+                        userIdentity='cn=thingie,ou=stuff,dc=example,dc=com',
+                        newPasswd='hushhush'),
+                    id=2)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPExtendedResponse(
+                        resultCode=ldaperrors.LDAPStrongAuthRequired.resultCode,
+                        responseName=pureldap.LDAPPasswordModifyRequest.oid),
+                    id=2)))
 
     def test_passwordModify_simple(self):
-        # first bind to some entry
-        self.thingie['userPassword'] = ['{SSHA}yVLLj62rFf3kDAbzwEU0zYAVvbWrze8='] # "secret"
-        self.server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(
-            dn='cn=thingie,ou=stuff,dc=example,dc=com',
-            auth='secret'), id=4)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPBindResponse(resultCode=0,
-                                      matchedDN='cn=thingie,ou=stuff,dc=example,dc=com'),
-            id=4)))
-        self.server.transport.clear()
+        data = {'committed': False}
 
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPPasswordModifyRequest(
-            userIdentity='cn=thingie,ou=stuff,dc=example,dc=com',
-            newPasswd='hushhush'),
-            id=2)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPExtendedResponse(
-            resultCode=ldaperrors.Success.resultCode,
-            responseName=pureldap.LDAPPasswordModifyRequest.oid),
-            id=2)),
-                          )
+        def onCommit_(result, info):
+            info['committed'] = result
+            return result
+
+        wrapCommit(self.thingie, onCommit_, data)
+        # first bind to some entry
+        self.thingie['userPassword'] = ['{SSHA}yVLLj62rFf3kDAbzwEU0zYAVvbWrze8=']  # "secret"
+        self.server.dataReceived(
+            str(pureldap.LDAPMessage(
+                pureldap.LDAPBindRequest(
+                    dn='cn=thingie,ou=stuff,dc=example,dc=com',
+                    auth='secret'),
+                id=4)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPBindResponse(
+                        resultCode=0,
+                        matchedDN='cn=thingie,ou=stuff,dc=example,dc=com'),
+                    id=4)))
+        self.server.transport.clear()
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPPasswordModifyRequest(
+                        userIdentity='cn=thingie,ou=stuff,dc=example,dc=com',
+                        newPasswd='hushhush'),
+                    id=2)))
+        self.assertEquals(data['committed'], True, "Server never committed data.")
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPExtendedResponse(
+                        resultCode=ldaperrors.Success.resultCode,
+                        responseName=pureldap.LDAPPasswordModifyRequest.oid),
+                    id=2)))
         # tree changed
         secrets = self.thingie.get('userPassword', [])
         self.assertEquals(len(secrets), 1)
@@ -486,8 +638,7 @@ class LDAPServerTest(unittest.TestCase):
             self.assertEquals(secret[:len('{SSHA}')], '{SSHA}')
             raw = base64.decodestring(secret[len('{SSHA}'):])
             salt = raw[20:]
-            self.assertEquals(entry.sshaDigest('hushhush', salt),
-                              secret)
+            self.assertEquals(entry.sshaDigest('hushhush', salt), secret)
 
     def test_unknownRequest(self):
         # make server miss one of the handle_* attributes
@@ -497,35 +648,45 @@ class LDAPServerTest(unittest.TestCase):
         self.server.__class__ = MockServer
         self.server.dataReceived(str(pureldap.LDAPMessage(
             pureldap.LDAPBindRequest(), id=2)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPExtendedResponse(resultCode=ldaperrors.LDAPProtocolError.resultCode,
-                                          responseName='1.3.6.1.4.1.1466.20036',
-                                          errorMessage='Unknown request'), id=2)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPExtendedResponse(
+                        resultCode=ldaperrors.LDAPProtocolError.resultCode,
+                        responseName='1.3.6.1.4.1.1466.20036',
+                        errorMessage='Unknown request'),
+                    id=2)))
 
     def test_control_unknown_critical(self):
         self.server.dataReceived(str(pureldap.LDAPMessage(
             pureldap.LDAPBindRequest(), id=2,
             controls=[('42.42.42.42', True, None),
                       ])))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPBindResponse(
-            resultCode=ldaperrors.LDAPUnavailableCriticalExtension.resultCode,
-            errorMessage='Unknown control 42.42.42.42'), id=2)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPBindResponse(
+                        resultCode=ldaperrors.LDAPUnavailableCriticalExtension.resultCode,
+                        errorMessage='Unknown control 42.42.42.42'),
+                    id=2)))
 
     def test_control_unknown_nonCritical(self):
-        self.thingie['userPassword'] = ['{SSHA}yVLLj62rFf3kDAbzwEU0zYAVvbWrze8='] # "secret"
+        self.thingie['userPassword'] = ['{SSHA}yVLLj62rFf3kDAbzwEU0zYAVvbWrze8=']  # "secret"
         self.server.dataReceived(str(pureldap.LDAPMessage(
             pureldap.LDAPBindRequest(dn='cn=thingie,ou=stuff,dc=example,dc=com',
                                      auth='secret'),
             controls=[('42.42.42.42', False, None)],
             id=4)))
-        self.assertEquals(self.server.transport.value(),
-                          str(pureldap.LDAPMessage(
-            pureldap.LDAPBindResponse(resultCode=0,
-                                      matchedDN='cn=thingie,ou=stuff,dc=example,dc=com'),
-            id=4)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPBindResponse(
+                        resultCode=0,
+                        matchedDN='cn=thingie,ou=stuff,dc=example,dc=com'),
+                    id=4)))
 
 
 class TestSchema(unittest.TestCase):
@@ -551,6 +712,7 @@ class TestSchema(unittest.TestCase):
 
         class LDAPServerFactory(protocol.ServerFactory):
             protocol = ldapserver.LDAPServer
+
             def __init__(self, root):
                 self.root = root
 
@@ -567,15 +729,15 @@ class TestSchema(unittest.TestCase):
         d = fetchschema.fetch(self.client, 'dc=example,dc=com')
         (attributeTypes, objectClasses) = util.pumpingDeferredResult(d)
 
-        self.failUnlessEqual([str(x) for x in attributeTypes],
-                             [str(schema.AttributeTypeDescription(x)) for x in [
-            test_schema.AttributeType_KnownValues.knownValues[0][0],
-            ]])
+        self.failUnlessEqual(
+            [str(x) for x in attributeTypes],
+            [str(schema.AttributeTypeDescription(x)) for x in [
+                test_schema.AttributeType_KnownValues.knownValues[0][0]]])
 
-        self.failUnlessEqual([str(x) for x in objectClasses],
-                             [str(schema.ObjectClassDescription(x)) for x in [
-            test_schema.OBJECTCLASSES['organization'],
-            test_schema.OBJECTCLASSES['organizationalUnit'],
-            ]])
+        self.failUnlessEqual(
+            [str(x) for x in objectClasses],
+            [str(schema.ObjectClassDescription(x)) for x in [
+                test_schema.OBJECTCLASSES['organization'],
+                test_schema.OBJECTCLASSES['organizationalUnit']]])
 
     testSimple.todo = 'Not supported yet.'


### PR DESCRIPTION
I noticed that issuing an LDAP password change request would seem to work for an LDAP server using an ldiftree backend (`ldaptor/ldiftree.py`).  However, if you subsequently issued an LDAP search for the entry which just had its password changed, the `userPassword` attribute was unchanged.

I determined this was because `LDAPServer` was not calling `commit()` like it was doing for an LDAP modify operation.

The server tests use the in-memory back end.  `commit()` is a no-op for that back end, so I had to wrap the commit method of the entry being tested to verify that commit was being called.

It was not clear what the Deferred that is returned from `commit()` was supposed to fire-- the in-memory back end returned the entry itself, while the ldiftree didn't return anything.  There was a curious comment that suggested that commit should indicate whether it succeeded or failed, so I chose to have it fire a simple boolean value and patched that up.

I made lots of formatting changes on the files I touched to keep `pyflakes` and `pep8` happy.
 