### PR TITLE
BUGFIX: LDAP search should return only the attributes requested.

### DIFF
--- a/ldaptor/test/test_server.py
+++ b/ldaptor/test/test_server.py
@@ -225,6 +225,43 @@ class LDAPServerTest(unittest.TestCase):
                     pureldap.LDAPSearchResultDone(resultCode=0),
                     id=2)))
 
+    def test_search_matchAll_oneResult_filtered(self):
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchRequest(
+                        baseObject='cn=thingie,ou=stuff,dc=example,dc=com',
+                        attributes=['cn']),
+                    id=2)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchResultEntry(
+                        objectName='cn=thingie,ou=stuff,dc=example,dc=com',
+                        attributes=[
+                            ('cn', ['thingie'])]),
+                    id=2)
+            ) + str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchResultDone(resultCode=0),
+                    id=2)))
+
+    def test_search_matchAll_oneResult_filteredNoAttribsRemaining(self):
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchRequest(
+                        baseObject='cn=thingie,ou=stuff,dc=example,dc=com',
+                        attributes=['xyzzy']),
+                    id=2)))
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPSearchResultDone(resultCode=0),
+                    id=2)))
+
     def test_search_matchAll_manyResults(self):
         self.server.dataReceived(
             str(


### PR DESCRIPTION
Should return all attributes if no attributes are requested.

This should correct issue #38.
I made the correction and wrote a couple tests.

Thanks,
Carl