### PR TITLE
Cookbook

### DIFF
--- a/docs/source/cookbook.rst
+++ b/docs/source/cookbook.rst
@@ -1,0 +1,14 @@
+================
+Ldaptor Cookbook
+================
+
+The following recipies demonstrate how to accomplish various LDAP-related 
+tasks with Twisted and Ldaptor.  Recipies are broken into categories for
+convenience.
+
+
+.. toctree::
+   :maxdepth: 2
+   :glob:
+
+   cookbook/*

--- a/docs/source/cookbook/clients.rst
+++ b/docs/source/cookbook/clients.rst
@@ -1,0 +1,78 @@
+============
+LDAP Clients
+============
+
+The following recipies demonstrate asynchronous LDAP clients.
+
+""""""""""""""""""""""""""""""""
+A Minimal Client Using Endpoints
+""""""""""""""""""""""""""""""""
+
+While Ldaptor exposes helper classes to connect clients to the DIT,
+it is possible to use the Twisted *endpoints* API to connect an Ldaptor
+client to a server.
+
+''''
+Code
+''''
+
+.. code-block:: python
+
+    #! /usr/bin/env python
+
+    from ldaptor.protocols.ldap.ldapclient import LDAPClient
+    from ldaptor.protocols.ldap.ldapsyntax import LDAPEntry
+    from twisted.internet.defer import inlineCallbacks, returnValue
+    from twisted.internet.endpoints import clientFromString, connectProtocol
+    from twisted.internet.task import react
+    from twisted.python import log
+    from cStringIO import StringIO
+    import sys
+
+    @inlineCallbacks
+    def onConnect(clientProtocol):
+        o = LDAPEntry(clientProtocol, "dc=org")
+        resultList = yield o.search()
+        f = StringIO()
+        for result in resultList:
+            f.write(str(result))
+            f.write("\n")
+        log.msg("LDIF formatted results:\n{0}".format(f.getvalue()))
+
+    def onError(err, reactor):
+        if reactor.running:
+            log.err(err)
+            reactor.stop()
+
+    def main(reactor):
+        log.startLogging(sys.stdout)
+        endpoint_str = "tcp:host=localhost:port=8080"
+        e = clientFromString(reactor, endpoint_str)
+        d = connectProtocol(e, LDAPClient())
+        d.addCallback(onConnect)
+        d.addErrback(onError, reactor)
+        return d
+
+    react(main)
+
+''''''''''
+Discussion
+''''''''''
+
+The :py:func:`twisted.internet.task.react()` function is perfect for running a
+one-shot `main()` function.  When `main()` is called, we create a client 
+endpoint from a string description and the reactor.
+:py:func:`twisted.internet.endpoints.connectProtocol()` is used to make a
+one-time connection to an LDAP DIT listening on the local host, port 8080.
+When the deferred returned from that function fires, the connection has
+been established and the client protocol instance is passed to the 
+:py:func:`onConnect()` callback.
+
+This callback uses inline deferreds to make the syntax more compact.  We create
+an :py:class:`ldaptor.protocols.ldap.ldapsyntax.LDAPEntry` with a DN matching
+the root of the DIT and call the asynchronous :py:func:`search()` method.  The
+result returned when the deferred fires is a list of :py:class:`LDAPEntry` 
+objects.
+
+When cast as strings, these entries are formatted as LDIF.
+

--- a/docs/source/cookbook/ldap-proxy.rst
+++ b/docs/source/cookbook/ldap-proxy.rst
@@ -1,6 +1,6 @@
-====================
-Create an LDAP Proxy
-====================
+============
+LDAP Proxies
+============
 
 An LDAP proxy sits between an LDAP client and an LDAP server.  It accepts LDAP 
 requests from the client and forwards them to the LDAP server.  Responses from
@@ -40,13 +40,15 @@ An LDAP proxy has many different uses:
   to the proxy, which in turn will distrbute the connections amongst the 
   replicas.
 
---------
-Examples
---------
-
 """"""""""""""""""
 Logging LDAP Proxy
 """"""""""""""""""
+A logging LDAP proxy inspects the LDAP requests and responses and records them
+in a log.
+
+''''
+Code
+''''
 
 .. code-block:: python
 
@@ -94,23 +96,126 @@ Logging LDAP Proxy
         reactor.listenTCP(10389, factory)
         reactor.run()
 
-The main idea in the above program is to subclass 
-`ldaptor.protocols.ldap.proxybase.ProxyBase` and override its
-`handleProxiedResponse()` method.
+''''''''''
+Discussion
+''''''''''
 
-The function `ldapBindRequestRepr()` is used to patch the __repr__ magic method
-of the `ldaptor.protocols.pureldap.LDAPBindRequest` class.  The representation
-normally prints the BIND password, which is typically *not* what you want.
+The main idea in the above program is to subclass 
+:py:class:`ldaptor.protocols.ldap.proxybase.ProxyBase` and override its
+:py:func:`handleProxiedResponse()` method.
+
+The function :py:func:`ldapBindRequestRepr()` is used to patch the 
+:py:func:`__repr__` magic method of the 
+:py:class:`ldaptor.protocols.pureldap.LDAPBindRequest` class.  The 
+representation normally prints the BIND password, which is typically *not* what
+you want.
 
 The main program entry point starts logging and creates a generic server factory.
-The proxied LDAP server is configured to be running on the local host on port 8080.
+The proxied LDAP server is configured to run on the local host on port 8080.
 The factory protocol is set to a function that takes no arguments and returns an
-instance of our `LoggingProxy` that has been configured with te proxied LDAP server 
-settings.  The Twisted reactor is then configured to listen on TCP port 10389 and
-use te factory to create protocol instances to handle incoming connections.
+instance of our :py:class:`LoggingProxy` that has been configured with the 
+proxied LDAP server settings.  The Twisted reactor is then configured to listen
+on TCP port 10389 and use the factory to create protocol instances to handle 
+incoming connections.
 
-The `ProxyBase` class handles the typical LDAP protocol events but provides convenient
-hooks for intercepting LDAP requests and responses.  In this proxy, we wait until
-we have a reponse and log both the request and the respone.  in the case of a search
-request with multiple responses, the request is repeatedly displayed with each response.
+The :py:class:`ProxyBase` class handles the typical LDAP protocol events but 
+provides convenient hooks for intercepting LDAP requests and responses.  In 
+this proxy, we wait until we have a reponse and log both the request and the 
+response.  in the case of a search request with multiple responses, the 
+request is repeatedly displayed with each response.
+
+This program explicitly starts logging and the Twisted reactor loop.  However,
+the :program:`twistd` program can perform these tasks for you and allow you
+to configure options from the command line.
+
+.. code-block:: python
+
+    from ldaptor import config
+    from ldaptor.protocols import pureldap
+    from ldaptor.protocols.ldap.proxybase import ProxyBase
+    from twisted.application.service import Application, Service
+    from twisted.internet import defer, protocol, reactor
+    from twisted.internet.endpoints import serverFromString
+    from twisted.python import log
+
+
+    class LoggingProxy(ProxyBase):
+        """
+        A simple example of using `ProxyBase` to log requests and responses.
+        """
+        def handleProxiedResponse(self, response, request, controls):
+            """
+            Log the representation of the responses received.
+            """
+            log.msg("Request => " + repr(request))
+            log.msg("Response => " + repr(response))
+            return defer.succeed(response)
+
+
+    def ldapBindRequestRepr(self):
+        l=[]
+        l.append('version={0}'.format(self.version))
+        l.append('dn={0}'.format(repr(self.dn)))
+        l.append('auth=****')
+        if self.tag!=self.__class__.tag:
+            l.append('tag={0}'.format(self.tag))
+        l.append('sasl={0}'.format(repr(self.sasl)))
+        return self.__class__.__name__+'('+', '.join(l)+')'
+
+    pureldap.LDAPBindRequest.__repr__ = ldapBindRequestRepr
+
+
+    class LoggingProxyService(Service):
+        endpoint_str = "tcp:10389"
+        proxied = ('localhost', 8080)
+
+        def startService(self):
+            factory = protocol.ServerFactory()
+            use_tls = False
+            cfg = config.LDAPConfig(serviceLocationOverrides={'': self.proxied, })
+            factory.protocol = lambda : LoggingProxy(cfg, use_tls=use_tls)
+            ep = serverFromString(reactor, self.endpoint_str)
+            d = ep.listen(factory)
+            d.addCallback(self.setListeningPort)
+            d.addErrback(log.err)
+
+        def setListeningPort(self, port):
+            self.port_ = port
+
+        def stopService(self):
+            # If there are asynchronous cleanup tasks that need to
+            # be performed, add deferreds for them to `async_tasks`.
+            async_tasks = []
+            if self.port_ is not None:
+                async_tasks.append(self.port_.stopListening())
+            if len(async_tasks) > 0:
+                return defer.DeferredList(async_tasks, consumeErrors=True)
+
+
+    application = Application("Logging LDAP Proxy")
+    service = LoggingProxyService()
+    service.setServiceParent(application)
+
+This program is very similar to the previous one.  However, this one is run
+with :program:`twistd`::
+
+    $ twistd -ny loggingproxy.py
+
+The :program:`twistd` program looks for the global name `application` in the
+script and runs all the services attached to it.  We moved most of the startup
+code from the `if __name__ == '__main__'` block into the service's
+:py:func:`startService()` method.  This method is called when our service 
+starts up.  Conversely, :py:func:`stopService()` is called when the service is 
+about to shut down.
+
+This improved example also makes use of an endpoint string.  This is a string
+description of the socket on which our LDAP proxy server will listen.  The
+advantage of endpoints is that you can read these strings from a configuration
+file and change how your server listens.  Our example listens on a plain old 
+TCP socket, but you could easilly switch to a TLS socket or a UNIX domain
+socket without having to change a line of code.
+
+Listening on an endpoint is an asynchronous task, so we set a callback to 
+record the listening port.  When the service stops, we ask the port to stop 
+listening.
 

--- a/docs/source/cookbook/ldap-proxy.rst
+++ b/docs/source/cookbook/ldap-proxy.rst
@@ -1,0 +1,116 @@
+====================
+Create an LDAP Proxy
+====================
+
+An LDAP proxy sits between an LDAP client and an LDAP server.  It accepts LDAP 
+requests from the client and forwards them to the LDAP server.  Responses from
+the server are then relayed back to the client.
+
+----------------
+Why is it Useful
+----------------
+
+An LDAP proxy has many different uses:
+
+* If a client does not natively support LDAP over SSL or StartTLS, a proxy
+  can be run on the client host.  The client can interact with the proxy
+  which can use LDAPS or StartTLS when communicating with the backend
+  service.
+* When troubleshooting LDAP connections between LDAP clients and servers,
+  it can be useful to determine what kinds of requests and responses
+  are passing between the client and server.  Sometimes, access to client
+  or server logs is not available or not helpful.  By logging the interactions
+  at the proxy, one can gain insight into what requests are being made by the
+  client and what responses the server makes.
+* It may be desirable to provide limited access to an LDAP service.  For 
+  example, it may be desirable to grant an application search access to an 
+  LDAP DIT, but any Modify, Add, or Delete operations are not allowed.  A
+  proxy can be configured to disable those particular LDAP operations.
+* LDAP requests can be modified before sending them on to the LDAP server.
+  For example, the base DN of search could be transparently modified based
+  on the current BIND user.
+* Similarly, LDAP responses from the server can be modified before sending 
+  them to the client.  For example, search results could be populated with
+  computed attributes, or a domain could be appended to any returned `uid`
+  attribute.
+* The proxy can be configured to connect to one of several LDAP servers
+  (replicas).  This can be an effective technique when a particular LDAP
+  client library shows affinity for a particular host in an LDAP replica
+  round-robin architecture.  The client can be configured to always connect
+  to the proxy, which in turn will distrbute the connections amongst the 
+  replicas.
+
+--------
+Examples
+--------
+
+""""""""""""""""""
+Logging LDAP Proxy
+""""""""""""""""""
+
+.. code-block:: python
+
+    from ldaptor import config
+    from ldaptor.protocols import pureldap
+    from ldaptor.protocols.ldap.proxybase import ProxyBase
+    from twisted.internet import defer, protocol, reactor
+    from twisted.python import log
+    import sys
+
+    class LoggingProxy(ProxyBase):
+        """
+        A simple example of using `ProxyBase` to log requests and responses.
+        """
+        def handleProxiedResponse(self, response, request, controls):
+            """
+            Log the representation of the responses received.
+            """
+            log.msg("Request => " + repr(request))
+            log.msg("Response => " + repr(response))
+            return defer.succeed(response)
+
+    def ldapBindRequestRepr(self):
+        l=[]
+        l.append('version={0}'.format(self.version))
+        l.append('dn={0}'.format(repr(self.dn)))
+        l.append('auth=****')
+        if self.tag!=self.__class__.tag:
+            l.append('tag={0}'.format(self.tag))
+        l.append('sasl={0}'.format(repr(self.sasl)))
+        return self.__class__.__name__+'('+', '.join(l)+')'
+
+    pureldap.LDAPBindRequest.__repr__ = ldapBindRequestRepr
+
+    if __name__ == '__main__':
+        """
+        Demonstration LDAP proxy; passes all requests to localhost:10389.
+        """
+        log.startLogging(sys.stderr)
+        factory = protocol.ServerFactory()
+        proxied = ('localhost', 8080)
+        use_tls = False
+        cfg = config.LDAPConfig(serviceLocationOverrides={'': proxied, })
+        factory.protocol = lambda : LoggingProxy(cfg, use_tls=use_tls)
+        reactor.listenTCP(10389, factory)
+        reactor.run()
+
+The main idea in the above program is to subclass 
+`ldaptor.protocols.ldap.proxybase.ProxyBase` and override its
+`handleProxiedResponse()` method.
+
+The function `ldapBindRequestRepr()` is used to patch the __repr__ magic method
+of the `ldaptor.protocols.pureldap.LDAPBindRequest` class.  The representation
+normally prints the BIND password, which is typically *not* what you want.
+
+The main program entry point starts logging and creates a generic server factory.
+The proxied LDAP server is configured to be running on the local host on port 8080.
+The factory protocol is set to a function that takes no arguments and returns an
+instance of our `LoggingProxy` that has been configured with te proxied LDAP server 
+settings.  The Twisted reactor is then configured to listen on TCP port 10389 and
+use te factory to create protocol instances to handle incoming connections.
+
+The `ProxyBase` class handles the typical LDAP protocol events but provides convenient
+hooks for intercepting LDAP requests and responses.  In this proxy, we wait until
+we have a reponse and log both the request and the respone.  in the case of a search
+request with multiple responses, the request is repeatedly displayed with each response.
+

--- a/docs/source/cookbook/servers.rst
+++ b/docs/source/cookbook/servers.rst
@@ -1,0 +1,97 @@
+============
+LDAP Servers
+============
+
+An LDAP directory information tree (DIT) is a highly specialized
+database with entries arranged in a tree-like structure.
+
+
+""""""""""""""""""""
+File-System LDAP DIT
+""""""""""""""""""""
+A minimal LDAP DIT that stores entries in the local file system
+
+''''
+Code
+''''
+
+.. code-block:: python
+
+    #-*-coding:utf-8-*-
+    """
+        Testing a simple ldaptor ldap server
+        Base on an example by Gaston TJEBBES aka "tonthon":
+        http://tonthon.blogspot.com/2011/02/ldaptor-ldap-with-twisted-server-side.html
+    """
+    import tempfile, sys
+
+    from twisted.application import service, internet
+    from twisted.internet import reactor
+    from twisted.internet.protocol import ServerFactory
+    from twisted.python.components import registerAdapter
+    from twisted.python import log
+    from ldaptor.interfaces import IConnectedLDAPEntry
+    from ldaptor.protocols.ldap.ldapserver import LDAPServer
+    from ldaptor.ldiftree import LDIFTreeEntry
+    from schema import COUNTRY, COMPANY, PEOPLE, USERS
+
+
+    class Tree(object):
+
+        def __init__(self, path='/tmp'):
+            dirname = tempfile.mkdtemp('.ldap', 'test-server', '/tmp')
+            self.db = LDIFTreeEntry(dirname)
+            self.init_db()
+
+        def init_db(self):
+            """
+                Add subtrees to the top entry
+                top->country->company->people
+            """
+            country = self.db.addChild(COUNTRY[0], COUNTRY[1])
+            company = country.addChild(COMPANY[0], COMPANY[1])
+            people = company.addChild(PEOPLE[0], PEOPLE[1])
+            for user in USERS:
+                people.addChild(user[0], user[1])
+
+
+    class LDAPServerFactory(ServerFactory):
+        """
+            Our Factory is meant to persistently store the ldap tree
+        """
+        protocol = LDAPServer
+
+        def __init__(self, root):
+            self.root = root
+
+        def buildProtocol(self, addr):
+            proto = self.protocol()
+            proto.debug = self.debug
+            proto.factory = self
+            return proto
+
+    if __name__ == '__main__':
+        if len(sys.argv) == 2:
+            port = int(sys.argv[1])
+        else:
+            port = 8080
+        # First of all, to show logging info in stdout :
+        log.startLogging(sys.stderr)
+        # We initialize our tree
+        tree = Tree()
+        # When the ldap protocol handle the ldap tree,
+        # it retrieves it from the factory adapting
+        # the factory to the IConnectedLDAPEntry interface
+        # So we need to register an adapter for our factory
+        # to match the IConnectedLDAPEntry
+        registerAdapter(
+            lambda x: x.root,
+            LDAPServerFactory,
+            IConnectedLDAPEntry)
+        # Run it !!
+        factory = LDAPServerFactory(tree.db)
+        factory.debug = True
+        application = service.Application("ldaptor-server")
+        myService = service.IServiceCollection(application)
+        reactor.listenTCP(port, factory)
+        reactor.run()

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -52,6 +52,7 @@ User's Guide
 
    ldap-intro
    addressbook-example
+   cookbook/*
    ldaptor
 
 Meta

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,44 +6,23 @@ What is Ldaptor
 
 Ldaptor is a pure-Python Twisted library that implements:
 
-- LDAP client logic
+- LDAP client and server logic
 - separately-accessible LDAP and BER protocol message generation/parsing
 - ASCII-format LDAP filter generation and parsing
 - LDIF format data generation
 
 Get it from `PyPI <https://pypi.python.org/pypi/Ldaptor>`_, find out what's new in the :doc:`NEWS`!
 
-Quick Usage Example
--------------------
+-----------
+Quick Start
+-----------
 
-.. code-block:: python
+.. toctree::
+    :maxdepth: 1
 
-    from twisted.internet import reactor, defer
-    from ldaptor.protocols.ldap import ldapclient, ldapsyntax, ldapconnector
+    quickstart
 
-    @defer.inlineCallbacks
-    def example():
-        serverip = '192.168.128.21'
-        basedn = 'dc=example,dc=com'
-        binddn = 'bjensen@example.com'
-        bindpw = 'secret'
-        query = '(cn=Babs*)'
-        c = ldapconnector.LDAPClientCreator(reactor, ldapclient.LDAPClient)
-        overrides = {basedn: (serverip, 389)}
-        client = yield c.connect(basedn, overrides=overrides)
-        yield client.bind(binddn, bindpw)
-        o = ldapsyntax.LDAPEntry(client, basedn)
-        results = yield o.search(filterText=query)
-        for entry in results:
-            print entry
-
-    if __name__ == '__main__':
-        df = example()
-        df.addErrback(lambda err: err.printTraceback())
-        df.addCallback(lambda _: reactor.stop())
-        reactor.run()
-
-
+------------
 User's Guide
 ------------
 
@@ -52,8 +31,17 @@ User's Guide
 
    ldap-intro
    addressbook-example
-   cookbook/*
+   cookbook
    ldaptor
+
+----------------
+Ldaptor Cookbook
+----------------
+
+.. toctree::
+   :maxdepth: 2
+
+   cookbook
 
 Meta
 ----

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -1,0 +1,38 @@
+
+======================
+LDAP Client Quickstart
+======================
+
+.. code-block:: python
+
+    from twisted.internet import reactor, defer
+    from ldaptor.protocols.ldap import ldapclient, ldapsyntax, ldapconnector
+
+    @defer.inlineCallbacks
+    def example():
+        serverip = '192.168.128.21'
+        basedn = 'dc=example,dc=com'
+        binddn = 'bjensen@example.com'
+        bindpw = 'secret'
+        query = '(cn=Babs*)'
+        c = ldapconnector.LDAPClientCreator(reactor, ldapclient.LDAPClient)
+        overrides = {basedn: (serverip, 389)}
+        client = yield c.connect(basedn, overrides=overrides)
+        yield client.bind(binddn, bindpw)
+        o = ldapsyntax.LDAPEntry(client, basedn)
+        results = yield o.search(filterText=query)
+        for entry in results:
+            print entry
+
+    if __name__ == '__main__':
+        df = example()
+        df.addErrback(lambda err: err.printTraceback())
+        df.addCallback(lambda _: reactor.stop())
+        reactor.run()
+
+=======================
+LDAP Server Quick Start
+=======================
+
+LDAP servers ...
+

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -34,5 +34,92 @@ LDAP Client Quickstart
 LDAP Server Quick Start
 =======================
 
-LDAP servers ...
 
+.. code-block:: python
+
+    from twisted.application import service, internet
+    from twisted.internet import reactor
+    from twisted.internet.protocol import ServerFactory
+    from twisted.python.components import registerAdapter
+    from twisted.python import log
+    from ldaptor.inmemory import fromLDIFFile
+    from ldaptor.interfaces import IConnectedLDAPEntry
+    from ldaptor.protocols.ldap import distinguishedname
+    from ldaptor.protocols.ldap.ldapserver import LDAPServer
+    import tempfile
+    from cStringIO import StringIO
+    import sys
+
+    LDIF = """\
+    dn: dc=org
+    dc: org
+    objectClass: dcObject
+
+    dn: dc=example,dc=org
+    dc: example
+    objectClass: dcObject
+    objectClass: organization
+
+    dn: ou=people,dc=example,dc=org
+    objectClass: organizationalUnit
+    ou: people
+
+    dn: cn=bob,ou=people,dc=example,dc=org
+    cn: bob
+    givenName: Bob
+    mail: bob@example.org
+    objectclass: top
+    objectclass: person
+    objectClass: inetOrgPerson
+    sn: Roberts
+
+    """
+
+
+    class Tree(object):
+
+        def __init__(self):
+            global LDIF
+            self.f = StringIO(LDIF)
+            d = fromLDIFFile(self.f)
+            d.addCallback(self.ldifRead)
+
+        def ldifRead(self, result):
+            self.f.close()
+            self.db = result
+
+    class LDAPServerFactory(ServerFactory):
+        protocol = LDAPServer
+
+        def __init__(self, root):
+            self.root = root
+
+        def buildProtocol(self, addr):
+            proto = self.protocol()
+            proto.debug = self.debug
+            proto.factory = self
+            return proto
+
+    if __name__ == '__main__':
+        if len(sys.argv) == 2:
+            port = int(sys.argv[1])
+        else:
+            port = 8080
+        # First of all, to show logging info in stdout :
+        log.startLogging(sys.stderr)
+        # We initialize our tree
+        tree = Tree()
+        # When the LDAP Server protocol wants to manipulate the DIT, it invokes
+        # `root = interfaces.IConnectedLDAPEntry(self.factory)` to get the root
+        # of the DIT.  The factory that creates the protocol must therefore
+        # be adapted to the IConnectedLDAPEntry interface.
+        registerAdapter(
+            lambda x: x.root,
+            LDAPServerFactory,
+            IConnectedLDAPEntry)
+        factory = LDAPServerFactory(tree.db)
+        factory.debug = True
+        application = service.Application("ldaptor-server")
+        myService = service.IServiceCollection(application)
+        reactor.listenTCP(port, factory)
+        reactor.run()

--- a/ldaptor/protocols/ldap/proxybase.py
+++ b/ldaptor/protocols/ldap/proxybase.py
@@ -242,7 +242,8 @@ class MyProxy(ProxyBase):
 
 if __name__ == '__main__':
     """
-    Demonstration LDAP proxy; passes all requests to localhost:389.
+    Demonstration LDAP proxy; listens on localhost:10389; passes all requests 
+    to localhost:8080 and logs responses..
     """
     from twisted.internet import protocol
     import sys


### PR DESCRIPTION
I tried updating the documentation to be a little more straightforward.  I thought having both quickstart client and server sections would be useful for folks that want to dive right in.  I thought the introductory text could be better organized.  I added a "Cookbook" section for putting various short Ldaptor examples.  I was inspired by the O'Reilly Python Cookbook book, which I thought was a great way to learn how do accomplish various tasks with Python by example.

The documentation is by no means complete-- I am thinking of it as more of a starting point.

I apparently also snuck in a correction to errors I had made in the `proxybase` test code docstring.
