### PR TITLE
Proxybase - use `clientConnector` for making client connections, updated some docs

### DIFF
--- a/docs/source/addressbook-example.rst
+++ b/docs/source/addressbook-example.rst
@@ -39,9 +39,9 @@ Writing things down, John Smith LDIF::
      ple lines as long as the non-first lines are inden
      ted in the LDIF.
 
-------------------------------------
+-------------------------------------
 Asynchronous LDAP Clients and Servers
-------------------------------------
+-------------------------------------
 
 Ldaptor is a set of pure-Python LDAP client and server protocols and libraries..
 
@@ -90,15 +90,15 @@ Ldaptor contains helper classes to simplify connecting to an LDAP DIT.
 
 .. code-block:: python
 
-    >>> from ldaptor.protocols.ldap import ldapclient, ldapconnector
+    >>> from ldaptor.protocols.ldap.ldapclient import LDAPClient
     >>> from twisted.internet import reactor
-    >>> connector=ldapconnector.LDAPClientCreator(reactor, ldapclient.LDAPClient)
-    >>> connector
-    <ldaptor.protocols.ldap.ldapconnector.LDAPClientCreator
-    instance at 0x40619b6c>
-    >>> d = connector.connectAnonymously(dn, {dn: ('localhost', 10389)})
+    >>> from twisted.internet.endpoints import clientFromString, connectProtocol
+    >>> e = clientFromString(reactor, "tcp:host=localhost:port=10389")
+    >>> e
+    <twisted.internet.endpoints.TCP4ClientEndpoint at 0xb452e0c>
+    >>> d = connectProtocol(e, LDAPClient)
     >>> d
-    <Deferred at 0x402d058c>
+    <Deferred at 0xb34656c>
 
 
 ---------

--- a/docs/source/addressbook-example.rst
+++ b/docs/source/addressbook-example.rst
@@ -115,7 +115,7 @@ Deferreds
 Searching
 ---------
 
-Once connected to the DIT, and LDAP client can search for entries.
+Once connected to the DIT, an LDAP client can search for entries.
 
 .. code-block:: python
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,7 +31,6 @@ User's Guide
 
    ldap-intro
    addressbook-example
-   cookbook
    ldaptor
 
 ----------------

--- a/docs/source/ldap-intro.rst
+++ b/docs/source/ldap-intro.rst
@@ -141,6 +141,11 @@ In general, LDAP servers index the entries and can effectively search for matche
 
 An LDAP search takes the following information as input:
 
+* base DN
+* scope (base, one level, subtree)
+* filter
+* attributes requested
+
 .. NOTE::
    Once again, we are skipping some details for
    understandability.
@@ -209,8 +214,8 @@ Now, all the client needs to do is remember which numbers are still in use, and 
 It can internally maintain search state based on these numbers, and process result entries based on them.
 The client can reuse a number when it is known that no more server replies will be sent using that number; for example, the search done message gives this guarantee.
 
-Finally, when the client longer wants to talk to the server, it sends a message effectively saying "good bye".
-This message is known as ``unbind``.
+Finally, when the client no longer wants to talk to the server, it sends a message effectively saying 
+"good bye".  This message is known as ``unbind``.
 This only means that the state of connection is the same as when connected, before the first ``bind``; that is, it un-authenticates the current user.
 If the client really wants to close the connection, it will then close the TCP socket.
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -84,6 +84,7 @@ LDAP Server Quick Start
     objectclass: person
     objectClass: inetOrgPerson
     sn: Roberts
+    userPassword: secret
 
     """
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -11,6 +11,7 @@ LDAP Client Quickstart
     from twisted.internet.task import react
     from ldaptor.protocols.ldap.ldapclient import LDAPClient
     from ldaptor.protocols.ldap.ldapsyntax import LDAPEntry
+    import sys
 
     @defer.inlineCallbacks
     def onConnect(client):
@@ -28,15 +29,15 @@ LDAP Client Quickstart
         for entry in results:
             print(entry)
 
-    def onError(err, reactor):
-        err.printTraceback()
+    def onError(err):
+        err.printDetailedTraceback(file=sys.stderr)
 
     def main(reactor):
         endpoint_str = "tcp:host=127.0.0.1:port=8080"
         e = clientFromString(reactor, endpoint_str)
         d = connectProtocol(e, LDAPClient())
         d.addCallback(onConnect)
-        d.addErrback(onError, reactor)
+        d.addErrback(onError)
         return d
 
     react(main)

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -49,7 +49,7 @@ LDAP Server Quick Start
 .. code-block:: python
 
     from twisted.application import service, internet
-    from twisted.internet import reactor
+    from twisted.internet.endpoints import serverFromString
     from twisted.internet.protocol import ServerFactory
     from twisted.python.components import registerAdapter
     from twisted.python import log
@@ -112,6 +112,7 @@ LDAP Server Quick Start
             return proto
 
     if __name__ == '__main__':
+        from twisted.internet import reactor
         if len(sys.argv) == 2:
             port = int(sys.argv[1])
         else:
@@ -132,5 +133,7 @@ LDAP Server Quick Start
         factory.debug = True
         application = service.Application("ldaptor-server")
         myService = service.IServiceCollection(application)
-        reactor.listenTCP(port, factory)
+        serverEndpointStr = "tcp:{0}".format(port)
+        e = serverFromString(reactor, serverEndpointStr)
+        d = e.listen(factory)
         reactor.run()

--- a/ldaptor/protocols/ldap/ldapconnector.py
+++ b/ldaptor/protocols/ldap/ldapconnector.py
@@ -1,9 +1,21 @@
 from twisted.internet import protocol, defer
-from twisted.internet.endpoints import clientFromString, connectProtocol
+from twisted.internet.endpoints import clientFromString
+try:
+    from twisted.internet import endpoints
+    connectProtocol = endpoints.connectProtocol
+except AttributeError:
+    # Twisted >= 13.1
+    from twisted.internet.protocol import Factory
+    def connectProtocol(endpoint, protocol):
+        class OneShotFactory(Factory):
+            def buildProtocol(self, addr):
+                return protocol
+        return endpoint.connect(OneShotFactory())
 from ldaptor.protocols.ldap import distinguishedname
 try:
-    from twisted.internet.utils import SRVConnector
-except ImportError:
+    from twisted.internet import utils
+    SRVConnector = utils.SRVConnector
+except AttributeError:
     from twisted.names.srvconnect import SRVConnector
 
 def connectToLDAPEndpoint(reactor, endpointStr, clientProtocol):

--- a/ldaptor/protocols/ldap/ldapconnector.py
+++ b/ldaptor/protocols/ldap/ldapconnector.py
@@ -1,10 +1,16 @@
 from twisted.internet import protocol, defer
+from twisted.internet.endpoints import clientFromString, connectProtocol
 from ldaptor.protocols.ldap import distinguishedname
-
 try:
     from twisted.internet.utils import SRVConnector
 except ImportError:
     from twisted.names.srvconnect import SRVConnector
+
+def connectToLDAPEndpoint(reactor, endpointStr, clientProtocol):
+    e = clientFromString(reactor, endpointStr)
+    d = connectProtocol(e, clientProtocol())
+    return d
+
 
 class LDAPConnector(SRVConnector):
     def __init__(self, reactor, dn, factory,

--- a/ldaptor/protocols/ldap/proxybase.py
+++ b/ldaptor/protocols/ldap/proxybase.py
@@ -27,16 +27,16 @@ class ProxyBase(ldapserver.BaseLDAPServer):
         # are queued.
         self.queuedRequests = []
         self.startTLS_initiated = False
-        assert clientConnector is not None, (
-            "You must set the `clientConnector` property on this instance.  "
-            "It should be a callable that attempts to connect to a server. "
-            "This callable should return a deferred that will fire with a "
-            "protocol instance when the connection is complete.")
 
     def connectionMade(self):
         """
         Establish a connection to the proxied LDAP server.
         """
+        assert self.clientConnector is not None, (
+            "You must set the `clientConnector` property on this instance.  "
+            "It should be a callable that attempts to connect to a server. "
+            "This callable should return a deferred that will fire with a "
+            "protocol instance when the connection is complete.")
         d = self.clientConnector()
         d.addCallback(self._connectedToProxiedServer)
         d.addErrback(self._failedToConnectToProxiedServer)

--- a/ldaptor/test/test_proxybase.py
+++ b/ldaptor/test/test_proxybase.py
@@ -4,10 +4,9 @@ Test cases for ldaptor.protocols.ldap.proxybase module.
 from functools import partial
 import itertools
 from twisted.internet import error, defer
-from twisted.internet.task import Clock, deferLater
+from twisted.internet.task import Clock
 from twisted.trial import unittest
 from twisted.test import proto_helpers
-from ldaptor import config
 from ldaptor.protocols.ldap import proxybase, ldaperrors
 from ldaptor.protocols import pureldap
 from ldaptor import testutil
@@ -66,13 +65,6 @@ def failToConnectToServer(reactor, delay=0):
 
     reactor.callLater(delay, onConnect)
     return d
-
-def makeClientCreatorFactory(delay):
-    def makeClientCreator(reactor_, protocol):
-        cc = WontConnectClientCreator(reactor=reactor_)
-        cc.delay = delay
-        return cc
-    return makeClientCreator
 
 
 class ProxyBase(unittest.TestCase):

--- a/ldaptor/test/test_proxybase.py
+++ b/ldaptor/test/test_proxybase.py
@@ -1,6 +1,7 @@
 """
 Test cases for ldaptor.protocols.ldap.proxybase module.
 """
+from functools import partial
 import itertools
 from twisted.internet import error, defer
 from twisted.internet.task import Clock, deferLater
@@ -57,30 +58,14 @@ class WontConnectError(Exception):
     pass
 
 
-class WontConnectClientCreator(object):
-    """
-    A test LDAP client creator that will raise an exception when the
-    `connect()` method is called.
-    """
-    ex = None
-    delay = 0
+def failToConnectToServer(reactor, delay=0):
+    d = defer.Deferred()
 
-    def __init__(self, *args, **kwgs):
-        if self.ex is None:
-            self.ex = WontConnectError("Test LDAP client refuses to connect.")
-        self.reactor = kwgs.get('reactor', None)
+    def onConnect():
+        d.errback(fail=WontConnectError("Test LDAP client refuses to connect."))
 
-    def connect(self, *args, **kwgs):
-        delay = self.delay
-        if delay == 0:
-            return defer.fail(self.ex)
-        else:
-            d = deferLater(self.reactor, delay, self.refuseConnect_)
-            return d
-
-    def refuseConnect_(self):
-        return defer.fail(self.ex)
-
+    reactor.callLater(delay, onConnect)
+    return d
 
 def makeClientCreatorFactory(delay):
     def makeClientCreator(reactor_, protocol):
@@ -97,8 +82,26 @@ class ProxyBase(unittest.TestCase):
         """
         protocol = kwds.get("protocol", proxybase.ProxyBase)
         clock = Clock()
-        proto_args = dict(reactor_=clock)
-        server = testutil.createServer(protocol, *responses, proto_args=proto_args)
+        clock = kwds.get('clock', clock)
+        server = protocol()
+        clientTestDriver = testutil.LDAPClientTestDriver(*responses)
+        
+        def simulateConnectToServer():
+            d = defer.Deferred()
+
+            def onConnect():
+                clientTestDriver.connectionMade()
+                d.callback(clientTestDriver)
+
+            clock.callLater(0, onConnect)
+            return d
+
+        clientConnector = kwds.get('clientConnector', simulateConnectToServer)
+        server.clientConnector = clientConnector
+        server.clientTestDriver = clientTestDriver
+        server.transport = proto_helpers.StringTransport()
+        server.reactor = clock
+        server.connectionMade()
         return server
 
     def test_bind(self):
@@ -156,17 +159,19 @@ class ProxyBase(unittest.TestCase):
         The server disconects correctly when the client terminates the
         connection without sending an unbind request.
         """
-        server = self.createServer([pureldap.LDAPBindResponse(resultCode=0)], [])
+        server = self.createServer([pureldap.LDAPBindResponse(resultCode=0)])
         server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=2)))
         server.reactor.advance(1)
         client = server.client
         client.assertSent(pureldap.LDAPBindRequest())
-        self.assertEquals(server.transport.value(),
-                          str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
+        self.assertEquals(
+            server.transport.value(),
+            str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
         server.connectionLost(error.ConnectionDone)
         server.reactor.advance(1)
-        client.assertSent(pureldap.LDAPBindRequest(),
-                          'fake-unbind-by-LDAPClientTestDriver')
+        client.assertSent(
+            pureldap.LDAPBindRequest(),
+            'fake-unbind-by-LDAPClientTestDriver')
         self.assertEquals(server.transport.value(),
                           str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
 
@@ -218,13 +223,13 @@ class ProxyBase(unittest.TestCase):
         When making a request and the proxy cannot connect to the proxied server, the
         connection is terminated.
         """
-        conf = config.LDAPConfig(serviceLocationOverrides={'': ('localhost', 8080)})
-        server = proxybase.ProxyBase(conf, reactor_=Clock())
-        server.transport = proto_helpers.StringTransport()
-        server.clientCreator = makeClientCreatorFactory(0)
-        server.connectionMade()
-        server.clientCreator = WontConnectClientCreator
-        server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=4)))
+        clock = Clock()
+        connector = partial(failToConnectToServer, clock)
+        server = self.createServer(
+            [], 
+            clientConnector=connector, 
+            clock=clock)
+        self.assertEquals(connector, server.clientConnector)
         server.reactor.advance(1)
         self.assertEquals(server.transport.value(), "")
 
@@ -234,12 +239,15 @@ class ProxyBase(unittest.TestCase):
         pending BIND and startTLS requests are replied to and the connection
         is closed.
         """
-        conf = config.LDAPConfig(serviceLocationOverrides={'': ('localhost', 8080)})
-        server = proxybase.ProxyBase(conf, reactor_=Clock())
-        server.transport = proto_helpers.StringTransport()
-        server.clientCreator = makeClientCreatorFactory(2)
-        server.connectionMade()
+        clock = Clock()
+        connector = partial(failToConnectToServer, clock)
+        server = self.createServer(
+            [], 
+            clientConnector=connector, 
+            clock=clock)
+        self.assertEquals(connector, server.clientConnector)
         server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=4)))
         server.reactor.advance(2)
-        self.assertEquals(server.transport.value(),
-                          str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=52), id=4)))
+        self.assertEquals(
+            server.transport.value(),
+            str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=52), id=4)))


### PR DESCRIPTION
I realized that the `ProxyBase` class assumed a particular kind of connection to the proxied server using the `ldaptor.protocols.ldap.ldapconnector.LDAPClientCreator` or something very similar.  This made it difficult to integrate it with connecting using Twisted client endpoints.  Since there has not been a release since `ProxyBase` was added, I broke the original API and replaced the relevant properties with a `clientConnector` property that is a callable that should take care of establishing the connection and returns a deferred that fires with a client protocol instance.

Related, I updated some of the documentation that referenced the old API.  

I also updated some of the documentation for clients and servers in general to use Twisted endpoints instead of `LDAPClientCreator`.  There were a couple reasons.  

Typical LDAP clients I have worked with just want to connect to a host and a port and maybe use LDAPS or STARTTLS.  They do not use a much more complex configuration than that, nor do they try to use DNS SRV records, which `LDAPClientCreator` throws into the mix.  In my opinion, this muddies the waters a bit for someone just trying to get started with ldaptor, and I think the documentation should reflect that.

On a technical level, `LDAPClientCreator` is based on the older Twisted `ClientCreator` which is somewhat less flexible than the newer client endpoints.  The `LDAPClientCreator` implementation also makes use of what appears to be a "private" class, `protocol._InstanceFactory`. 

This makes me think that unless someone *really* needs to use SRV lookups, the documentation should just steer them to making a more straightforward connection to the server.
