### PR TITLE
Documentation updates

### DIFF
--- a/docs/source/addressbook-example.rst
+++ b/docs/source/addressbook-example.rst
@@ -82,6 +82,30 @@ Twisted supports TCP, UDP, SSL/TLS, multicast, Unix sockets, a large number of p
 
 Twisted includes many full-blown applications, such as web, SSH, FTP, DNS and news servers.
 
+---------
+Deferreds
+---------
+
+- A promise that a function will at some point have a result.
+- You can attach callback functions to a Deferred.
+- Once it gets a result these callbacks will be called.
+- Also allows you to register a callback for an error, with the default behavior of logging the error.
+- Standard way to handle all sorts of blocking or delayed operations.
+
+.. note::
+
+    Because of the asynchronous nature of Deferreds, a standard interactive
+    Python shell won't work treat the following examples the way you might
+    expect.  That is because the Twisted reator is not running, so connections
+    will never be made and Deferreds will never fire their callback function(s).
+
+    If you want to follow along interactively, you can use the following
+    interactive shell that comes with Twisted.  It runs a reactor in the 
+    background so you can see deferred results::
+
+        $ python -m twisted.conch.stdio
+
+
 -------------------------------
 Connect to a DIT Asynchronously
 -------------------------------
@@ -96,20 +120,9 @@ Ldaptor contains helper classes to simplify connecting to an LDAP DIT.
     >>> e = clientFromString(reactor, "tcp:host=localhost:port=10389")
     >>> e
     <twisted.internet.endpoints.TCP4ClientEndpoint at 0xb452e0c>
-    >>> d = connectProtocol(e, LDAPClient)
+    >>> d = connectProtocol(e, LDAPClient())
     >>> d
-    <Deferred at 0xb34656c>
-
-
----------
-Deferreds
----------
-
-- A promise that a function will at some point have a result.
-- You can attach callback functions to a Deferred.
-- Once it gets a result these callbacks will be called.
-- Also allows you to register a callback for an error, with the default behavior of logging the error.
-- Standard way to handle all sorts of blocking or delayed operations.
+    <Deferred at 0x36755a8 current result: <ldaptor.protocols.ldap.ldapclient.LDAPClient instance at 0x36757a0>>
 
 ---------
 Searching
@@ -119,15 +132,15 @@ Once connected to the DIT, an LDAP client can search for entries.
 
 .. code-block:: python
 
-    >>> from twisted.trial.util import deferredResult
-    >>> proto = deferredResult(d)
+    >>> proto = d.result
     >>> proto
-    <ldaptor.protocols.ldap.ldapclient.LDAPClient
-    instance at 0x40619dac>
+    <ldaptor.protocols.ldap.ldapclient.LDAPClient instance at 0x40619dac>
     >>> from ldaptor.protocols.ldap import ldapsyntax
+    >>> from ldaptor.protocols.ldap import distinguishedname
+    >>> dn = distinguishedname.DistinguishedName("dc=example,dc=org")
     >>> baseEntry = ldapsyntax.LDAPEntry(client=proto, dn=dn)
-    >>> d2 = baseEntry.search(filterText='(gn=j*)')
-    >>> results = deferredResult(d2)
+    >>> d2 = baseEntry.search(filterText='(givenName=b*)')
+    >>> results = d2.result
 
 -------
 Results

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -103,7 +103,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'alabaster'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/source/cookbook/clients.rst
+++ b/docs/source/cookbook/clients.rst
@@ -63,14 +63,14 @@ The :py:func:`twisted.internet.task.react()` function is perfect for running a
 one-shot `main()` function.  When `main()` is called, we create a client 
 endpoint from a string description and the reactor.
 :py:func:`twisted.internet.endpoints.connectProtocol()` is used to make a
-one-time connection to an LDAP DIT listening on the local host, port 8080.
+one-time connection to an LDAP directory listening on the local host, port 8080.
 When the deferred returned from that function fires, the connection has
 been established and the client protocol instance is passed to the 
 :py:func:`onConnect()` callback.
 
 This callback uses inline deferreds to make the syntax more compact.  We create
 an :py:class:`ldaptor.protocols.ldap.ldapsyntax.LDAPEntry` with a DN matching
-the root of the DIT and call the asynchronous :py:func:`search()` method.  The
+the root of the directory and call the asynchronous :py:func:`search()` method.  The
 result returned when the deferred fires is a list of :py:class:`LDAPEntry` 
 objects.
 

--- a/docs/source/cookbook/ldap-proxy.rst
+++ b/docs/source/cookbook/ldap-proxy.rst
@@ -6,9 +6,9 @@ An LDAP proxy sits between an LDAP client and an LDAP server.  It accepts LDAP
 requests from the client and forwards them to the LDAP server.  Responses from
 the server are then relayed back to the client.
 
-----------------
-Why is it Useful
-----------------
+-----------------
+Why is it Useful?
+-----------------
 
 An LDAP proxy has many different uses:
 
@@ -39,6 +39,10 @@ An LDAP proxy has many different uses:
   round-robin architecture.  The client can be configured to always connect
   to the proxy, which in turn will distrbute the connections amongst the 
   replicas.
+
+--------------
+Proxy Recipies
+--------------
 
 """"""""""""""""""
 Logging LDAP Proxy

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,7 +30,7 @@ User's Guide
    :maxdepth: 1
 
    ldap-intro
-   addressbook-example
+   simple-app 
    ldaptor
 
 ----------------

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -42,6 +42,8 @@ LDAP Client Quickstart
 
     react(main)
 
+.. _quickstart-server-label:
+
 =======================
 LDAP Server Quick Start
 =======================
@@ -78,13 +80,37 @@ LDAP Server Quick Start
 
     dn: cn=bob,ou=people,dc=example,dc=org
     cn: bob
-    givenName: Bob
+    gn: Bob
     mail: bob@example.org
     objectclass: top
     objectclass: person
     objectClass: inetOrgPerson
     sn: Roberts
     userPassword: secret
+
+    dn: gn=John+sn=Doe,ou=people,dc=example,dc=org
+    objectClass: addressbookPerson
+    gn: John
+    sn: Doe
+    street: Back alley
+    postOfficeBox: 123
+    postalCode: 54321
+    postalAddress: Backstreet
+    st: NY
+    l: New York City
+    c: US
+    userPassword: terces
+
+    dn: gn=John+sn=Smith,ou=people, dc=example,dc=org
+    objectClass: addressbookPerson
+    gn: John
+    sn: Smith
+    telephoneNumber: 555-1234
+    facsimileTelephoneNumber: 555-1235
+    description: This is a description that can span multi
+     ple lines as long as the non-first lines are inden
+     ted in the LDIF.
+    userPassword: eekretsay
 
     """
 

--- a/docs/source/simple-app.rst
+++ b/docs/source/simple-app.rst
@@ -1,5 +1,5 @@
 ==================================
-Creating a simple LDAP application
+Creating a Simple LDAP Application
 ==================================
 
 --------------
@@ -39,6 +39,32 @@ Writing things down, John Smith LDIF::
      ple lines as long as the non-first lines are inden
      ted in the LDIF.
 
+-------
+Twisted
+-------
+
+Twisted is an event-driven networking framework written in Python and licensed under the MIT (Expat) License.
+
+Twisted supports TCP, UDP, SSL/TLS, multicast, Unix sockets, a large number of protocols (including HTTP, NNTP, SSH, IRC, FTP, and others), and much more.
+
+Twisted includes many full-blown applications, such as web, SSH, FTP, DNS and news servers.
+
+---------
+Deferreds
+---------
+
+- A promise that a function will at some point have a result.
+- You can attach callback functions to a Deferred.
+- Once it gets a result these callbacks will be called.
+- Also allows you to register a callback for an error, with the default behavior of logging the error.
+- Standard way to handle all sorts of blocking or delayed operations.
+
+-------------------
+Overview of Ldaptor
+-------------------
+
+.. image::  _static/images/overview.png
+
 -------------------------------------
 Asynchronous LDAP Clients and Servers
 -------------------------------------
@@ -47,9 +73,9 @@ Ldaptor is a set of pure-Python LDAP client and server protocols and libraries..
 
 It is licensed under the MIT (Expat) License.
 
----------------------------------
+"""""""""""""""""""""""""""""""""
 Following Along with the Examples
----------------------------------
+"""""""""""""""""""""""""""""""""
 
 If you are following along with the interactive examples, you will need an LDAP 
 directory server to which the example client can connect.  A script that 
@@ -90,36 +116,9 @@ Working with Distinguished Names
     >>> str(dn)
     'dc=example,dc=com'
 
-
--------------------
-Overview of Ldaptor
--------------------
-
-.. image::  _static/images/overview.png
-
--------
-Twisted
--------
-
-Twisted is an event-driven networking framework written in Python and licensed under the MIT (Expat) License.
-
-Twisted supports TCP, UDP, SSL/TLS, multicast, Unix sockets, a large number of protocols (including HTTP, NNTP, SSH, IRC, FTP, and others), and much more.
-
-Twisted includes many full-blown applications, such as web, SSH, FTP, DNS and news servers.
-
----------
-Deferreds
----------
-
-- A promise that a function will at some point have a result.
-- You can attach callback functions to a Deferred.
-- Once it gets a result these callbacks will be called.
-- Also allows you to register a callback for an error, with the default behavior of logging the error.
-- Standard way to handle all sorts of blocking or delayed operations.
-
--------------------------------
-Connect to a DIT Asynchronously
--------------------------------
+-------------------------------------
+Connect to a Directory Asynchronously
+-------------------------------------
 
 Ldaptor contains helper classes to simplify connecting to an LDAP DIT.
 


### PR DESCRIPTION
Primarily, I updated the "Creating a Simple Application ..." section of the docs.  The interactive examples were broken because they relied on a deprecated function in `twisted.trial` to get the results of deferreds at the interactive prompt.  Luckilly, twisted provides its own interactive shell *with* a reactor in the `twisted.conch` package, so I was able to salvage the interactive examples by adding a note to try them in that shell.

I also reorganized the sub-sections until I felt they were in the correct order.  

I changed the Sphinx config setting 'default' to 'alabaseter' because Sphinx was complaining that 'default' is going away and I should choose either 'alabaster' or 'classic'.  I am not partial to either-- just wanted to silence the warning.