### PR TITLE
Requested attributes fix and subtree build change

### DIFF
--- a/ldaptor/entryhelpers.py
+++ b/ldaptor/entryhelpers.py
@@ -130,7 +130,7 @@ class SubtreeFromChildrenMixin(object):
             callback(self)
             d = self.children()
             def _gotChildren(children, callback):
-                for c in children:
+                for c in reversed(children):
                     c.subtree(callback)
             d.addCallback(_gotChildren, callback)
             return d

--- a/ldaptor/entryhelpers.py
+++ b/ldaptor/entryhelpers.py
@@ -129,9 +129,15 @@ class SubtreeFromChildrenMixin(object):
         else:
             callback(self)
             d = self.children()
+            def _processOneChild(_, children, callback):
+                if not children:
+                    return None
+
+                c = children.pop()
+                d = c.subtree(callback)
+                d.addCallback(_processOneChild, children, callback)
             def _gotChildren(children, callback):
-                for c in reversed(children):
-                    c.subtree(callback)
+                _processOneChild(None, children, callback)
             d.addCallback(_gotChildren, callback)
             return d
 

--- a/ldaptor/entryhelpers.py
+++ b/ldaptor/entryhelpers.py
@@ -129,15 +129,9 @@ class SubtreeFromChildrenMixin(object):
         else:
             callback(self)
             d = self.children()
-            def _processOneChild(_, children, callback):
-                if not children:
-                    return None
-
-                c = children.pop()
-                d = c.subtree(callback)
-                d.addCallback(_processOneChild, children, callback)
             def _gotChildren(children, callback):
-                _processOneChild(None, children, callback)
+                for c in children:
+                    c.subtree(callback)
             d.addCallback(_gotChildren, callback)
             return d
 

--- a/ldaptor/protocols/ldap/ldapserver.py
+++ b/ldaptor/protocols/ldap/ldapserver.py
@@ -199,7 +199,7 @@ class LDAPServer(BaseLDAPServer):
     def _cbSearchGotBase(self, base, dn, request, reply):
         def _sendEntryToClient(entry):
             requested_attribs = request.attributes
-            if len(requested_attribs) > 0:
+            if len(requested_attribs) > 0 and '*' not in requested_attribs:
                 filtered_attribs = [
                     (k, entry.get(k)) for k in requested_attribs if k in entry]
             else:


### PR DESCRIPTION
1. Some clients request for all attributes by sending ['*'] as a list of required attributes (like Apache Directory Studio).
2. Recursive callback of _processOneChild in subtree method reaches recursion limit while searching through a long list of children. With recursion limit of 1000 it processes ~180 child entries before raising exception. I found no way to fix it without removing deferred getting of every next child.