### PR TITLE
When parsing LDAPControls, criticality may not exist while controlValue still does.

### DIFF
--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -841,13 +841,17 @@ class LDAPControl(BERSequence):
     def fromBER(klass, tag, content, berdecoder=None):
         l = berDecodeMultiple(content, berdecoder)
 
+        assert 1<=len(l)<= 3
+
         kw = {}
-        if l[1:]:
+        if len(l) == 2:
+            if isinstance(l[1], BERBoolean):
+              kw['criticality'] = l[1].value
+            elif isinstance(l[1], BEROctetString):
+              kw['controlValue'] = l[1].value
+        elif len(l) == 3:
             kw['criticality'] = l[1].value
-        if l[2:]:
             kw['controlValue'] = l[2].value
-        # TODO is controlType, controlValue allowed without criticality?
-        assert not l[3:]
 
         r = klass(controlType=l[0].value,
                   tag=tag,

--- a/ldaptor/test/test_pureldap.py
+++ b/ldaptor/test/test_pureldap.py
@@ -358,13 +358,14 @@ class KnownValues(unittest.TestCase):
           'controls': [ ('1.2.3.4', None, None),
                         ('2.3.4.5', False),
                         ('3.4.5.6', True, '\x00\x01\x02\xFF'),
+                        ('4.5.6.7', None, '\x00\x01\x02\xFF'),
                         ],
           },
          pureldap.LDAPBERDecoderContext_TopLevel(
         inherit=pureldap.LDAPBERDecoderContext_LDAPMessage(
         fallback=pureldap.LDAPBERDecoderContext(fallback=pureber.BERDecoderContext()),
         inherit=pureldap.LDAPBERDecoderContext(fallback=pureber.BERDecoderContext()))),
-         [0x30, 59]
+         [0x30, 76]
          # id
          + [0x02, 0x01, 42]
          # value
@@ -376,6 +377,9 @@ class KnownValues(unittest.TestCase):
                              criticality=False),
         pureldap.LDAPControl(controlType='3.4.5.6',
                              criticality=True,
+                             controlValue='\x00\x01\x02\xFF'),
+        pureldap.LDAPControl(controlType='4.5.6.7',
+                             criticality=None,
                              controlValue='\x00\x01\x02\xFF'),
         ]))),
          ),


### PR DESCRIPTION
See updated unit test.