### PR TITLE
Implement Compare* Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ ldaptor.egg-info
 venv/
 build/
 dist/
+.cache
+tags

--- a/ldaptor/protocols/ldap/ldapserver.py
+++ b/ldaptor/protocols/ldap/ldapserver.py
@@ -196,6 +196,55 @@ class LDAPServer(BaseLDAPServer):
         return pureldap.LDAPSearchResultDone(
             resultCode=ldaperrors.Success.resultCode)
 
+    fail_LDAPCompareRequest = pureldap.LDAPCompareResponse
+
+    def handle_LDAPCompareRequest(self, request, controls, reply):
+        def _cbCompareGotBase(base, ava, reply):
+            def _done(result_list):
+                if result_list:
+                    resultCode = ldaperrors.LDAPCompareTrue.resultCode
+                else:
+                    resultCode = ldaperrors.LDAPCompareFalse.resultCode
+                return pureldap.LDAPCompareResponse(resultCode)
+
+            # base.search only works with Filter Objects, and not with
+            # AttributeValueAssertion objects. Here we convert the AVA to an
+            # equivalent Filter so we can re-use the existing search
+            # functionality we require.
+            search_filter = pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=ava.attributeDesc,
+                assertionValue=ava.assertionValue
+            )
+
+            d = base.search(filterObject=search_filter,
+                           scope=pureldap.LDAP_SCOPE_baseObject,
+                           derefAliases = pureldap.LDAP_DEREF_neverDerefAliases)
+
+            d.addCallback(_done)
+
+            return d
+
+        def _cbCompareLDAPError(reason):
+            reason.trap(ldaperrors.LDAPException)
+            return pureldap.LDAPCompareResponse(
+                resultCode=reason.value.resultCode)
+
+        def _cbCompareOtherError(reason):
+            return pureldap.LDAPCompareResponse(
+                resultCode=ldaperrors.other,
+                errorMessage=reason.getErrorMessage())
+
+        self.checkControls(controls)
+        dn = distinguishedname.DistinguishedName(request.entry)
+        root = interfaces.IConnectedLDAPEntry(self.factory)
+
+        d = root.lookup(dn)
+        d.addCallback(_cbCompareGotBase, request.ava, reply)
+        d.addErrback(_cbCompareLDAPError)
+        d.addErrback(defer.logError)
+        d.addErrback(_cbCompareOtherError)
+        return d
+
     def _cbSearchGotBase(self, base, dn, request, reply):
         def _sendEntryToClient(entry):
             requested_attribs = request.attributes

--- a/ldaptor/protocols/ldap/ldapserver.py
+++ b/ldaptor/protocols/ldap/ldapserver.py
@@ -216,9 +216,11 @@ class LDAPServer(BaseLDAPServer):
                 assertionValue=ava.assertionValue
             )
 
-            d = base.search(filterObject=search_filter,
-                           scope=pureldap.LDAP_SCOPE_baseObject,
-                           derefAliases = pureldap.LDAP_DEREF_neverDerefAliases)
+            d = base.search(
+                    filterObject=search_filter,
+                    scope=pureldap.LDAP_SCOPE_baseObject,
+                    derefAliases=pureldap.LDAP_DEREF_neverDerefAliases
+                    )
 
             d.addCallback(_done)
 
@@ -288,9 +290,9 @@ class LDAPServer(BaseLDAPServer):
     def handle_LDAPSearchRequest(self, request, controls, reply):
         self.checkControls(controls)
 
-        if (request.baseObject == ''
-                and request.scope == pureldap.LDAP_SCOPE_baseObject
-                and request.filter == pureldap.LDAPFilter_present('objectClass')):
+        if (request.baseObject == '' and
+                request.scope == pureldap.LDAP_SCOPE_baseObject and
+                request.filter == pureldap.LDAPFilter_present('objectClass')):
             return self.getRootDSE(request, reply)
         dn = distinguishedname.DistinguishedName(request.baseObject)
         root = interfaces.IConnectedLDAPEntry(self.factory)
@@ -470,15 +472,15 @@ class LDAPServer(BaseLDAPServer):
         if self.boundUser is None:
             raise ldaperrors.LDAPStrongAuthRequired()
 
-        if (userIdentity is not None
-                and userIdentity != self.boundUser.dn):
+        if (userIdentity is not None and
+                userIdentity != self.boundUser.dn):
             log.msg('User %(actor)s tried to change password of %(target)s' % {
                 'actor': str(self.boundUser.dn),
                 'target': str(userIdentity),
                 })
             raise ldaperrors.LDAPInsufficientAccessRights()
-        if (oldPasswd is not None
-                or newPasswd is None):
+        if (oldPasswd is not None or
+                newPasswd is None):
             raise ldaperrors.LDAPOperationsError(
                 'Password does not support this case.')
         self.boundUser.setPassword(newPasswd)

--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -355,7 +355,7 @@ class LDAPAttributeValueAssertion(BERSequence):
     def __str__(self):
         return str(BERSequence([self.attributeDesc,
                                 self.assertionValue],
-                                tag=self.tag))
+                               tag=self.tag))
 
     def __repr__(self):
         if self.tag==self.__class__.tag:
@@ -1139,19 +1139,27 @@ class LDAPModifyDNRequest(LDAPProtocolRequest, BERSequence):
 class LDAPModifyDNResponse(LDAPResult):
     tag=CLASS_APPLICATION|13
 
+
 class LDAPBERDecoderContext_Compare(BERDecoderContext):
     Identities = {
         BERSequence.tag: LDAPAttributeValueAssertion
     }
 
+
 class LDAPCompareRequest(LDAPProtocolRequest, BERSequence):
-    tag=CLASS_APPLICATION|14
+    tag = CLASS_APPLICATION | 14
 
     entry = None
     ava = None
 
     def fromBER(klass, tag, content, berdecoder=None):
-        l = berDecodeMultiple(content, LDAPBERDecoderContext_Compare(fallback=berdecoder, inherit=berdecoder))
+        l = berDecodeMultiple(
+                content,
+                LDAPBERDecoderContext_Compare(
+                    fallback=berdecoder,
+                    inherit=berdecoder
+                    )
+                )
 
         r = klass(entry=l[0].value,
                   ava=l[1],
@@ -1169,15 +1177,17 @@ class LDAPCompareRequest(LDAPProtocolRequest, BERSequence):
         self.ava = ava
 
     def __str__(self):
-        l = [ LDAPString(self.entry), self.ava ]
+        l = [LDAPString(self.entry), self.ava]
         return str(BERSequence(l, tag=self.tag))
 
     def __repr__(self):
-        l = [ "entry={}".format(self.entry), "ava={}".format(repr(self.ava)) ]
+        l = ["entry={}".format(self.entry), "ava={}".format(repr(self.ava))]
         return "{}({})".format(self.__class__.__name__, ', '.join(l))
 
+
 class LDAPCompareResponse(LDAPResult):
-    tag=CLASS_APPLICATION|15
+    tag=CLASS_APPLICATION | 15
+
 
 class LDAPAbandonRequest(LDAPProtocolRequest, LDAPInteger):
     tag = CLASS_APPLICATION|0x10

--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -355,7 +355,7 @@ class LDAPAttributeValueAssertion(BERSequence):
     def __str__(self):
         return str(BERSequence([self.attributeDesc,
                                 self.assertionValue],
-                               tag=self.tag))
+                                tag=self.tag))
 
     def __repr__(self):
         if self.tag==self.__class__.tag:
@@ -1139,8 +1139,45 @@ class LDAPModifyDNRequest(LDAPProtocolRequest, BERSequence):
 class LDAPModifyDNResponse(LDAPResult):
     tag=CLASS_APPLICATION|13
 
-#class LDAPCompareResponse(LDAPProtocolResponse):
-#class LDAPCompareRequest(LDAPProtocolRequest):
+class LDAPBERDecoderContext_Compare(BERDecoderContext):
+    Identities = {
+        BERSequence.tag: LDAPAttributeValueAssertion
+    }
+
+class LDAPCompareRequest(LDAPProtocolRequest, BERSequence):
+    tag=CLASS_APPLICATION|14
+
+    entry = None
+    ava = None
+
+    def fromBER(klass, tag, content, berdecoder=None):
+        l = berDecodeMultiple(content, LDAPBERDecoderContext_Compare(fallback=berdecoder, inherit=berdecoder))
+
+        r = klass(entry=l[0].value,
+                  ava=l[1],
+                  tag=tag)
+
+        return r
+    fromBER = classmethod(fromBER)
+
+    def __init__(self, entry, ava, tag=None):
+        LDAPProtocolRequest.__init__(self)
+        BERSequence.__init__(self, [], tag=tag)
+        assert entry is not None
+        assert ava is not None
+        self.entry = entry
+        self.ava = ava
+
+    def __str__(self):
+        l = [ LDAPString(self.entry), self.ava ]
+        return str(BERSequence(l, tag=self.tag))
+
+    def __repr__(self):
+        l = [ "entry={}".format(self.entry), "ava={}".format(repr(self.ava)) ]
+        return "{}({})".format(self.__class__.__name__, ', '.join(l))
+
+class LDAPCompareResponse(LDAPResult):
+    tag=CLASS_APPLICATION|15
 
 class LDAPAbandonRequest(LDAPProtocolRequest, LDAPInteger):
     tag = CLASS_APPLICATION|0x10
@@ -1402,4 +1439,6 @@ class LDAPBERDecoderContext(BERDecoderContext):
         LDAPModifyDNRequest.tag: LDAPModifyDNRequest,
         LDAPModifyDNResponse.tag: LDAPModifyDNResponse,
         LDAPAbandonRequest.tag: LDAPAbandonRequest,
+        LDAPCompareRequest.tag: LDAPCompareRequest,
+        LDAPCompareResponse.tag: LDAPCompareResponse
     }

--- a/ldaptor/test/test_server.py
+++ b/ldaptor/test/test_server.py
@@ -52,6 +52,45 @@ class LDAPServerTest(unittest.TestCase):
                 'objectClass': ['a', 'b'],
                 'cn': ['another'],
             })
+
+        # Add Users Subtree
+        self.users = self.root.addChild(
+            rdn='ou=People',
+            attributes={
+                'objectClass': ['top', 'organizationalunit'],
+                'ou': ['People']
+            })
+
+        self.users.addChild(
+            rdn='uid=kthompson',
+            attributes={
+                'objectClass': ['top', 'inetOrgPerson'],
+                'uid': ['kthompson']
+            })
+
+        self.users.addChild(
+            rdn='uid=bgates',
+            attributes={
+                'objectClass': ['top', 'inetOrgPerson'],
+                'uid': ['bgates']
+            })
+
+        # Add Groups Subtree
+        self.groups = self.root.addChild(
+            rdn='ou=Groups',
+            attributes={
+                'objectClass': ['top', 'organizationalunit'],
+                'ou': ['Groups']
+            })
+
+        self.groups.addChild(
+            rdn = 'cn=unix',
+            attributes={
+                'uniquemember': ['uid=kthompson,ou=People,dc=example,dc=com'],
+                'objectClass': ['top', 'groupOfUniqueNames'],
+                'cn': ['unix']
+            })
+
         server = ldapserver.LDAPServer()
         server.factory = self.root
         server.transport = proto_helpers.StringTransport()
@@ -187,6 +226,66 @@ class LDAPServerTest(unittest.TestCase):
         self.server.dataReceived(
             str(pureldap.LDAPMessage(pureldap.LDAPUnbindRequest(), id=7)))
         self.assertEquals(self.server.transport.value(), '')
+
+    def test_compare_outOfTree(self):
+        dn = 'dc=invalid'
+        attribute_desc = pureldap.LDAPString('objectClass')
+        attribute_value = pureldap.LDAPString('groupOfUniqueNames')
+        ava = pureldap.LDAPAttributeValueAssertion(attribute_desc, attribute_value)
+
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPCompareRequest(entry=dn, ava=ava),
+                    id=2)))
+
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPCompareResponse(
+                        resultCode=ldaperrors.LDAPNoSuchObject.resultCode),
+                    id=2)))
+
+    def test_compare_inGroup(self):
+        dn = 'cn=unix,ou=Groups,dc=example,dc=com'
+        attribute_desc = pureldap.LDAPString('uniquemember')
+        attribute_value = pureldap.LDAPString('uid=kthompson,ou=People,dc=example,dc=com')
+        ava = pureldap.LDAPAttributeValueAssertion(attribute_desc, attribute_value)
+
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPCompareRequest(entry=dn, ava=ava),
+                    id=2)))
+
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPCompareResponse(
+                        resultCode=ldaperrors.LDAPCompareTrue.resultCode),
+                    id=2)))
+
+    def test_compare_notInGroup(self):
+        dn = 'cn=unix,ou=Groups,dc=example,dc=com'
+        attribute_desc = pureldap.LDAPString('uniquemember')
+        attribute_value = pureldap.LDAPString('uid=bgates,ou=People,dc=example,dc=com')
+        ava = pureldap.LDAPAttributeValueAssertion(attribute_desc, attribute_value)
+
+        self.server.dataReceived(
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPCompareRequest(entry=dn, ava=ava),
+                    id=2)))
+
+        self.assertEquals(
+            self.server.transport.value(),
+            str(
+                pureldap.LDAPMessage(
+                    pureldap.LDAPCompareResponse(
+                        resultCode=ldaperrors.LDAPCompareFalse.resultCode),
+                    id=2)))
 
     def test_search_outOfTree(self):
         self.server.dataReceived(

--- a/ldaptor/test/test_server.py
+++ b/ldaptor/test/test_server.py
@@ -84,7 +84,7 @@ class LDAPServerTest(unittest.TestCase):
             })
 
         self.groups.addChild(
-            rdn = 'cn=unix',
+            rdn='cn=unix',
             attributes={
                 'uniquemember': ['uid=kthompson,ou=People,dc=example,dc=com'],
                 'objectClass': ['top', 'groupOfUniqueNames'],


### PR DESCRIPTION
This PR implements the CompareRequest and CompareResponse functionality for both pureldap library and the LDAP server implementation. It also adds testing around the newly implemented features.