### PR TITLE
Fix extended response handling

### DIFF
--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -1338,17 +1338,29 @@ class LDAPExtendedResponse(LDAPResult):
         l = berDecodeMultiple(content, LDAPBERDecoderContext_LDAPExtendedResponse(
             fallback=berdecoder))
 
-        assert 3<=len(l)<=4
+        assert 3<=len(l)<=6
 
         referral = None
-        #if (l[3:] and isinstance(l[3], LDAPReferral)):
-            #TODO support referrals
-            #self.referral=self.data[0]
+        responseName = None
+        response = None
+        for obj in l[3:]:
+            if isinstance(obj, LDAPResponseName):
+                responseName = obj.value
+            elif isinstance(obj, LDAPResponse):
+                response = obj.value
+            elif isinstance(obj, LDAPReferral):
+                #TODO support referrals
+                #self.referral=self.data[0]
+                pass
+            else:
+                assert False
 
         r = klass(resultCode=l[0].value,
                   matchedDN=l[1].value,
                   errorMessage=l[2].value,
                   referral=referral,
+                  responseName=responseName,
+                  response=response,
                   tag=tag)
         return r
     fromBER = classmethod(fromBER)

--- a/ldaptor/test/test_pureldap.py
+++ b/ldaptor/test/test_pureldap.py
@@ -561,6 +561,38 @@ class KnownValues(unittest.TestCase):
             + l('42.42.42'))
          ),
 
+        (pureldap.LDAPExtendedResponse,
+         [],
+         {'resultCode': 49,
+          'matchedDN': 'foo',
+          'errorMessage': 'bar',
+          'responseName': None,
+          'response': None,
+          },
+         None,
+         [0x40|0x20|24, 3+2+3+2+3,
+          0x0a, 1, 49,
+          0x04, len('foo')] + l('foo') + [
+          0x04, len('bar')] + l('bar'),
+         ),
+
+        (pureldap.LDAPExtendedResponse,
+         [],
+         {'resultCode': 49,
+          'matchedDN': 'foo',
+          'errorMessage': 'bar',
+          'responseName': '1.2.3.4.5.6.7.8.9',
+          'response': 'baz',
+          },
+         None,
+         [0x40|0x20|24, 3+2+3+2+3+2+len('1.2.3.4.5.6.7.8.9')+2+3,
+          0x0a, 1, 49,
+          0x04, len('foo')] + l('foo') + [
+          0x04, len('bar')] + l('bar') + [
+          0x8a, len('1.2.3.4.5.6.7.8.9')] + l('1.2.3.4.5.6.7.8.9') + [
+          0x8b, len('baz')] + l('baz'),
+         ),
+
         (pureldap.LDAPAbandonRequest,
          [],
          {'id': 3},


### PR DESCRIPTION
I tried to implement simplest LDAP proxy based on [example from documentation](http://ldaptor.readthedocs.io/en/latest/cookbook/ldap-proxy.html#code) and found that TLS client (`use_tls = True`) is not working with my server. Here is the output of example code:
```
2016-12-02 05:09:03+0300 [-] Log opened.
2016-12-02 05:09:03+0300 [-] ServerFactory starting on 10389
2016-12-02 05:09:03+0300 [-] Starting factory <twisted.internet.protocol.ServerFactory instance at 0x109102dd0>
2016-12-02 05:09:09+0300 [twisted.internet.protocol.ServerFactory] Starting factory <ldaptor.protocols.ldap.ldapconnector.OneShotFactory instance at 0x109125bd8>
2016-12-02 05:09:10+0300 [LDAPClient,client] Unhandled Error
       	Traceback (most recent call last):
       	  File "/Users/i_m/projects/current/ldapcached/.venv/lib/python2.7/site-packages/twisted/python/log.py", line 84, in callWithLogger
       	    return callWithContext({"system": lp}, func, *args, **kw)
       	  File "/Users/i_m/projects/current/ldapcached/.venv/lib/python2.7/site-packages/twisted/python/log.py", line 69, in callWithContext
       	    return context.call({ILogContext: newCtx}, func, *args, **kw)
       	  File "/Users/i_m/projects/current/ldapcached/.venv/lib/python2.7/site-packages/twisted/python/context.py", line 118, in callWithContext
       	    return self.currentContext().callWithContext(ctx, func, *args, **kw)
       	  File "/Users/i_m/projects/current/ldapcached/.venv/lib/python2.7/site-packages/twisted/python/context.py", line 81, in callWithContext
       	    return func(*args,**kw)
       	--- <exception caught here> ---
       	  File "/Users/i_m/projects/current/ldapcached/.venv/lib/python2.7/site-packages/twisted/internet/selectreactor.py", line 150, in _doReadOrWrite
       	    why = getattr(selectable, method)()
       	  File "/Users/i_m/projects/current/ldapcached/.venv/lib/python2.7/site-packages/twisted/internet/tcp.py", line 203, in doRead
       	    return self._dataReceived(data)
       	  File "/Users/i_m/projects/current/ldapcached/.venv/lib/python2.7/site-packages/twisted/internet/tcp.py", line 209, in _dataReceived
       	    rval = self.protocol.dataReceived(data)
       	  File "/Users/i_m/projects/current/ldapcached/.venv/lib/python2.7/site-packages/twisted/internet/endpoints.py", line 85, in dataReceived
       	    return self._wrappedProtocol.dataReceived(data)
       	  File "/Users/i_m/projects/current/ldapcached/.venv/lib/python2.7/site-packages/ldaptor/protocols/ldap/ldapclient.py", line 54, in dataReceived
       	    o, bytes = pureber.berDecodeObject(self.berdecoder, self.buffer)
       	  File "/Users/i_m/projects/current/ldapcached/.venv/lib/python2.7/site-packages/ldaptor/protocols/pureber.py", line 373, in berDecodeObject
       	    berdecoder=inh)
       	  File "/Users/i_m/projects/current/ldapcached/.venv/lib/python2.7/site-packages/ldaptor/protocols/pureldap.py", line 57, in fromBER
       	    l = berDecodeMultiple(content, berdecoder)
       	  File "/Users/i_m/projects/current/ldapcached/.venv/lib/python2.7/site-packages/ldaptor/protocols/pureber.py", line 392, in berDecodeMultiple
       	    n, bytes = berDecodeObject(berdecoder, content)
       	  File "/Users/i_m/projects/current/ldapcached/.venv/lib/python2.7/site-packages/ldaptor/protocols/pureber.py", line 373, in berDecodeObject
       	    berdecoder=inh)
       	  File "/Users/i_m/projects/current/ldapcached/.venv/lib/python2.7/site-packages/ldaptor/protocols/pureldap.py", line 1293, in fromBER
       	    assert 3<=len(l)<=4
       	exceptions.AssertionError:

2016-12-02 05:09:10+0300 [LDAPClient,client] [ERROR] Could not connect to proxied server.  Error was:
       	[Failure instance: Traceback (failure with no frames): <type 'exceptions.AssertionError'>:
       	]
2016-12-02 05:09:10+0300 [LDAPClient,client] Stopping factory <ldaptor.protocols.ldap.ldapconnector.OneShotFactory instance at 0x109125bd8>
```
This happens because current code expects maximum of 4 encoded values in extended response, but up to 6 may actually exists:
```
        LDAPResult ::= SEQUENCE {
             resultCode         ENUMERATED {
                  ...  },
             matchedDN          LDAPDN,
             diagnosticMessage  LDAPString,
             referral           [3] Referral OPTIONAL }

        ExtendedResponse ::= [APPLICATION 24] SEQUENCE {
             COMPONENTS OF LDAPResult,
             responseName     [10] LDAPOID OPTIONAL,
             responseValue    [11] OCTET STRING OPTIONAL }
```
This PR fixes my problem and also adds additional check for STARTTLS response.