### PR TITLE
Don't add callbacks for each child individually.

### DIFF
--- a/ldaptor/entryhelpers.py
+++ b/ldaptor/entryhelpers.py
@@ -129,15 +129,10 @@ class SubtreeFromChildrenMixin(object):
         else:
             callback(self)
             d = self.children()
-            def _processOneChild(_, children, callback):
-                if not children:
-                    return None
-
-                c = children.pop()
-                d = c.subtree(callback)
-                d.addCallback(_processOneChild, children, callback)
             def _gotChildren(children, callback):
-                _processOneChild(None, children, callback)
+                if children:
+                    while len(children) > 0:
+                        children.pop().subtree(callback)
             d.addCallback(_gotChildren, callback)
             return d
 


### PR DESCRIPTION
This fixes an issue when there are a large number of children and
the original callback has been called, quickly causing the maximum
recursive limit to be exceeded since each additional _processOneChild callback gets evaluated immediately by Twisted.