### PR TITLE
Added custom escaping functionality when generating LDAP filter strings

### DIFF
--- a/ldaptor/protocols/pureber.py
+++ b/ldaptor/protocols/pureber.py
@@ -113,7 +113,7 @@ def ber2int(e, signed=True):
         v=(v<<8) | ord(e[i])
     return v
 
-class BERBase:
+class BERBase(object):
     tag = None
 
     def identification(self):


### PR DESCRIPTION
Fixes #73, see issue for further details.