### PR TITLE
Added ability to logically compare LDAPFilterSet objects

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+Release 17.1 (UNRELEASED)
+-------------------------
+
+Features
+^^^^^^^^
+
+- Ability to logically compare ldaptor.protocols.pureldap.LDAPFilter_and and ldaptor.protocols.pureldap.LDAPFilter_or objects with ==.
+- Ability to customize ldaptor.protocols.pureldap.LDAPFilter_* object's encoding of values when using asText.
+
 Release 16.0 (2016-06-07)
 -------------------------
 

--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -392,6 +392,15 @@ class LDAPFilterSet(BERSet):
         return r
     fromBER = classmethod(fromBER)
 
+    def __eq__(self, rhs):
+        # Fast paths
+        if self is rhs:
+            return True
+        elif len(self) != len(rhs):
+            return False
+
+        return sorted(self, key=str) == sorted(rhs, key=str)
+
 class LDAPFilter_and(LDAPFilterSet):
     tag = CLASS_CONTEXT|0x00
 

--- a/ldaptor/test/test_pureldap.py
+++ b/ldaptor/test/test_pureldap.py
@@ -868,3 +868,173 @@ class TestEscaping(unittest.TestCase):
         for filt, expected in filters:
             result = filt.asText()
             self.assertEqual(expected, result)
+
+class TestFilterSetEquality(unittest.TestCase):
+    def test_basic_and_equal(self):
+        filter1 = pureldap.LDAPFilter_and([
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('foo'),
+                assertionValue=pureldap.LDAPAttributeValue('1')
+            ),
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('bar'),
+                assertionValue=pureldap.LDAPAttributeValue('2')
+            ),
+        ])
+        filter2 = pureldap.LDAPFilter_and([
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('bar'),
+                assertionValue=pureldap.LDAPAttributeValue('2')
+            ),
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('foo'),
+                assertionValue=pureldap.LDAPAttributeValue('1')
+            ),
+        ])
+
+        self.assertEqual(filter1, filter2)
+
+    def test_basic_and_not_equal(self):
+        filter1 = pureldap.LDAPFilter_and([
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('foo'),
+                assertionValue=pureldap.LDAPAttributeValue('1')
+            ),
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('bar'),
+                assertionValue=pureldap.LDAPAttributeValue('2')
+            ),
+        ])
+        filter2 = pureldap.LDAPFilter_and([
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('bar'),
+                assertionValue=pureldap.LDAPAttributeValue('1')
+            ),
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('foo'),
+                assertionValue=pureldap.LDAPAttributeValue('1')
+            ),
+        ])
+
+        self.assertNotEqual(filter1, filter2)
+
+    def test_basic_or_equal(self):
+        filter1 = pureldap.LDAPFilter_or([
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('foo'),
+                assertionValue=pureldap.LDAPAttributeValue('1')
+            ),
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('bar'),
+                assertionValue=pureldap.LDAPAttributeValue('2')
+            ),
+        ])
+        filter2 = pureldap.LDAPFilter_or([
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('bar'),
+                assertionValue=pureldap.LDAPAttributeValue('2')
+            ),
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('foo'),
+                assertionValue=pureldap.LDAPAttributeValue('1')
+            ),
+        ])
+
+        self.assertEqual(filter1, filter2)
+
+    def test_basic_or_not_equal(self):
+        filter1 = pureldap.LDAPFilter_or([
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('foo'),
+                assertionValue=pureldap.LDAPAttributeValue('1')
+            ),
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('bar'),
+                assertionValue=pureldap.LDAPAttributeValue('2')
+            ),
+        ])
+        filter2 = pureldap.LDAPFilter_or([
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('bar'),
+                assertionValue=pureldap.LDAPAttributeValue('1')
+            ),
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('foo'),
+                assertionValue=pureldap.LDAPAttributeValue('1')
+            ),
+        ])
+
+        self.assertNotEqual(filter1, filter2)
+
+    def test_nested_equal(self):
+        filter1 = pureldap.LDAPFilter_or([
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('foo'),
+                assertionValue=pureldap.LDAPAttributeValue('1')
+            ),
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('bar'),
+                assertionValue=pureldap.LDAPAttributeValue('2')
+            ),
+            pureldap.LDAPFilter_and([
+                pureldap.LDAPFilter_equalityMatch(
+                    attributeDesc=pureldap.LDAPAttributeDescription('baz'),
+                    assertionValue=pureldap.LDAPAttributeValue('1')
+                ),
+                pureldap.LDAPFilter_equalityMatch(
+                    attributeDesc=pureldap.LDAPAttributeDescription('bob'),
+                    assertionValue=pureldap.LDAPAttributeValue('2')
+                ),
+            ]),
+        ])
+        filter2 = pureldap.LDAPFilter_or([
+            pureldap.LDAPFilter_and([
+                pureldap.LDAPFilter_equalityMatch(
+                    attributeDesc=pureldap.LDAPAttributeDescription('bob'),
+                    assertionValue=pureldap.LDAPAttributeValue('2')
+                ),
+                pureldap.LDAPFilter_equalityMatch(
+                    attributeDesc=pureldap.LDAPAttributeDescription('baz'),
+                    assertionValue=pureldap.LDAPAttributeValue('1')
+                ),
+            ]),
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('bar'),
+                assertionValue=pureldap.LDAPAttributeValue('2')
+            ),
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('foo'),
+                assertionValue=pureldap.LDAPAttributeValue('1')
+            ),
+        ])
+
+        self.assertEqual(filter1, filter2)
+
+    def test_escape_and_equal(self):
+        def custom_escaper(s):
+            return ''.join(bin(ord(c)) for c in s)
+
+        filter1 = pureldap.LDAPFilter_and([
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('foo'),
+                assertionValue=pureldap.LDAPAttributeValue('1'),
+                escaper=custom_escaper
+            ),
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('foo'),
+                assertionValue=pureldap.LDAPAttributeValue('2')
+            ),
+        ])
+        filter2 = pureldap.LDAPFilter_and([
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('foo'),
+                assertionValue=pureldap.LDAPAttributeValue('1')
+            ),
+            pureldap.LDAPFilter_equalityMatch(
+                attributeDesc=pureldap.LDAPAttributeDescription('foo'),
+                assertionValue=pureldap.LDAPAttributeValue('2'),
+                escaper=custom_escaper
+            ),
+        ])
+
+        self.assertEqual(filter1, filter2)


### PR DESCRIPTION
Fixes #76 

Here's my purposed fix for the issue I was having in #76. I like it because it's a fairly simple solution to the problem at hand.

It's worth noting, I did consider an alternate solution. Namely, using the `collections.Counter` object. I would've actually preferred this solution because it's faster, but, unfortunately it doesn't work for nested OR and AND filters. E.g. `test_nested_equal`. Something like:

```diff
diff --git a/ldaptor/protocols/pureber.py b/ldaptor/protocols/pureber.py
index 7b12678..9052e13 100644
--- a/ldaptor/protocols/pureber.py
+++ b/ldaptor/protocols/pureber.py
@@ -305,6 +305,9 @@ class BERSequence(BERStructured, UserList.UserList):
             return self.__class__.__name__+"(value=%s, tag=%d)" \
                    %(repr(self.data), self.tag)
 
+    def __hash__(self):
+        return hash(self.asText())
+
 
 class BERSequenceOf(BERSequence):
     pass
diff --git a/ldaptor/protocols/pureldap.py b/ldaptor/protocols/pureldap.py
index f97973c..ef90fcf 100644
--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -15,7 +15,7 @@
 
 """LDAP protocol message conversion; no application logic here."""
 
-import operator
+import collections
 import string
 
 from pureber import (
@@ -394,8 +394,10 @@ class LDAPFilterSet(BERSet):
     fromBER = classmethod(fromBER)
 
     def __eq__(self, rhs):
-        return (sorted(self, key=operator.methodcaller('asText')) ==
-            sorted(rhs, key=operator.methodcaller('asText')))
+        return (
+            collections.Counter(self) ==
+            collections.Counter(rhs)
+        )
 
 class LDAPFilter_and(LDAPFilterSet):
     tag = CLASS_CONTEXT|0x00
```

`Counter` uses hashing on the backend, so we'd have to implement `__hash__`, and is preferable because it runs in `O(n)`, but fails at recursive comparisons. `sorted` runs in `O(n log n)`, and works for recursive comparisons because to sort we will recursively be calling `__eq__`.

Note that `Counter` is essentially what [assertItemsEqual](https://docs.python.org/2.7/library/unittest.html#unittest.TestCase.assertItemsEqual) does, but alas won't work recursively :(

Let me know what you think! Especially if you can see some way to make `Counter` work!