### PR TITLE
made string comparision case insensitive by using lowercase function

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -15,6 +15,11 @@ Changes
 
 - Using modern classmethod decorator instead of old-style method call.
 
+Bugfixes
+^^^^^^^^
+
+- DN matching now case insensitive.
+
 Release 16.0 (2016-06-07)
 -------------------------
 

--- a/ldaptor/__init__.py
+++ b/ldaptor/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "16.0.0"
+__version__ = "16.0.1"
 
 __title__ = "ldaptor"
 __description__ = "A Pure-Python Twisted library for LDAP"

--- a/ldaptor/__init__.py
+++ b/ldaptor/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "16.0.1"
+__version__ = "16.0.0"
 
 __title__ = "ldaptor"
 __description__ = "A Pure-Python Twisted library for LDAP"

--- a/ldaptor/protocols/ldap/distinguishedname.py
+++ b/ldaptor/protocols/ldap/distinguishedname.py
@@ -110,8 +110,8 @@ class LDAPAttributeTypeAndValue:
     def __eq__(self, other):
         if not isinstance(other, LDAPAttributeTypeAndValue):
             return NotImplemented
-        return (self.attributeType == other.attributeType
-                and self.value == other.value)
+        return (self.attributeType.lower() == other.attributeType.lower()
+                and self.value.lower() == other.value.lower())
 
     def __ne__(self, other):
         return not (self == other)


### PR DESCRIPTION
Generally the userDN is case insensitive in the ldap servers I have seen so far.
For ldaptor this was not the case, so here's a pr that resolves that.

Let me know what you think!

Kind Regards,
Chris
