### PR TITLE
Style cleanup in preparation for python3 port.

### DIFF
--- a/ldaptor/attributeset.py
+++ b/ldaptor/attributeset.py
@@ -1,14 +1,15 @@
 from copy import deepcopy
 
+
 class LDAPAttributeSet(set):
     def __init__(self, key, *a, **kw):
         self.key = key
         super(LDAPAttributeSet, self).__init__(*a, **kw)
 
     def __repr__(self):
-        values=list(self)
+        values = list(self)
         values.sort()
-        attributes=', '.join([repr(x) for x in values])
+        attributes = ', '.join([repr(x) for x in values])
         return '%s(%r, [%s])' % (
             self.__class__.__name__,
             self.key,
@@ -24,14 +25,14 @@ class LDAPAttributeSet(set):
                 return False
             return super(LDAPAttributeSet, self).__eq__(other)
         else:
-            me=list(self)
+            me = list(self)
             me.sort()
-            him=list(other)
+            him = list(other)
             him.sort()
             return me == him
 
     def __ne__(self, other):
-        return not self==other
+        return not self == other
 
     def difference(self, other):
         return set(self) - set(other)
@@ -49,6 +50,7 @@ class LDAPAttributeSet(set):
         result = self.__class__(self.key)
         result.update(self)
         return result
+
     __copy__ = copy
 
     def __deepcopy__(self, memo):

--- a/ldaptor/config.py
+++ b/ldaptor/config.py
@@ -5,6 +5,7 @@ from ldaptor import interfaces
 from ldaptor.insensitive import InsensitiveString
 from ldaptor.protocols.ldap import distinguishedname
 
+
 class MissingBaseDNError(Exception):
     """Configuration must specify a base DN"""
 
@@ -30,7 +31,7 @@ class LDAPConfig(object):
         if serviceLocationOverrides is not None:
             for k,v in serviceLocationOverrides.items():
                 dn = distinguishedname.DistinguishedName(k)
-                self.serviceLocationOverrides[dn]=v
+                self.serviceLocationOverrides[dn] = v
         if identityBaseDN is not None:
             identityBaseDN = distinguishedname.DistinguishedName(identityBaseDN)
             self.identityBaseDN = identityBaseDN
@@ -73,7 +74,7 @@ class LDAPConfig(object):
                         port = None
 
                 dn = distinguishedname.DistinguishedName(stringValue=base)
-                serviceLocationOverride[dn]=(host, port)
+                serviceLocationOverride[dn] = (host, port)
         return serviceLocationOverride
 
     def copy(self, **kw):
@@ -117,9 +118,8 @@ class LDAPConfig(object):
 
 
 DEFAULTS = {
-    'samba': { 'use-lmhash': 'no',
-               },
-    }
+    'samba': {'use-lmhash': 'no'},
+}
 
 CONFIG_FILES = [
     '/etc/ldaptor/global.cfg',
@@ -127,6 +127,7 @@ CONFIG_FILES = [
     ]
 
 __config = None
+
 
 def loadConfig(configFiles=None,
                reload=False):
@@ -148,6 +149,7 @@ def loadConfig(configFiles=None,
         x.read(configFiles)
         __config = x
     return __config
+
 
 def useLMhash():
     """

--- a/ldaptor/entry.py
+++ b/ldaptor/entry.py
@@ -1,5 +1,6 @@
 import base64
 import random
+
 from ldaptor import interfaces, attributeset, delta
 from ldaptor.protocols.ldap import distinguishedname, ldif, ldaperrors
 from twisted.internet import defer
@@ -21,7 +22,7 @@ def sshaDigest(passphrase, salt=None):
     s = sha1()
     s.update(passphrase)
     s.update(salt)
-    encoded = base64.encodestring(s.digest()+salt).rstrip()
+    encoded = base64.encodestring(s.digest() + salt).rstrip()
     crypt = '{SSHA}' + encoded
     return crypt
 

--- a/ldaptor/entryhelpers.py
+++ b/ldaptor/entryhelpers.py
@@ -12,6 +12,7 @@ def safelower(s):
     except AttributeError:
         return s
 
+
 class DiffTreeMixin(object):
     def _diffTree_gotMyChildren(self, myChildren, other, result):
         d = other.children()
@@ -33,7 +34,7 @@ class DiffTreeMixin(object):
 
         # differences in common children
         commonRDN = list(my & his)
-        commonRDN.sort() # for reproducability only
+        commonRDN.sort()  # for reproducability only
         d = self._diffTree_commonChildren([
             (rdnToChild(rdn, myChildren), rdnToChild(rdn, otherChildren))
             for rdn in commonRDN
@@ -41,7 +42,7 @@ class DiffTreeMixin(object):
 
         # added children
         addedRDN = list(his - my)
-        addedRDN.sort() # for reproducability only
+        addedRDN.sort()  # for reproducability only
         d2 = self._diffTree_addedChildren([
             rdnToChild(rdn, otherChildren)
             for rdn in addedRDN
@@ -50,7 +51,7 @@ class DiffTreeMixin(object):
 
         # deleted children
         deletedRDN = list(my - his)
-        deletedRDN.sort() # for reproducability only
+        deletedRDN.sort()  # for reproducability only
         d3 = self._diffTree_deletedChildren([
             rdnToChild(rdn, myChildren)
             for rdn in deletedRDN
@@ -74,11 +75,13 @@ class DiffTreeMixin(object):
         first, rest = children[0], children[1:]
 
         d = first.subtree()
+
         def _gotSubtree(l, result):
             for c in l:
                 o = delta.AddOp(c)
                 result.append(o)
             return result
+
         d.addCallback(_gotSubtree, result)
 
         d.addCallback(lambda _: self._diffTree_addedChildren(rest, result))
@@ -90,12 +93,14 @@ class DiffTreeMixin(object):
         first, rest = children[0], children[1:]
 
         d = first.subtree()
+
         def _gotSubtree(l, result):
-            l.reverse() # remove children before their parent
+            l.reverse()  # remove children before their parent
             for c in l:
                 o = delta.DeleteOp(c)
                 result.append(o)
             return result
+
         d.addCallback(_gotSubtree, result)
 
         d.addCallback(lambda _: self._diffTree_deletedChildren(rest, result))
@@ -119,6 +124,7 @@ class DiffTreeMixin(object):
 
         return d
 
+
 class SubtreeFromChildrenMixin(object):
     def subtree(self, callback=None):
         if callback is None:
@@ -135,6 +141,7 @@ class SubtreeFromChildrenMixin(object):
                         children.pop().subtree(callback)
             d.addCallback(_gotChildren, callback)
             return d
+
 
 class MatchMixin(object):
     def match(self, filter):
@@ -225,9 +232,10 @@ class MatchMixin(object):
                                 return True
                 return False
             else:
-                raise ldapsyntax.MatchNotImplemented, filter
+                raise ldapsyntax.MatchNotImplemented(filter)
         else:
-            raise ldapsyntax.MatchNotImplemented, filter
+            raise ldapsyntax.MatchNotImplemented(filter)
+
 
 class SearchByTreeWalkingMixin(object):
     def search(self,
@@ -241,14 +249,14 @@ class SearchByTreeWalkingMixin(object):
                typesOnly=0,
                callback=None):
         if filterObject is None and filterText is None:
-            filterObject=pureldap.LDAPFilterMatchAll
+            filterObject = pureldap.LDAPFilterMatchAll
         elif filterObject is None and filterText is not None:
-            filterObject=ldapfilter.parseFilter(filterText)
+            filterObject = ldapfilter.parseFilter(filterText)
         elif filterObject is not None and filterText is None:
             pass
         elif filterObject is not None and filterText is not None:
-            f=ldapfilter.parseFilter(filterText)
-            filterObject=pureldap.LDAPFilter_and((f, filterObject))
+            f = ldapfilter.parseFilter(filterText)
+            filterObject = pureldap.LDAPFilter_and((f, filterObject))
 
         if scope is None:
             scope = pureldap.LDAP_SCOPE_wholeSubtree
@@ -264,10 +272,10 @@ class SearchByTreeWalkingMixin(object):
             def iterateSelf(callback):
                 callback(self)
                 return defer.succeed(None)
+
             iterator = iterateSelf
         else:
-            raise ldaperrors.LDAPProtocolError, \
-                  'unknown search scope: %r' % scope
+            raise ldaperrors.LDAPProtocolError('unknown search scope: %r' % scope)
 
         results = []
         if callback is None:

--- a/ldaptor/inmemory.py
+++ b/ldaptor/inmemory.py
@@ -122,7 +122,6 @@ class ReadOnlyInMemoryLDAPEntry(entry.EditableLDAPEntry,
 
 
 class InMemoryLDIFProtocol(ldifprotocol.LDIF):
-
     """
     Receive LDIF data and gather results into an ReadOnlyInMemoryLDAPEntry.
 
@@ -150,11 +149,13 @@ class InMemoryLDIFProtocol(ldifprotocol.LDIF):
             if parent is not None:
                 parent.addChild(rdn=entry.dn.split()[0],
                                 attributes=entry)
+
         d.addCallback(_add, entry)
         d.addErrback(self.addFailed, entry)
 
         def _passDB(_, db):
             return db
+
         d.addCallback(_passDB, db)
         return d
 

--- a/ldaptor/ldapfilter.py
+++ b/ldaptor/ldapfilter.py
@@ -31,19 +31,22 @@ RFC2254:
         value      = AttributeValue from Section 4.1.6 of [1]
 """
 
+
 class InvalidLDAPFilter(Exception):
     def __init__(self, msg, loc, text):
         Exception.__init__(self)
-        self.msg=msg
-        self.loc=loc
-        self.text=text
+        self.msg = msg
+        self.loc = loc
+        self.text = text
 
     def __str__(self):
         return "Invalid LDAP filter: %s at point %d in %r" \
                % (self.msg, self.loc, self.text)
 
+
 def parseExtensible(attr, s):
     raise NotImplementedError
+
 
 from pyparsing import Word, Literal, Optional, ZeroOrMore, Suppress, \
                        Group, Forward, OneOrMore, ParseException, \
@@ -59,51 +62,63 @@ attr.leaveWhitespace()
 attr.setName('attr')
 hexdigits = Word(string.hexdigits, exact=2)
 hexdigits.setName('hexdigits')
-escaped = Suppress(Literal('\\'))+hexdigits
+escaped = Suppress(Literal('\\')) + hexdigits
 escaped.setName('escaped')
-def _p_escaped(s,l,t):
-    text=t[0]
+
+
+def _p_escaped(s, l, t):
+    text = t[0]
     return chr(int(text, 16))
+
+
 escaped.setParseAction(_p_escaped)
 value = Combine(OneOrMore(CharsNotIn('*()\\\0') | escaped))
 value.setName('value')
 equal = Literal("=")
-equal.setParseAction(lambda s,l,t: pureldap.LDAPFilter_equalityMatch)
+equal.setParseAction(lambda s, l, t: pureldap.LDAPFilter_equalityMatch)
 approx = Literal("~=")
-approx.setParseAction(lambda s,l,t: pureldap.LDAPFilter_approxMatch)
+approx.setParseAction(lambda s, l, t: pureldap.LDAPFilter_approxMatch)
 greater = Literal(">=")
-greater.setParseAction(lambda s,l,t: pureldap.LDAPFilter_greaterOrEqual)
+greater.setParseAction(lambda s, l, t: pureldap.LDAPFilter_greaterOrEqual)
 less = Literal("<=")
-less.setParseAction(lambda s,l,t: pureldap.LDAPFilter_lessOrEqual)
+less.setParseAction(lambda s, l, t: pureldap.LDAPFilter_lessOrEqual)
 filtertype = equal | approx | greater | less
 filtertype.setName('filtertype')
 simple = attr + filtertype + value
 simple.leaveWhitespace()
 simple.setName('simple')
-def _p_simple(s,l,t):
+
+
+def _p_simple(s, l, t):
     attr, filtertype, value = t
     return filtertype(attributeDesc=pureldap.LDAPAttributeDescription(attr),
                       assertionValue=pureldap.LDAPAssertionValue(value))
+
+
 simple.setParseAction(_p_simple)
 present = attr + "=*"
-present.setParseAction(lambda s,l,t: pureldap.LDAPFilter_present(t[0]))
+present.setParseAction(lambda s, l, t: pureldap.LDAPFilter_present(t[0]))
 initial = value.copy()
-initial.setParseAction(lambda s,l,t: pureldap.LDAPFilter_substrings_initial(t[0]))
+initial.setParseAction(lambda s, l, t: pureldap.LDAPFilter_substrings_initial(t[0]))
 initial.setName('initial')
 any_value = value + Suppress(Literal("*"))
-any_value.setParseAction(lambda s,l,t: pureldap.LDAPFilter_substrings_any(t[0]))
+any_value.setParseAction(lambda s, l, t: pureldap.LDAPFilter_substrings_any(t[0]))
 any = Suppress(Literal("*")) + ZeroOrMore(any_value)
 any.setName('any')
 final = value.copy()
 final.setName('final')
-final.setParseAction(lambda s,l,t: pureldap.LDAPFilter_substrings_final(t[0]))
+final.setParseAction(lambda s, l, t: pureldap.LDAPFilter_substrings_final(t[0]))
 substring = attr + Suppress(Literal("=")) + Group(Optional(initial) + any + Optional(final))
 substring.setName('substring')
-def _p_substring(s,l,t):
+
+
+def _p_substring(s, l, t):
     attrtype, substrings = t
     return pureldap.LDAPFilter_substrings(
         type=attrtype,
         substrings=substrings)
+
+
 substring.setParseAction(_p_substring)
 
 keystring = Word(string.ascii_letters,
@@ -117,53 +132,72 @@ matchingrule = oid.copy()
 matchingrule.setName('matchingrule')
 
 extensible_dn = Optional(":dn")
-def _p_extensible_dn(s,l,t):
+
+
+def _p_extensible_dn(s, l, t):
     return bool(t)
+
+
 extensible_dn.setParseAction(_p_extensible_dn)
 
 matchingrule_or_none = Optional(Suppress(":") + matchingrule)
-def _p_matchingrule_or_none(s,l,t):
+
+
+def _p_matchingrule_or_none(s, l, t):
     if not t:
         return [None]
     else:
         return t[0]
+
+
 matchingrule_or_none.setParseAction(_p_matchingrule_or_none)
 
 extensible_attr = attr + extensible_dn + matchingrule_or_none + Suppress(":=") + value
 extensible_attr.setName('extensible_attr')
-def _p_extensible_attr(s,l,t):
-    return list(t)
-extensible_attr.setParseAction(_p_extensible_attr)
 
+
+def _p_extensible_attr(s, l, t):
+    return list(t)
+
+
+extensible_attr.setParseAction(_p_extensible_attr)
 
 extensible_noattr = extensible_dn + Suppress(":") + matchingrule + Suppress(":=") + value
 extensible_noattr.setName('extensible_noattr')
-def _p_extensible_noattr(s,l,t):
-    return [None]+list(t)
+
+
+def _p_extensible_noattr(s, l, t):
+    return [None] + list(t)
+
+
 extensible_noattr.setParseAction(_p_extensible_noattr)
 
 extensible = extensible_attr | extensible_noattr
 extensible.setName('extensible')
-def _p_extensible(s,l,t):
+
+
+def _p_extensible(s, l, t):
     attr, dn, matchingRule, value = t
     return pureldap.LDAPFilter_extensibleMatch(
         matchingRule=matchingRule,
         type=attr,
         matchValue=value,
         dnAttributes=dn)
+
+
 extensible.setParseAction(_p_extensible)
 item = simple ^ present ^ substring ^ extensible
 item.setName('item')
 item.leaveWhitespace()
 not_ = Suppress(Literal('!')) + filter_
-not_.setParseAction(lambda s,l,t: pureldap.LDAPFilter_not(t[0]))
+not_.setParseAction(lambda s, l, t: pureldap.LDAPFilter_not(t[0]))
 not_.setName('not')
 filterlist = OneOrMore(filter_)
 or_ = Suppress(Literal('|')) + filterlist
-or_.setParseAction(lambda s,l,t: pureldap.LDAPFilter_or(t))
+or_.setParseAction(lambda s, l, t: pureldap.LDAPFilter_or(t))
 or_.setName('or')
 and_ = Suppress(Literal('&')) + filterlist
-and_.setParseAction(lambda s,l,t: pureldap.LDAPFilter_and(t))
+and_.setParseAction(lambda s, l, t: pureldap.LDAPFilter_and(t))
 and_.setName('and')
 filtercomp = and_ | or_ | not_ | item
 filtercomp.setName('filtercomp')
@@ -180,39 +214,52 @@ toplevel = (StringStart().leaveWhitespace()
 toplevel.leaveWhitespace()
 toplevel.setName('toplevel')
 
+
 def parseFilter(s):
     try:
-        x=toplevel.parseString(s)
-    except ParseException, e:
-        raise InvalidLDAPFilter, (e.msg,
+        x = toplevel.parseString(s)
+    except ParseException as e:
+        raise InvalidLDAPFilter(e.msg,
                                   e.loc,
                                   e.line)
-    assert len(x)==1
+    assert len(x) == 1
     return x[0]
 
 
 maybeSubString_value = Combine(OneOrMore(CharsNotIn('*\\\0') | escaped))
 
 maybeSubString_simple = maybeSubString_value.copy()
-def _p_maybeSubString_simple(s,l,t):
+
+
+def _p_maybeSubString_simple(s, l, t):
     return (lambda attr:
             pureldap.LDAPFilter_equalityMatch(
-        attributeDesc=pureldap.LDAPAttributeDescription(attr),
-        assertionValue=pureldap.LDAPAssertionValue(t[0])))
+                attributeDesc=pureldap.LDAPAttributeDescription(attr),
+                assertionValue=pureldap.LDAPAssertionValue(t[0])))
+
+
 maybeSubString_simple.setParseAction(_p_maybeSubString_simple)
 
 maybeSubString_present = Literal("*")
-def _p_maybeSubString_present(s,l,t):
+
+
+def _p_maybeSubString_present(s, l, t):
     return (lambda attr:
             pureldap.LDAPFilter_present(attr))
+
+
 maybeSubString_present.setParseAction(_p_maybeSubString_present)
 
 maybeSubString_substring = Optional(initial) + any + Optional(final)
-def _p_maybeSubString_substring(s,l,t):
+
+
+def _p_maybeSubString_substring(s, l, t):
     return (lambda attr:
             pureldap.LDAPFilter_substrings(
-        type=attr,
-        substrings=t))
+                type=attr,
+                substrings=t))
+
+
 maybeSubString_substring.setParseAction(_p_maybeSubString_substring)
 
 maybeSubString = (maybeSubString_simple
@@ -220,19 +267,22 @@ maybeSubString = (maybeSubString_simple
                   ^ maybeSubString_substring
                   )
 
+
 def parseMaybeSubstring(attrType, s):
     try:
-        x=maybeSubString.parseString(s)
-    except ParseException, e:
-        raise InvalidLDAPFilter, (e.msg,
+        x = maybeSubString.parseString(s)
+    except ParseException as e:
+        raise InvalidLDAPFilter(e.msg,
                                   e.loc,
                                   e.line)
-    assert len(x)==1
+    assert len(x) == 1
     fn = x[0]
     return fn(attrType)
 
-if __name__=='__main__':
+
+if __name__ == '__main__':
     import sys
+
     for filt in sys.argv[1:]:
-        print repr(parseFilter(filt))
-        print
+        print(repr(parseFilter(filt)))
+        print()

--- a/ldaptor/md4.py
+++ b/ldaptor/md4.py
@@ -9,9 +9,9 @@ implementated based on rfc at http://www.faqs.org/rfcs/rfc1320.html
 # Passlib is (c) `Assurance Technologies <http://www.assurancetechnologies.com>`
 # and is released under the `BSD license <http://www.opensource.org/licenses/bsd-license.php>`
 
-#=============================================================================
+# =============================================================================
 # imports
-#=============================================================================
+# =============================================================================
 # core
 from binascii import hexlify
 import struct
@@ -19,24 +19,29 @@ from warnings import warn
 # site
 from compat import b, bytes, bascii_to_str, irange  # , PY3  # twisted isn't Python3, yet
 # local
-__all__ = [ "md4" ]
-#=============================================================================
-# utils
-#=============================================================================
-def F(x,y,z):
-    return (x&y) | ((~x) & z)
+__all__ = ["md4"]
 
-def G(x,y,z):
-    return (x&y) | (x&z) | (y&z)
+
+# =============================================================================
+# utils
+# =============================================================================
+def F(x, y, z):
+    return (x & y) | ((~x) & z)
+
+
+def G(x, y, z):
+    return (x & y) | (x & z) | (y & z)
+
 
 ##def H(x,y,z):
 ##    return x ^ y ^ z
 
-MASK_32 = 2**32-1
+MASK_32 = 2 ** 32 - 1
 
-#=============================================================================
+
+# =============================================================================
 # main class
-#=============================================================================
+# =============================================================================
 class md4(object):
     """pep-247 compatible implementation of MD4 hash algorithm
 
@@ -67,9 +72,9 @@ class md4(object):
     name = "md4"
     digest_size = digestsize = 16
 
-    _count = 0 # number of 64-byte blocks processed so far (not including _buf)
-    _state = None # list of [a,b,c,d] 32 bit ints used as internal register
-    _buf = None # data processed in 64 byte blocks, this holds leftover from last update
+    _count = 0  # number of 64-byte blocks processed so far (not including _buf)
+    _state = None  # list of [a,b,c,d] 32 bit ints used as internal register
+    _buf = None  # data processed in 64 byte blocks, this holds leftover from last update
 
     def __init__(self, content=None):
         self._count = 0
@@ -80,71 +85,71 @@ class md4(object):
 
     # round 1 table - [abcd k s]
     _round1 = [
-        [0,1,2,3, 0,3],
-        [3,0,1,2, 1,7],
-        [2,3,0,1, 2,11],
-        [1,2,3,0, 3,19],
+        [0, 1, 2, 3, 0, 3],
+        [3, 0, 1, 2, 1, 7],
+        [2, 3, 0, 1, 2, 11],
+        [1, 2, 3, 0, 3, 19],
 
-        [0,1,2,3, 4,3],
-        [3,0,1,2, 5,7],
-        [2,3,0,1, 6,11],
-        [1,2,3,0, 7,19],
+        [0, 1, 2, 3, 4, 3],
+        [3, 0, 1, 2, 5, 7],
+        [2, 3, 0, 1, 6, 11],
+        [1, 2, 3, 0, 7, 19],
 
-        [0,1,2,3, 8,3],
-        [3,0,1,2, 9,7],
-        [2,3,0,1, 10,11],
-        [1,2,3,0, 11,19],
+        [0, 1, 2, 3, 8, 3],
+        [3, 0, 1, 2, 9, 7],
+        [2, 3, 0, 1, 10, 11],
+        [1, 2, 3, 0, 11, 19],
 
-        [0,1,2,3, 12,3],
-        [3,0,1,2, 13,7],
-        [2,3,0,1, 14,11],
-        [1,2,3,0, 15,19],
+        [0, 1, 2, 3, 12, 3],
+        [3, 0, 1, 2, 13, 7],
+        [2, 3, 0, 1, 14, 11],
+        [1, 2, 3, 0, 15, 19],
     ]
 
     # round 2 table - [abcd k s]
     _round2 = [
-        [0,1,2,3, 0,3],
-        [3,0,1,2, 4,5],
-        [2,3,0,1, 8,9],
-        [1,2,3,0, 12,13],
+        [0, 1, 2, 3, 0, 3],
+        [3, 0, 1, 2, 4, 5],
+        [2, 3, 0, 1, 8, 9],
+        [1, 2, 3, 0, 12, 13],
 
-        [0,1,2,3, 1,3],
-        [3,0,1,2, 5,5],
-        [2,3,0,1, 9,9],
-        [1,2,3,0, 13,13],
+        [0, 1, 2, 3, 1, 3],
+        [3, 0, 1, 2, 5, 5],
+        [2, 3, 0, 1, 9, 9],
+        [1, 2, 3, 0, 13, 13],
 
-        [0,1,2,3, 2,3],
-        [3,0,1,2, 6,5],
-        [2,3,0,1, 10,9],
-        [1,2,3,0, 14,13],
+        [0, 1, 2, 3, 2, 3],
+        [3, 0, 1, 2, 6, 5],
+        [2, 3, 0, 1, 10, 9],
+        [1, 2, 3, 0, 14, 13],
 
-        [0,1,2,3, 3,3],
-        [3,0,1,2, 7,5],
-        [2,3,0,1, 11,9],
-        [1,2,3,0, 15,13],
+        [0, 1, 2, 3, 3, 3],
+        [3, 0, 1, 2, 7, 5],
+        [2, 3, 0, 1, 11, 9],
+        [1, 2, 3, 0, 15, 13],
     ]
 
     # round 3 table - [abcd k s]
     _round3 = [
-        [0,1,2,3, 0,3],
-        [3,0,1,2, 8,9],
-        [2,3,0,1, 4,11],
-        [1,2,3,0, 12,15],
+        [0, 1, 2, 3, 0, 3],
+        [3, 0, 1, 2, 8, 9],
+        [2, 3, 0, 1, 4, 11],
+        [1, 2, 3, 0, 12, 15],
 
-        [0,1,2,3, 2,3],
-        [3,0,1,2, 10,9],
-        [2,3,0,1, 6,11],
-        [1,2,3,0, 14,15],
+        [0, 1, 2, 3, 2, 3],
+        [3, 0, 1, 2, 10, 9],
+        [2, 3, 0, 1, 6, 11],
+        [1, 2, 3, 0, 14, 15],
 
-        [0,1,2,3, 1,3],
-        [3,0,1,2, 9,9],
-        [2,3,0,1, 5,11],
-        [1,2,3,0, 13,15],
+        [0, 1, 2, 3, 1, 3],
+        [3, 0, 1, 2, 9, 9],
+        [2, 3, 0, 1, 5, 11],
+        [1, 2, 3, 0, 13, 15],
 
-        [0,1,2,3, 3,3],
-        [3,0,1,2, 11,9],
-        [2,3,0,1, 7,11],
-        [1,2,3,0, 15,15],
+        [0, 1, 2, 3, 3, 3],
+        [3, 0, 1, 2, 11, 9],
+        [2, 3, 0, 1, 7, 11],
+        [1, 2, 3, 0, 15, 15],
     ]
 
     def _process(self, block):
@@ -157,23 +162,23 @@ class md4(object):
         state = list(orig)
 
         # round 1 - F function - (x&y)|(~x & z)
-        for a1,b1,c1,d1,k1,s1 in self._round1:
-            t = (state[a1] + F(state[b1],state[c1],state[d1]) + X[k1]) & MASK_32
-            state[a1] = ((t<<s1) & MASK_32) + (t>>(32-s1))
+        for a1, b1, c1, d1, k1, s1 in self._round1:
+            t = (state[a1] + F(state[b1], state[c1], state[d1]) + X[k1]) & MASK_32
+            state[a1] = ((t << s1) & MASK_32) + (t >> (32 - s1))
 
         # round 2 - G function
-        for a1,b1,c1,d1,k1,s1 in self._round2:
-            t = (state[a1] + G(state[b1],state[c1],state[d1]) + X[k1] + 0x5a827999) & MASK_32
-            state[a1] = ((t<<s1) & MASK_32) + (t>>(32-s1))
+        for a1, b1, c1, d1, k1, s1 in self._round2:
+            t = (state[a1] + G(state[b1], state[c1], state[d1]) + X[k1] + 0x5a827999) & MASK_32
+            state[a1] = ((t << s1) & MASK_32) + (t >> (32 - s1))
 
         # round 3 - H function - x ^ y ^ z
-        for a1,b1,c1,d1,k1,s1 in self._round3:
+        for a1, b1, c1, d1, k1, s1 in self._round3:
             t = (state[a1] + (state[b1] ^ state[c1] ^ state[d1]) + X[k1] + 0x6ed9eba1) & MASK_32
-            state[a1] = ((t<<s1) & MASK_32) + (t>>(32-s1))
+            state[a1] = ((t << s1) & MASK_32) + (t >> (32 - s1))
 
         # add back into original state
         for i in irange(4):
-            orig[i] = (orig[i]+state[i]) & MASK_32
+            orig[i] = (orig[i] + state[i]) & MASK_32
 
     def update(self, content):
         if not isinstance(content, bytes):
@@ -209,9 +214,9 @@ class md4(object):
         # then 0x00 padding until congruent w/ 56 mod 64 bytes
         # then last 8 bytes = msg length in bits
         buf = self._buf
-        msglen = self._count*512 + len(buf)*8
-        block = buf + b('\x80') + b('\x00') * ((119-len(buf)) % 64) + \
-            struct.pack("<2I", msglen & MASK_32, (msglen>>32) & MASK_32)
+        msglen = self._count * 512 + len(buf) * 8
+        block = buf + b('\x80') + b('\x00') * ((119 - len(buf)) % 64) + \
+                struct.pack("<2I", msglen & MASK_32, (msglen >> 32) & MASK_32)
         if len(block) == 128:
             self._process(block[:64])
             self._process(block[64:])
@@ -227,20 +232,22 @@ class md4(object):
     def hexdigest(self):
         return bascii_to_str(hexlify(self.digest()))
 
-    #===================================================================
-    # eoc
-    #===================================================================
+        # ===================================================================
+        # eoc
+        # ===================================================================
+
 
 # keep ref around for unittest, 'md4' usually replaced by ssl wrapper, below.
 _builtin_md4 = md4
 
-#=============================================================================
+# =============================================================================
 # check if hashlib provides accelarated md4
-#=============================================================================
+# =============================================================================
 import hashlib
 from compat import PYPY
 
-def _has_native_md4(): # pragma: no cover -- runtime detection
+
+def _has_native_md4():  # pragma: no cover -- runtime detection
     try:
         h = hashlib.new("md4")
     except ValueError:
@@ -257,17 +264,18 @@ def _has_native_md4(): # pragma: no cover -- runtime detection
     warn("native md4 support disabled, sanity check failed!", PasslibRuntimeWarning)
     return False
 
+
 if _has_native_md4():
     # overwrite md4 class w/ hashlib wrapper
     def md4(content=None):
         "wrapper for hashlib.new('md4')"
         return hashlib.new('md4', content or b(''))
 
-#=============================================================================
+# =============================================================================
 # Include to match existing md4.new() code:
-#=============================================================================
+# =============================================================================
 new = md4
 
-#=============================================================================
+# =============================================================================
 # eof
-#=============================================================================
+# =============================================================================

--- a/ldaptor/protocols/ldap/autofill/posixAccount.py
+++ b/ldaptor/protocols/ldap/autofill/posixAccount.py
@@ -2,7 +2,8 @@ from twisted.internet import defer
 from ldaptor import numberalloc
 from ldaptor.protocols.ldap import ldapsyntax, autofill
 
-class Autofill_posix: #TODO baseclass
+
+class Autofill_posix:  # TODO baseclass
     def __init__(self,
                  baseDN,
                  freeNumberGetter=numberalloc.getFreeNumber):
@@ -25,7 +26,7 @@ class Autofill_posix: #TODO baseclass
     def start(self, ldapObject):
         assert 'objectClass' in ldapObject
         if 'posixAccount' not in ldapObject['objectClass']:
-            raise autofill.ObjectMissingObjectClassException, ldapObject
+            raise autofill.ObjectMissingObjectClassException(ldapObject)
 
         assert 'loginShell' not in ldapObject
         ldapObject['loginShell'] = ['/bin/sh']
@@ -39,8 +40,8 @@ class Autofill_posix: #TODO baseclass
         d = defer.DeferredList([d1, d2], fireOnOneErrback=1)
 
         # silence the log
-        d1.addErrback(lambda x:None)
-        d2.addErrback(lambda x:None)
+        d1.addErrback(lambda x: None)
+        d2.addErrback(lambda x: None)
 
         d.addCallback(self._cb_gotNumbers, ldapObject)
         return d

--- a/ldaptor/protocols/ldap/distinguishedname.py
+++ b/ldaptor/protocols/ldap/distinguishedname.py
@@ -7,62 +7,66 @@ escapedChars = r',+"\<>;='
 escapedChars_leading = r' #'
 escapedChars_trailing = r' #'
 
+
 def escape(s):
-    r=''
-    r_trailer=''
+    r = ''
+    r_trailer = ''
 
     if s and s[0] in escapedChars_leading:
-        r='\\'+s[0]
-        s=s[1:]
+        r = '\\' + s[0]
+        s = s[1:]
 
     if s and s[-1] in escapedChars_trailing:
-        r_trailer='\\'+s[-1]
-        s=s[:-1]
+        r_trailer = '\\' + s[-1]
+        s = s[:-1]
 
     for c in s:
         if c in escapedChars:
-            r=r+'\\'+c
-        elif ord(c)<=31:
-            r=r+'\\%02X' % ord(c)
+            r = r + '\\' + c
+        elif ord(c) <= 31:
+            r = r + '\\%02X' % ord(c)
         else:
-            r=r+c
+            r = r + c
 
-    return r+r_trailer
+    return r + r_trailer
+
 
 def unescape(s):
-    r=''
+    r = ''
     while s:
-        if s[0]=='\\':
+        if s[0] == '\\':
             if s[1] in '0123456789abcdef':
-                r=r+chr(int(s[1:3], 16))
-                s=s[3:]
+                r = r + chr(int(s[1:3], 16))
+                s = s[3:]
             else:
-                r=r+s[1]
-                s=s[2:]
+                r = r + s[1]
+                s = s[2:]
         else:
-            r=r+s[0]
-            s=s[1:]
+            r = r + s[0]
+            s = s[1:]
     return r
+
 
 def _splitOnNotEscaped(s, separator):
     if not s:
         return []
 
-    r=['']
+    r = ['']
     while s:
-        if s[0]=='\\':
-            r[-1]=r[-1]+s[:2]
-            s=s[2:]
+        if s[0] == '\\':
+            r[-1] = r[-1] + s[:2]
+            s = s[2:]
         else:
             if s[0] in separator:
                 r.append('')
-                s=s[1:]
-                while s[0]==' ':
-                    s=s[1:]
+                s = s[1:]
+                while s[0] == ' ':
+                    s = s[1:]
             else:
-                r[-1]=r[-1]+s[0]
-                s=s[1:]
+                r[-1] = r[-1] + s[0]
+                s = s[1:]
     return r
+
 
 class InvalidRelativeDistinguishedName(Exception):
     """Invalid relative distinguished name."""
@@ -74,6 +78,7 @@ class InvalidRelativeDistinguishedName(Exception):
     def __str__(self):
         return "Invalid relative distinguished name %s." \
                % repr(self.rdn)
+
 
 class LDAPAttributeTypeAndValue:
     # TODO I should be used everywhere
@@ -90,7 +95,7 @@ class LDAPAttributeTypeAndValue:
             assert attributeType is None
             assert value is None
             if '=' not in stringValue:
-                raise InvalidRelativeDistinguishedName, stringValue
+                raise InvalidRelativeDistinguishedName(stringValue)
             self.attributeType, self.value = stringValue.split('=', 1)
 
     def __str__(self):
@@ -133,6 +138,7 @@ class LDAPAttributeTypeAndValue:
 
     def __ge__(self, other):
         return not self < other
+
 
 class RelativeDistinguishedName:
     """LDAP Relative Distinguished Name."""
@@ -205,6 +211,7 @@ class RelativeDistinguishedName:
 class DistinguishedName:
     """LDAP Distinguished Name."""
     listOfRDNs = None
+
     def __init__(self, magic=None, stringValue=None, listOfRDNs=None):
         assert (magic is not None
                 or stringValue is not None
@@ -266,7 +273,7 @@ class DistinguishedName:
 
     def getDomainName(self):
         domainParts = []
-        l=list(self.listOfRDNs)
+        l = list(self.listOfRDNs)
         l.reverse()
         for rdn in l:
             if rdn.count() != 1:
@@ -285,14 +292,14 @@ class DistinguishedName:
         if self == other:
             return 1
         if not isinstance(other, DistinguishedName):
-            other=DistinguishedName(other)
-        its=list(other.split())
-        mine=list(self.split())
+            other = DistinguishedName(other)
+        its = list(other.split())
+        mine = list(self.split())
 
         while mine and its:
-            m=mine.pop()
-            i=its.pop()
-            if m!=i:
+            m = mine.pop()
+            i = its.pop()
+            if m != i:
                 return 0
         if mine:
             return 0

--- a/ldaptor/protocols/ldap/fetchschema.py
+++ b/ldaptor/protocols/ldap/fetchschema.py
@@ -2,17 +2,19 @@ from ldaptor.protocols.ldap import ldaperrors, ldapsyntax
 from ldaptor.protocols import pureldap
 from ldaptor import schema
 
+
 def _fetchCb(subschemaSubentry, client):
-    o=ldapsyntax.LDAPEntry(client=client,
-                           dn=subschemaSubentry)
-    d=o.search(scope=pureldap.LDAP_SCOPE_baseObject,
-               sizeLimit=1,
-               attributes=["attributeTypes", "objectClasses"])
+    o = ldapsyntax.LDAPEntry(client=client,
+                             dn=subschemaSubentry)
+    d = o.search(scope=pureldap.LDAP_SCOPE_baseObject,
+                 sizeLimit=1,
+                 attributes=["attributeTypes", "objectClasses"])
+
     def handleSearchResults(l):
-        if len(l)==0:
-            raise ldaperrors.LDAPOther, "No such DN"
-        elif len(l)==1:
-            o=l[0]
+        if len(l) == 0:
+            raise ldaperrors.LDAPOther("No such DN")
+        elif len(l) == 1:
+            o = l[0]
 
             attributeTypes = []
             objectClasses = []
@@ -20,34 +22,35 @@ def _fetchCb(subschemaSubentry, client):
                 attributeTypes.append(schema.AttributeTypeDescription(str(text)))
             for text in o.get("objectClasses", []):
                 objectClasses.append(schema.ObjectClassDescription(str(text)))
-            assert attributeTypes, "LDAP server doesn't give attributeTypes for subschemaSubentry dn=%s"%o.dn
+            assert attributeTypes, "LDAP server doesn't give attributeTypes for subschemaSubentry dn=%s" % o.dn
             return (attributeTypes, objectClasses)
         else:
-            raise ldaperrors.LDAPOther, "DN matched multiple entries"
+            raise ldaperrors.LDAPOther("DN matched multiple entries")
+
     d.addCallback(handleSearchResults)
     return d
 
+
 def fetch(client, baseObject):
-    o=ldapsyntax.LDAPEntry(client=client,
-                           dn=baseObject)
-    d=o.search(scope=pureldap.LDAP_SCOPE_baseObject,
-               sizeLimit=1,
-               attributes=["subschemaSubentry"])
+    o = ldapsyntax.LDAPEntry(client=client,
+                             dn=baseObject)
+    d = o.search(scope=pureldap.LDAP_SCOPE_baseObject,
+                 sizeLimit=1,
+                 attributes=["subschemaSubentry"])
 
     def handleSearchResults(l):
-        if len(l)==0:
-            raise ldaperrors.LDAPOther, "No such DN"
-        elif len(l)==1:
-            o=l[0]
+        if len(l) == 0:
+            raise ldaperrors.LDAPOther("No such DN")
+        elif len(l) == 1:
+            o = l[0]
             assert "subschemaSubentry" in o, "No subschemaSubentry. TODO"
             subSchemas = o["subschemaSubentry"]
-            assert len(subSchemas)==1, "More than one subschemaSubentry is not support yet. TODO"
+            assert len(subSchemas) == 1, "More than one subschemaSubentry is not support yet. TODO"
             for s in subSchemas:
                 return s
         else:
-            raise ldaperrors.LDAPOther, "DN matched multiple entries"
+            raise ldaperrors.LDAPOther("DN matched multiple entries")
 
     d.addCallback(handleSearchResults)
     d.addCallback(_fetchCb, client)
     return d
-

--- a/ldaptor/protocols/ldap/ldapconnector.py
+++ b/ldaptor/protocols/ldap/ldapconnector.py
@@ -1,5 +1,6 @@
 from twisted.internet import protocol, defer
 from twisted.internet.endpoints import clientFromString
+
 try:
     from twisted.internet import endpoints
     connectProtocol = endpoints.connectProtocol
@@ -18,6 +19,7 @@ try:
 except AttributeError:
     from twisted.names.srvconnect import SRVConnector
 
+
 def connectToLDAPEndpoint(reactor, endpointStr, clientProtocol):
     e = clientFromString(reactor, endpointStr)
     d = connectProtocol(e, clientProtocol())
@@ -30,7 +32,7 @@ class LDAPConnector(SRVConnector):
         if not isinstance(dn, distinguishedname.DistinguishedName):
             dn = distinguishedname.DistinguishedName(stringValue=dn)
         if overrides is None:
-            overrides={}
+            overrides = {}
         self.override = self._findOverRide(dn, overrides)
 
         domain = dn.getDomainName() or ''
@@ -39,7 +41,7 @@ class LDAPConnector(SRVConnector):
                   connectFuncKwArgs={'bindAddress': bindAddress})
 
     def __getstate__(self):
-        r={}
+        r = {}
         r.update(self.__dict__)
         r['connector'] = None
         return r
@@ -104,6 +106,7 @@ class LDAPConnector(SRVConnector):
             port = 389
         return host, port
 
+
 class LDAPClientCreator(protocol.ClientCreator):
     def connect(self, dn, overrides=None, bindAddress=None):
         """Connect to remote host, return Deferred of resulting protocol instance."""
@@ -119,8 +122,9 @@ class LDAPClientCreator(protocol.ClientCreator):
         d = self.connect(dn, overrides=overrides)
 
         def _bind(proto):
-            d=proto.bind()
+            d = proto.bind()
             d.addCallback(lambda _: proto)
             return d
+
         d.addCallback(_bind)
         return d

--- a/ldaptor/protocols/ldap/ldaperrors.py
+++ b/ldaptor/protocols/ldap/ldaperrors.py
@@ -17,6 +17,7 @@
 reverse = None
 LDAPOther = None
 
+
 def get(resultCode, errorMessage):
     """Get an instance of the correct exception for this resultCode."""
 
@@ -26,29 +27,36 @@ def get(resultCode, errorMessage):
     else:
         return LDAPUnknownError(resultCode, errorMessage)
 
+
 class LDAPResult:
-    resultCode=None
-    name=None
+    resultCode = None
+    name = None
+
 
 class Success(LDAPResult):
-    resultCode=0
-    name='success'
+    resultCode = 0
+    name = 'success'
 
     def __init__(self, msg):
         pass
 
+
 class LDAPException(Exception, LDAPResult):
 
-    def _get_message(self): return self.__message
-    def _set_message(self, value): self.__message = value
+    def _get_message(self):
+        return self.__message
+
+    def _set_message(self, value):
+        self.__message = value
+
     message = property(_get_message, _set_message)
 
     def __init__(self, message=None):
         Exception.__init__(self)
-        self.message=message
+        self.message = message
 
     def __str__(self):
-        message=self.message
+        message = self.message
         if message:
             return '%s: %s' % (self.name, message)
         elif self.name:
@@ -56,17 +64,18 @@ class LDAPException(Exception, LDAPResult):
         else:
             return 'Unknown LDAP error %r' % self
 
+
 class LDAPUnknownError(LDAPException):
-    resultCode=None
+    resultCode = None
 
     def __init__(self, resultCode, message=None):
         assert resultCode not in reverse, \
-               "resultCode %r must be unknown" % resultCode
-        self.code=resultCode
+            "resultCode %r must be unknown" % resultCode
+        self.code = resultCode
         LDAPException.__init__(self, message)
 
     def __str__(self):
-        codeName='unknownError(%d)'%self.code
+        codeName = 'unknownError(%d)' % self.code
         if self.message:
             return '%s: %s' % (codeName, self.message)
         else:
@@ -89,6 +98,7 @@ def init(**errors):
             globals()[classname] = klass
         reverse[value] = klass
 
+
 init(
     success=0,
     operationsError=1,
@@ -100,11 +110,11 @@ init(
     authMethodNotSupported=7,
     strongAuthRequired=8,
     # 9 reserved
-    referral=10 ,
-    adminLimitExceeded=11 ,
-    unavailableCriticalExtension=12 ,
-    confidentialityRequired=13 ,
-    saslBindInProgress=14 ,
+    referral=10,
+    adminLimitExceeded=11,
+    unavailableCriticalExtension=12,
+    confidentialityRequired=13,
+    saslBindInProgress=14,
     noSuchAttribute=16,
     undefinedAttributeType=17,
     inappropriateMatching=18,
@@ -139,4 +149,4 @@ init(
     # 81-90 reserved for APIs
     )
 
-other=LDAPOther.resultCode
+other = LDAPOther.resultCode

--- a/ldaptor/protocols/ldap/ldapserver.py
+++ b/ldaptor/protocols/ldap/ldapserver.py
@@ -290,9 +290,9 @@ class LDAPServer(BaseLDAPServer):
     def handle_LDAPSearchRequest(self, request, controls, reply):
         self.checkControls(controls)
 
-        if (request.baseObject == '' and
-                request.scope == pureldap.LDAP_SCOPE_baseObject and
-                request.filter == pureldap.LDAPFilter_present('objectClass')):
+        if (request.baseObject == ''
+                and request.scope == pureldap.LDAP_SCOPE_baseObject
+                and request.filter == pureldap.LDAPFilter_present('objectClass')):
             return self.getRootDSE(request, reply)
         dn = distinguishedname.DistinguishedName(request.baseObject)
         root = interfaces.IConnectedLDAPEntry(self.factory)
@@ -472,15 +472,15 @@ class LDAPServer(BaseLDAPServer):
         if self.boundUser is None:
             raise ldaperrors.LDAPStrongAuthRequired()
 
-        if (userIdentity is not None and
-                userIdentity != self.boundUser.dn):
+        if (userIdentity is not None
+                and userIdentity != self.boundUser.dn):
             log.msg('User %(actor)s tried to change password of %(target)s' % {
                 'actor': str(self.boundUser.dn),
                 'target': str(userIdentity),
                 })
             raise ldaperrors.LDAPInsufficientAccessRights()
-        if (oldPasswd is not None or
-                newPasswd is None):
+        if (oldPasswd is not None
+                or newPasswd is None):
             raise ldaperrors.LDAPOperationsError(
                 'Password does not support this case.')
         self.boundUser.setPassword(newPasswd)

--- a/ldaptor/protocols/ldap/ldifprotocol.py
+++ b/ldaptor/protocols/ldap/ldifprotocol.py
@@ -12,38 +12,45 @@ class LDIFParseError(Exception):
         s = self.__doc__
         if self[:]:
             s = ': '.join([s]+map(str, self[:]))
-        return s+'.'
+        return s + '.'
+
 
 class LDIFLineWithoutSemicolonError(LDIFParseError):
     """LDIF line without semicolon seen"""
     pass
 
+
 class LDIFEntryStartsWithNonDNError(LDIFParseError):
     """LDIF entry starts with a non-DN line"""
     pass
+
 
 class LDIFEntryStartsWithSpaceError(LDIFParseError):
     """Invalid LDIF value format"""
     pass
 
+
 class LDIFVersionNotANumberError(LDIFParseError):
     """Non-numeric LDIF version number"""
     pass
+
 
 class LDIFUnsupportedVersionError(LDIFParseError):
     """LDIF version not supported"""
     pass
 
+
 class LDIFTruncatedError(LDIFParseError):
     """LDIF appears to be truncated"""
     pass
+
 
 HEADER = 'HEADER'
 WAIT_FOR_DN = 'WAIT_FOR_DN'
 IN_ENTRY = 'IN_ENTRY'
 
 class LDIF(object, basic.LineReceiver):
-    delimiter='\n'
+    delimiter = '\n'
     mode = HEADER
 
     dn = None
@@ -85,7 +92,7 @@ class LDIF(object, basic.LineReceiver):
         except ValueError:
             # unpack list of wrong size
             # -> invalid input data
-            raise LDIFLineWithoutSemicolonError, line
+            raise LDIFLineWithoutSemicolonError(line)
         val = self.parseValue(val)
         return key, val
 
@@ -99,10 +106,10 @@ class LDIF(object, basic.LineReceiver):
             try:
                 version = int(val)
             except ValueError:
-                raise LDIFVersionNotANumberError, val
+                raise LDIFVersionNotANumberError(val)
             self.version = version
             if version > 1:
-                raise LDIFUnsupportedVersionError, version
+                raise LDIFUnsupportedVersionError(version)
 
     def state_WAIT_FOR_DN(self, line):
         assert self.dn is None, 'self.dn must not be set when waiting for DN'
@@ -114,7 +121,7 @@ class LDIF(object, basic.LineReceiver):
         key, val = self._parseLine(line)
 
         if key.upper() != 'DN':
-            raise LDIFEntryStartsWithNonDNError, line
+            raise LDIFEntryStartsWithNonDNError(line)
 
         self.dn = val
         self.data = {}
@@ -146,4 +153,4 @@ class LDIF(object, basic.LineReceiver):
 
     def connectionLost(self, reason=protocol.connectionDone):
         if self.mode != WAIT_FOR_DN:
-            raise LDIFTruncatedError, reason
+            raise LDIFTruncatedError(reason)

--- a/ldaptor/protocols/ldap/svcbindproxy.py
+++ b/ldaptor/protocols/ldap/svcbindproxy.py
@@ -1,7 +1,8 @@
+import datetime
+
 from ldaptor.protocols.ldap import proxy
 from ldaptor.protocols.ldap import ldapsyntax, ldaperrors
 from ldaptor.protocols import pureldap
-import datetime
 
 class ServiceBindingProxy(proxy.Proxy):
     """
@@ -111,7 +112,7 @@ class ServiceBindingProxy(proxy.Proxy):
         def _gotEntries(entries):
             if not entries:
                 return None
-            assert len(entries)==1 #TODO
+            assert len(entries) == 1  # TODO
             e = entries[0]
             d = e.bind(request.auth)
             return d
@@ -162,6 +163,7 @@ if __name__ == '__main__':
     from twisted.internet import reactor, protocol
     from twisted.python import log
     import sys
+
     log.startLogging(sys.stderr)
     from ldaptor import config
 

--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -472,9 +472,8 @@ class LDAPFilter_equalityMatch(LDAPAttributeValueAssertion):
     tag = CLASS_CONTEXT | 0x03
 
     def asText(self):
-        return '(' + self.attributeDesc.value + '=' \
-               + escape(self.assertionValue.value) + ')'
-
+        return '('+self.attributeDesc.value+'=' \
+               +self.escaper(self.assertionValue.value)+')'
 
 class LDAPFilter_substrings_initial(LDAPString):
     tag = CLASS_CONTEXT | 0x00
@@ -529,14 +528,14 @@ class LDAPFilter_substrings(BERSequence):
             BERSequence(self.substrings)], tag=self.tag))
 
     def __repr__(self):
-        if self.tag == self.__class__.tag:
-            return self.__class__.__name__ \
-                   + "(type=%s, substrings=%s)" \
-                     % (repr(self.type), repr(self.substrings))
+        if self.tag==self.__class__.tag:
+            return self.__class__.__name__\
+                   +"(type=%s, substrings=%s)"\
+                   %(repr(self.type), repr(self.substrings))
         else:
-            return self.__class__.__name__ \
-                   + "(type=%s, substrings=%s, tag=%d)" \
-                     % (repr(self.type), repr(self.substrings), self.tag)
+            return self.__class__.__name__\
+                   +"(type=%s, substrings=%s, tag=%d)"\
+                   %(repr(self.type), repr(self.substrings), self.tag)
 
     def asText(self):
         initial = None
@@ -572,17 +571,15 @@ class LDAPFilter_greaterOrEqual(LDAPAttributeValueAssertion):
     tag = CLASS_CONTEXT | 0x05
 
     def asText(self):
-        return '(' + self.attributeDesc.value + '>=' \
-               + escape(self.assertionValue.value) + ')'
-
+        return '(' + self.attributeDesc.value + '>=' + \
+               self.escaper(self.assertionValue.value) + ')'
 
 class LDAPFilter_lessOrEqual(LDAPAttributeValueAssertion):
     tag = CLASS_CONTEXT | 0x06
 
     def asText(self):
-        return '(' + self.attributeDesc.value + '<=' \
-               + escape(self.assertionValue.value) + ')'
-
+        return '(' + self.attributeDesc.value + '<=' + \
+               self.escaper(self.assertionValue.value) + ')'
 
 class LDAPFilter_present(LDAPAttributeDescription):
     tag = CLASS_CONTEXT | 0x07
@@ -595,8 +592,8 @@ class LDAPFilter_approxMatch(LDAPAttributeValueAssertion):
     tag = CLASS_CONTEXT | 0x08
 
     def asText(self):
-        return '(' + self.attributeDesc.value + '~=' \
-               + escape(self.assertionValue.value) + ')'
+        return '(' + self.attributeDesc.value + '~=' + \
+               self.escaper(self.assertionValue.value) + ')'
 
 
 class LDAPMatchingRuleId(LDAPString):
@@ -1432,7 +1429,7 @@ class LDAPExtendedResponse(LDAPResult):
         l = berDecodeMultiple(content, LDAPBERDecoderContext_LDAPExtendedResponse(
             fallback=berdecoder))
 
-        assert 3 <= len(l) <= 4
+        assert 3 <= len(l) <= 6
 
         referral = None
         responseName = None

--- a/ldaptor/samba/smbpassword.py
+++ b/ldaptor/samba/smbpassword.py
@@ -1,16 +1,17 @@
 import string, warnings
 from ldaptor import md4, config
 
-lower='abcdefghijklmnopqrstuvwxyz'
-upper=lower.upper()
+lower = 'abcdefghijklmnopqrstuvwxyz'
+upper = lower.upper()
 toupper=string.maketrans(lower, upper)
 
 def nthash(password=''):
     """Generates nt md4 password hash for a given password."""
 
-    password=password[:128]
-    password=''.join([c+'\000' for c in password])
+    password = password[:128]
+    password = ''.join([c + '\000' for c in password])
     return md4.new(password).hexdigest().translate(toupper);
+
 
 def lmhash_locked(password=''):
     """
@@ -19,12 +20,14 @@ def lmhash_locked(password=''):
     Note that the author thinks LanMan hashes should be banished from
     the face of the earth.
     """
-    return 32*'X'
+    return 32 * 'X'
+
 
 def _no_lmhash(password=''):
     if config.useLMhash():
         warnings.warn("Cannot import Crypto.Cipher.DES, lmhash passwords disabled.")
     return lmhash_locked()
+
 
 def _have_lmhash(password=''):
     """
@@ -37,10 +40,11 @@ def _have_lmhash(password=''):
     if not config.useLMhash():
         return lmhash_locked()
 
-    password = (password+14*'\0')[:14]
+    password = (password + 14 * '\0')[:14]
     password = password.upper()
 
     return _deshash(password[:7]) + _deshash(password[7:])
+
 
 try:
     from Crypto.Cipher import DES
@@ -50,6 +54,8 @@ else:
     lmhash = _have_lmhash
 
 LM_MAGIC = "KGS!@#$%"
+
+
 def _deshash(p):
     # Insert parity bits. I'm not going to bother myself with smart
     # implementations.
@@ -63,6 +69,7 @@ def _deshash(p):
                      bool(byte & 4),
                      bool(byte & 2),
                      bool(byte & 1)])
+
     def _pack(bits):
         x = ((bits[0] << 7)
              + (bits[1] << 6)
@@ -86,4 +93,3 @@ def _deshash(p):
     raw = cipher.encrypt(LM_MAGIC)
     l = ['%02X' % ord(x) for x in raw]
     return ''.join(l)
-

--- a/ldaptor/test/test_attributeset.py
+++ b/ldaptor/test/test_attributeset.py
@@ -6,6 +6,7 @@ from twisted.trial import unittest
 import sets
 from ldaptor import attributeset
 
+
 class TestComparison(unittest.TestCase):
     def testEquality_True_Set(self):
         a = attributeset.LDAPAttributeSet('k', ['b', 'c', 'd'])
@@ -36,6 +37,7 @@ class TestComparison(unittest.TestCase):
         a = attributeset.LDAPAttributeSet('k', ['b', 'c', 'd'])
         b = attributeset.LDAPAttributeSet('l', ['b', 'c', 'd'])
         self.assertNotEqual(a, b)
+
 
 class TestSetOperations(unittest.TestCase):
     def testDifference(self):
@@ -80,6 +82,7 @@ class TestSetOperations(unittest.TestCase):
         class Magic:
             def __eq__(self, other):
                 return isinstance(other, self.__class__)
+
             def __hash__(self):
                 return 42
         m1 = Magic()

--- a/ldaptor/test/test_attributeset.py
+++ b/ldaptor/test/test_attributeset.py
@@ -11,22 +11,22 @@ class TestComparison(unittest.TestCase):
     def testEquality_True_Set(self):
         a = attributeset.LDAPAttributeSet('k', ['b', 'c', 'd'])
         b = attributeset.LDAPAttributeSet('k', ['b', 'c', 'd'])
-        self.assertEquals(a, b)
+        self.assertEqual(a, b)
 
     def testEquality_True_Set_Ordering(self):
         a = attributeset.LDAPAttributeSet('k', ['b', 'c', 'd'])
         b = attributeset.LDAPAttributeSet('k', ['b', 'd', 'c'])
-        self.assertEquals(a, b)
+        self.assertEqual(a, b)
 
     def testEquality_True_List(self):
         a = attributeset.LDAPAttributeSet('k', ['b', 'c', 'd'])
         b = ['b', 'c', 'd']
-        self.assertEquals(a, b)
+        self.assertEqual(a, b)
 
     def testEquality_True_List_Ordering(self):
         a = attributeset.LDAPAttributeSet('k', ['b', 'c', 'd'])
         b = ['b', 'd', 'c']
-        self.assertEquals(a, b)
+        self.assertEqual(a, b)
 
     def testEquality_False_Value(self):
         a = attributeset.LDAPAttributeSet('k', ['b', 'c', 'd'])
@@ -43,22 +43,22 @@ class TestSetOperations(unittest.TestCase):
     def testDifference(self):
         a = attributeset.LDAPAttributeSet('k', ['b', 'c', 'd'])
         b = attributeset.LDAPAttributeSet('k', ['b', 'c', 'e'])
-        self.assertEquals(a - b, sets.Set(['d']))
+        self.assertEqual(a - b, sets.Set(['d']))
 
     def testUnion(self):
         a = attributeset.LDAPAttributeSet('k', ['b', 'c', 'd'])
         b = attributeset.LDAPAttributeSet('k', ['b', 'c', 'e'])
-        self.assertEquals(a | b, sets.Set(['b', 'c', 'd', 'e']))
+        self.assertEqual(a | b, sets.Set(['b', 'c', 'd', 'e']))
 
     def testIntersection(self):
         a = attributeset.LDAPAttributeSet('k', ['b', 'c', 'd'])
         b = attributeset.LDAPAttributeSet('k', ['b', 'c', 'e'])
-        self.assertEquals(a & b, sets.Set(['b', 'c']))
+        self.assertEqual(a & b, sets.Set(['b', 'c']))
 
     def testSymmetricDifference(self):
         a = attributeset.LDAPAttributeSet('k', ['b', 'c', 'd'])
         b = attributeset.LDAPAttributeSet('k', ['b', 'c', 'e'])
-        self.assertEquals(a ^ b, sets.Set(['d', 'e']))
+        self.assertEqual(a ^ b, sets.Set(['d', 'e']))
 
     def testCopy(self):
         class Magic:
@@ -66,17 +66,17 @@ class TestSetOperations(unittest.TestCase):
         m1 = Magic()
         a = attributeset.LDAPAttributeSet('k', ['b', 'c', 'd', m1])
         b = a.__copy__()
-        self.assertEquals(a, b)
+        self.assertEqual(a, b)
         self.assertNotIdentical(a, b)
 
         magicFromA = [val for val in a if isinstance(val, Magic)][0]
         magicFromB = [val for val in b if isinstance(val, Magic)][0]
-        self.assertEquals(magicFromA, magicFromB)
+        self.assertEqual(magicFromA, magicFromB)
         self.assertIdentical(magicFromA, magicFromB)
 
         a.update('x')
-        self.assertEquals(a, sets.Set(['b', 'c', 'd', m1, 'x']))
-        self.assertEquals(b, sets.Set(['b', 'c', 'd', m1]))
+        self.assertEqual(a, sets.Set(['b', 'c', 'd', m1, 'x']))
+        self.assertEqual(b, sets.Set(['b', 'c', 'd', m1]))
 
     def testDeepCopy(self):
         class Magic:
@@ -88,14 +88,14 @@ class TestSetOperations(unittest.TestCase):
         m1 = Magic()
         a = attributeset.LDAPAttributeSet('k', ['a', m1])
         b = a.__deepcopy__({})
-        self.assertEquals(a, b)
+        self.assertEqual(a, b)
         self.assertNotIdentical(a, b)
 
         magicFromA = [val for val in a if isinstance(val, Magic)][0]
         magicFromB = [val for val in b if isinstance(val, Magic)][0]
-        self.assertEquals(magicFromA, magicFromB)
+        self.assertEqual(magicFromA, magicFromB)
         self.assertNotIdentical(magicFromA, magicFromB)
 
         a.update('x')
-        self.assertEquals(a, sets.Set(['a', m1, 'x']))
-        self.assertEquals(b, sets.Set(['a', m1]))
+        self.assertEqual(a, sets.Set(['a', m1, 'x']))
+        self.assertEqual(b, sets.Set(['a', m1]))

--- a/ldaptor/test/test_autofill.py
+++ b/ldaptor/test/test_autofill.py
@@ -6,7 +6,8 @@ from twisted.trial import unittest
 from ldaptor.protocols.ldap import ldapsyntax
 from ldaptor.testutil import LDAPClientTestDriver
 
-class Autofill_sum: #TODO baseclass
+
+class Autofill_sum:  # TODO baseclass
     def __init__(self, resultAttr, sumAttrs):
         self.resultAttr = resultAttr
         self.sumAttrs = sumAttrs
@@ -27,6 +28,7 @@ class Autofill_sum: #TODO baseclass
                 sum += val
         sum = str(sum)
         ldapObject[self.resultAttr] = [sum]
+
 
 class LDAPAutoFill_Simple(unittest.TestCase):
     def testSimpleSum(self):

--- a/ldaptor/test/test_autofill_samba.py
+++ b/ldaptor/test/test_autofill_samba.py
@@ -12,7 +12,7 @@ class LDAPAutoFill_sambaAccount(unittest.TestCase):
     def testMustHaveObjectClass(self):
         """Test that Autofill_samba fails unless object is a sambaAccount."""
         client = testutil.LDAPClientTestDriver()
-        o=ldapsyntax.LDAPEntryWithAutoFill(client=client,
+        o = ldapsyntax.LDAPEntryWithAutoFill(client=client,
                                            dn='cn=foo,dc=example,dc=com',
                                            attributes={
             'objectClass': ['something', 'other'],
@@ -29,12 +29,13 @@ class LDAPAutoFill_sambaAccount(unittest.TestCase):
     def testDefaultSetting(self):
         """Test that fields get their default values."""
         client = testutil.LDAPClientTestDriver()
-        o=ldapsyntax.LDAPEntryWithAutoFill(client=client,
+        o = ldapsyntax.LDAPEntryWithAutoFill(client=client,
                                            dn='cn=foo,dc=example,dc=com',
                                            attributes={
             'objectClass': ['sambaAccount', 'other'],
             })
         d = o.addAutofiller(sambaAccount.Autofill_samba())
+
         def cb(dummy):
             client.assertNothingSent()
 
@@ -51,74 +52,80 @@ class LDAPAutoFill_sambaAccount(unittest.TestCase):
             self.failUnlessEqual(o['pwdCanChange'], ['0'])
             self.failUnless('pwdMustChange' in o)
             self.failUnlessEqual(o['pwdMustChange'], ['0'])
+
         d.addCallback(cb)
         return d
 
     def testRid(self):
         """Test that rid field is updated based on uidNumber."""
         client = testutil.LDAPClientTestDriver()
-        o=ldapsyntax.LDAPEntryWithAutoFill(client=client,
+        o = ldapsyntax.LDAPEntryWithAutoFill(client=client,
                                            dn='cn=foo,dc=example,dc=com',
                                            attributes={
             'objectClass': ['sambaAccount', 'other'],
             })
         d = o.addAutofiller(sambaAccount.Autofill_samba())
+
         def cb(dummy):
             client.assertNothingSent()
 
             o['uidNumber'] = ['1000']
             self.failUnless('rid' in o)
-            self.failUnlessEqual(o['rid'], [str(2*1000+1000)])
+            self.failUnlessEqual(o['rid'], [str(2 * 1000 + 1000)])
             o['uidNumber'] = ['1001']
-            self.failUnlessEqual(o['rid'], [str(2*1001+1000)])
+            self.failUnlessEqual(o['rid'], [str(2 * 1001 + 1000)])
             o['uidNumber'] = ['1002']
-            self.failUnlessEqual(o['rid'], [str(2*1002+1000)])
+            self.failUnlessEqual(o['rid'], [str(2 * 1002 + 1000)])
             o['uidNumber'] = ['2000']
-            self.failUnlessEqual(o['rid'], [str(2*2000+1000)])
+            self.failUnlessEqual(o['rid'], [str(2 * 2000 + 1000)])
             o['uidNumber'] = ['3000']
-            self.failUnlessEqual(o['rid'], [str(2*3000+1000)])
+            self.failUnlessEqual(o['rid'], [str(2 * 3000 + 1000)])
             o['uidNumber'] = ['0']
-            self.failUnlessEqual(o['rid'], [str(2*0+1000)])
+            self.failUnlessEqual(o['rid'], [str(2 * 0 + 1000)])
             o['uidNumber'] = ['16000']
-            self.failUnlessEqual(o['rid'], [str(2*16000+1000)])
+            self.failUnlessEqual(o['rid'], [str(2 * 16000 + 1000)])
+
         d.addCallback(cb)
         return d
 
     def testPrimaryGroupId(self):
         """Test that primaryGroupID field is updated based on gidNumber."""
         client = testutil.LDAPClientTestDriver()
-        o=ldapsyntax.LDAPEntryWithAutoFill(client=client,
+        o = ldapsyntax.LDAPEntryWithAutoFill(client=client,
                                             dn='cn=foo,dc=example,dc=com',
                                             attributes={
             'objectClass': ['sambaAccount', 'other'],
             })
         d = o.addAutofiller(sambaAccount.Autofill_samba())
+
         def cb(dummy):
             client.assertNothingSent()
 
             o['gidNumber'] = ['1000']
             self.failUnless('primaryGroupID' in o)
-            self.failUnlessEqual(o['primaryGroupID'], [str(2*1000+1001)])
+            self.failUnlessEqual(o['primaryGroupID'], [str(2 * 1000 + 1001)])
             o['gidNumber'] = ['1001']
-            self.failUnlessEqual(o['primaryGroupID'], [str(2*1001+1001)])
+            self.failUnlessEqual(o['primaryGroupID'], [str(2 * 1001 + 1001)])
             o['gidNumber'] = ['1002']
-            self.failUnlessEqual(o['primaryGroupID'], [str(2*1002+1001)])
+            self.failUnlessEqual(o['primaryGroupID'], [str(2 * 1002 + 1001)])
             o['gidNumber'] = ['2000']
-            self.failUnlessEqual(o['primaryGroupID'], [str(2*2000+1001)])
+            self.failUnlessEqual(o['primaryGroupID'], [str(2 * 2000 + 1001)])
             o['gidNumber'] = ['3000']
-            self.failUnlessEqual(o['primaryGroupID'], [str(2*3000+1001)])
+            self.failUnlessEqual(o['primaryGroupID'], [str(2 * 3000 + 1001)])
             o['gidNumber'] = ['0']
-            self.failUnlessEqual(o['primaryGroupID'], [str(2*0+1001)])
+            self.failUnlessEqual(o['primaryGroupID'], [str(2 * 0 + 1001)])
             o['gidNumber'] = ['16000']
-            self.failUnlessEqual(o['primaryGroupID'], [str(2*16000+1001)])
+            self.failUnlessEqual(o['primaryGroupID'], [str(2 * 16000 + 1001)])
+
         d.addCallback(cb)
         return d
+
 
 class LDAPAutoFill_sambaSamAccount(unittest.TestCase):
     def testMustHaveObjectClass(self):
         """Test that Autofill_samba fails unless object is a sambaSamAccount."""
         client = testutil.LDAPClientTestDriver()
-        o=ldapsyntax.LDAPEntryWithAutoFill(client=client,
+        o = ldapsyntax.LDAPEntryWithAutoFill(client=client,
                                            dn='cn=foo,dc=example,dc=com',
                                            attributes={
             'objectClass': ['something', 'other'],
@@ -129,18 +136,20 @@ class LDAPAutoFill_sambaSamAccount(unittest.TestCase):
         def eb(val):
             client.assertNothingSent()
             val.trap(sambaSamAccount.ObjectMissingObjectClassException)
+
         d.addCallbacks(testutil.mustRaise, eb)
         return d
 
     def testDefaultSetting(self):
         """Test that fields get their default values."""
         client = testutil.LDAPClientTestDriver()
-        o=ldapsyntax.LDAPEntryWithAutoFill(client=client,
+        o = ldapsyntax.LDAPEntryWithAutoFill(client=client,
                                            dn='cn=foo,dc=example,dc=com',
                                            attributes={
             'objectClass': ['sambaSamAccount', 'other'],
             })
         d = o.addAutofiller(sambaSamAccount.Autofill_samba(domainSID='foo'))
+
         def cb(dummy):
             client.assertNothingSent()
 
@@ -160,19 +169,21 @@ class LDAPAutoFill_sambaSamAccount(unittest.TestCase):
             self.failUnlessEqual(o['sambaLogoffTime'], ['0'])
             self.failUnlessEqual(o['sambaPwdCanChange'], ['0'])
             self.failUnlessEqual(o['sambaPwdMustChange'], ['0'])
+
         d.addCallback(cb)
         return d
 
     def testDefaultSetting_fixedPrimaryGroupSID(self):
         """Test that fields get their default values."""
         client = testutil.LDAPClientTestDriver()
-        o=ldapsyntax.LDAPEntryWithAutoFill(client=client,
+        o = ldapsyntax.LDAPEntryWithAutoFill(client=client,
                                            dn='cn=foo,dc=example,dc=com',
                                            attributes={
             'objectClass': ['sambaSamAccount', 'other'],
             })
         d = o.addAutofiller(sambaSamAccount.Autofill_samba(domainSID='foo',
                                                            fixedPrimaryGroupSID=4131312))
+
         def cb(dummy):
             client.assertNothingSent()
 
@@ -194,115 +205,125 @@ class LDAPAutoFill_sambaSamAccount(unittest.TestCase):
             self.failUnlessEqual(o['sambaLogoffTime'], ['0'])
             self.failUnlessEqual(o['sambaPwdCanChange'], ['0'])
             self.failUnlessEqual(o['sambaPwdMustChange'], ['0'])
+
         d.addCallback(cb)
         return d
 
     def testSambaSID(self):
         """Test that sambaSID field is updated based on uidNumber."""
         client = testutil.LDAPClientTestDriver()
-        o=ldapsyntax.LDAPEntryWithAutoFill(client=client,
+        o = ldapsyntax.LDAPEntryWithAutoFill(client=client,
                                            dn='cn=foo,dc=example,dc=com',
                                            attributes={
             'objectClass': ['sambaSamAccount', 'other'],
             })
         d = o.addAutofiller(sambaSamAccount.Autofill_samba(domainSID='foo'))
+
         def cb(dummy):
             client.assertNothingSent()
 
             o['uidNumber'] = ['1000']
             self.failUnless('sambaSID' in o)
-            self.failUnlessEqual(o['sambaSID'], ['foo-%s' % (2*1000+1000)])
+            self.failUnlessEqual(o['sambaSID'], ['foo-%s' % (2 * 1000 + 1000)])
             o['uidNumber'] = ['1001']
-            self.failUnlessEqual(o['sambaSID'], ['foo-%s' % (2*1001+1000)])
+            self.failUnlessEqual(o['sambaSID'], ['foo-%s' % (2 * 1001 + 1000)])
             o['uidNumber'] = ['1002']
-            self.failUnlessEqual(o['sambaSID'], ['foo-%s' % (2*1002+1000)])
+            self.failUnlessEqual(o['sambaSID'], ['foo-%s' % (2 * 1002 + 1000)])
             o['uidNumber'] = ['2000']
-            self.failUnlessEqual(o['sambaSID'], ['foo-%s' % (2*2000+1000)])
+            self.failUnlessEqual(o['sambaSID'], ['foo-%s' % (2 * 2000 + 1000)])
             o['uidNumber'] = ['3000']
-            self.failUnlessEqual(o['sambaSID'], ['foo-%s' % (2*3000+1000)])
+            self.failUnlessEqual(o['sambaSID'], ['foo-%s' % (2 * 3000 + 1000)])
             o['uidNumber'] = ['0']
-            self.failUnlessEqual(o['sambaSID'], ['foo-%s' % (2*0+1000)])
+            self.failUnlessEqual(o['sambaSID'], ['foo-%s' % (2 * 0 + 1000)])
             o['uidNumber'] = ['16000']
-            self.failUnlessEqual(o['sambaSID'], ['foo-%s' % (2*16000+1000)])
+            self.failUnlessEqual(o['sambaSID'], ['foo-%s' % (2 * 16000 + 1000)])
+
         d.addCallback(cb)
         return d
 
     def testSambaSID_preExisting(self):
         """Test that sambaSID field is updated based on uidNumber."""
         client = testutil.LDAPClientTestDriver()
-        o=ldapsyntax.LDAPEntryWithAutoFill(client=client,
+        o = ldapsyntax.LDAPEntryWithAutoFill(client=client,
                                            dn='cn=foo,dc=example,dc=com',
                                            attributes={
             'objectClass': ['sambaSamAccount', 'other'],
             'uidNumber': ['1000'],
             })
         d = o.addAutofiller(sambaSamAccount.Autofill_samba(domainSID='foo'))
+
         def cb(dummy):
             client.assertNothingSent()
 
             self.failUnless('sambaSID' in o)
-            self.failUnlessEqual(o['sambaSID'], ['foo-%s' % (2*1000+1000)])
+            self.failUnlessEqual(o['sambaSID'], ['foo-%s' % (2 * 1000 + 1000)])
+
         d.addCallback(cb)
         return d
 
     def testSambaPrimaryGroupSID(self):
         """Test that sambaPrimaryGroupSID field is updated based on gidNumber."""
         client = testutil.LDAPClientTestDriver()
-        o=ldapsyntax.LDAPEntryWithAutoFill(client=client,
+        o = ldapsyntax.LDAPEntryWithAutoFill(client=client,
                                             dn='cn=foo,dc=example,dc=com',
                                             attributes={
             'objectClass': ['sambaSamAccount', 'other'],
             })
         d = o.addAutofiller(sambaSamAccount.Autofill_samba(domainSID='foo'))
+
         def cb(dummy):
             client.assertNothingSent()
 
             o['gidNumber'] = ['1000']
             self.failUnless('sambaPrimaryGroupSID' in o)
-            self.failUnlessEqual(o['sambaPrimaryGroupSID'], ['foo-%s' % (2*1000+1001)])
+            self.failUnlessEqual(o['sambaPrimaryGroupSID'], ['foo-%s' % (2 * 1000 + 1001)])
             o['gidNumber'] = ['1001']
-            self.failUnlessEqual(o['sambaPrimaryGroupSID'], ['foo-%s' % (2*1001+1001)])
+            self.failUnlessEqual(o['sambaPrimaryGroupSID'], ['foo-%s' % (2 * 1001 + 1001)])
             o['gidNumber'] = ['1002']
-            self.failUnlessEqual(o['sambaPrimaryGroupSID'], ['foo-%s' % (2*1002+1001)])
+            self.failUnlessEqual(o['sambaPrimaryGroupSID'], ['foo-%s' % (2 * 1002 + 1001)])
             o['gidNumber'] = ['2000']
-            self.failUnlessEqual(o['sambaPrimaryGroupSID'], ['foo-%s' % (2*2000+1001)])
+            self.failUnlessEqual(o['sambaPrimaryGroupSID'], ['foo-%s' % (2 * 2000 + 1001)])
             o['gidNumber'] = ['3000']
-            self.failUnlessEqual(o['sambaPrimaryGroupSID'], ['foo-%s' % (2*3000+1001)])
+            self.failUnlessEqual(o['sambaPrimaryGroupSID'], ['foo-%s' % (2 * 3000 + 1001)])
             o['gidNumber'] = ['0']
-            self.failUnlessEqual(o['sambaPrimaryGroupSID'], ['foo-%s' % (2*0+1001)])
+            self.failUnlessEqual(o['sambaPrimaryGroupSID'], ['foo-%s' % (2 * 0 + 1001)])
             o['gidNumber'] = ['16000']
-            self.failUnlessEqual(o['sambaPrimaryGroupSID'], ['foo-%s' % (2*16000+1001)])
+            self.failUnlessEqual(o['sambaPrimaryGroupSID'], ['foo-%s' % (2 * 16000 + 1001)])
+
         d.addCallback(cb)
         return d
 
     def testSambaPrimaryGroupSID_preExisting(self):
         """Test that sambaPrimaryGroupSID field is updated based on gidNumber."""
         client = testutil.LDAPClientTestDriver()
-        o=ldapsyntax.LDAPEntryWithAutoFill(client=client,
+        o = ldapsyntax.LDAPEntryWithAutoFill(client=client,
                                             dn='cn=foo,dc=example,dc=com',
                                             attributes={
             'objectClass': ['sambaSamAccount', 'other'],
             'gidNumber': ['1000'],
             })
         d = o.addAutofiller(sambaSamAccount.Autofill_samba(domainSID='foo'))
+
         def cb(dummy):
             client.assertNothingSent()
 
             self.failUnless('sambaPrimaryGroupSID' in o)
-            self.failUnlessEqual(o['sambaPrimaryGroupSID'], ['foo-%s' % (2*1000+1001)])
+            self.failUnlessEqual(o['sambaPrimaryGroupSID'], ['foo-%s' % (2 * 1000 + 1001)])
+
         d.addCallback(cb)
         return d
 
     def testSambaPrimaryGroupSID_notUpdatedWhenFixed(self):
         """Test that sambaPrimaryGroupSID field is updated based on gidNumber."""
         client = testutil.LDAPClientTestDriver()
-        o=ldapsyntax.LDAPEntryWithAutoFill(client=client,
+        o = ldapsyntax.LDAPEntryWithAutoFill(client=client,
                                             dn='cn=foo,dc=example,dc=com',
                                             attributes={
             'objectClass': ['sambaSamAccount', 'other'],
             })
         d = o.addAutofiller(sambaSamAccount.Autofill_samba(domainSID='foo',
                                                            fixedPrimaryGroupSID=4242))
+
         def cb(dummy):
             client.assertNothingSent()
 
@@ -311,5 +332,6 @@ class LDAPAutoFill_sambaSamAccount(unittest.TestCase):
             o['gidNumber'] = ['1000']
             self.failUnless('sambaPrimaryGroupSID' in o)
             self.failUnlessEqual(o['sambaPrimaryGroupSID'], ['foo-4242'])
+
         d.addCallback(cb)
         return d

--- a/ldaptor/test/test_config.py
+++ b/ldaptor/test/test_config.py
@@ -2,14 +2,17 @@
 Test cases for the ldaptor.config module.
 """
 
-from twisted.trial import unittest
 import os
+
+from twisted.trial import unittest
 from ldaptor import config
 
+
 def writeFile(path, content):
-    f = file(path, 'w')
+    f = open(path, 'w')
     f.write(content)
     f.close()
+
 
 class TestConfig(unittest.TestCase):
     def testSomething(self):

--- a/ldaptor/test/test_config.py
+++ b/ldaptor/test/test_config.py
@@ -36,10 +36,10 @@ fooVar = val2
             reload=True)
 
         val = self.cfg.get('fooSection', 'fooVar')
-        self.assertEquals(val, 'val2')
+        self.assertEqual(val, 'val2')
 
         val = self.cfg.get('barSection', 'barVar')
-        self.assertEquals(val, 'anotherVal')
+        self.assertEqual(val, 'anotherVal')
 
 class IdentitySearch(unittest.TestCase):
     def setUp(self):
@@ -56,15 +56,15 @@ identity-search = (something=%(name)s)
         self.config = config.LDAPConfig()
 
     def testConfig(self):
-        self.assertEquals(self.config.getIdentitySearch('foo'),
+        self.assertEqual(self.config.getIdentitySearch('foo'),
                           '(something=foo)')
 
     def testCopy(self):
         conf = self.config.copy(identitySearch='(&(bar=baz)(quux=%(name)s))')
-        self.assertEquals(conf.getIdentitySearch('foo'),
+        self.assertEqual(conf.getIdentitySearch('foo'),
                           '(&(bar=baz)(quux=foo))')
 
     def testInitArg(self):
         conf = config.LDAPConfig(identitySearch='(&(bar=thud)(quux=%(name)s))')
-        self.assertEquals(conf.getIdentitySearch('foo'),
+        self.assertEqual(conf.getIdentitySearch('foo'),
                           '(&(bar=thud)(quux=foo))')

--- a/ldaptor/test/test_connector.py
+++ b/ldaptor/test/test_connector.py
@@ -33,7 +33,7 @@ class TestCallableOverride(unittest.TestCase):
                           overrides={
             'dc=example,dc=com': ('server.example.com', 1389),
             })
-        self.assertEquals(o, ('server.example.com', 1389))
+        self.assertEqual(o, ('server.example.com', 1389))
 
     def testFindOverride_root(self):
         """Empty dn can be used as override."""
@@ -44,4 +44,4 @@ class TestCallableOverride(unittest.TestCase):
                           overrides={
             '': ('server.example.com', 1389),
             })
-        self.assertEquals(o, ('server.example.com', 1389))
+        self.assertEqual(o, ('server.example.com', 1389))

--- a/ldaptor/test/test_delta.py
+++ b/ldaptor/test/test_delta.py
@@ -101,7 +101,7 @@ class TestModifications(unittest.TestCase):
 class TestModificationOpLDIF(unittest.TestCase):
     def testAdd(self):
         m=delta.Add('foo', ['bar', 'baz'])
-        self.assertEquals(m.asLDIF(),
+        self.assertEqual(m.asLDIF(),
                           """\
 add: foo
 foo: bar
@@ -111,7 +111,7 @@ foo: baz
 
     def testDelete(self):
         m=delta.Delete('foo', ['bar', 'baz'])
-        self.assertEquals(m.asLDIF(),
+        self.assertEqual(m.asLDIF(),
                           """\
 delete: foo
 foo: bar
@@ -121,7 +121,7 @@ foo: baz
 
     def testDeleteAll(self):
         m=delta.Delete('foo')
-        self.assertEquals(m.asLDIF(),
+        self.assertEqual(m.asLDIF(),
                           """\
 delete: foo
 -
@@ -129,7 +129,7 @@ delete: foo
 
     def testReplace(self):
         m=delta.Replace('foo', ['bar', 'baz'])
-        self.assertEquals(m.asLDIF(),
+        self.assertEqual(m.asLDIF(),
                           """\
 replace: foo
 foo: bar
@@ -139,7 +139,7 @@ foo: baz
 
     def testReplaceAll(self):
         m=delta.Replace('thud')
-        self.assertEquals(m.asLDIF(),
+        self.assertEqual(m.asLDIF(),
                           """\
 replace: thud
 -
@@ -152,7 +152,7 @@ class TestAddOpLDIF(unittest.TestCase):
             dn='dc=example,dc=com',
             attributes={'foo': ['bar', 'baz'],
                         'quux': ['thud']}))
-        self.assertEquals(op.asLDIF(),
+        self.assertEqual(op.asLDIF(),
                           """\
 dn: dc=example,dc=com
 changetype: add
@@ -166,7 +166,7 @@ quux: thud
 class TestDeleteOpLDIF(unittest.TestCase):
     def testSimple(self):
         op=delta.DeleteOp('dc=example,dc=com')
-        self.assertEquals(op.asLDIF(),
+        self.assertEqual(op.asLDIF(),
                           """\
 dn: dc=example,dc=com
 changetype: delete
@@ -185,7 +185,7 @@ class TestOperationLDIF(unittest.TestCase):
             delta.Replace('telephonenumber', ['+1 408 555 1234', '+1 408 555 5678']),
             delta.Delete('facsimiletelephonenumber', ['+1 408 555 9876']),
             ])
-        self.assertEquals(op.asLDIF(),
+        self.assertEqual(op.asLDIF(),
                           """\
 dn: cn=Paula Jensen,ou=Product Development,dc=airius,dc=com
 changetype: modify
@@ -208,7 +208,7 @@ class TestModificationComparison(unittest.TestCase):
     def testEquality_Add_True(self):
         a = delta.Add('k', ['b', 'c', 'd'])
         b = delta.Add('k', ['b', 'c', 'd'])
-        self.assertEquals(a, b)
+        self.assertEqual(a, b)
 
     def testEquality_AddVsDelete_False(self):
         a = delta.Add('k', ['b', 'c', 'd'])

--- a/ldaptor/test/test_distinguishedname.py
+++ b/ldaptor/test/test_distinguishedname.py
@@ -20,7 +20,7 @@ class TestCaseWithKnownValues(unittest.TestCase):
                 listOfRDNs.append(r)
             fromList = dn.DistinguishedName(listOfRDNs)
 
-            self.assertEquals(fromString, fromList)
+            self.assertEqual(fromString, fromList)
 
             fromStringToString = str(fromString)
             fromListToString = str(fromList)
@@ -31,17 +31,17 @@ class TestCaseWithKnownValues(unittest.TestCase):
             # DNs equal their string representation. Note this does
             # not mean they equal all the possible string
             # representations -- just the canonical one.
-            self.assertEquals(fromString, canon)
-            self.assertEquals(fromList, canon)
-            self.assertEquals(canon, fromString)
-            self.assertEquals(canon, fromList)
+            self.assertEqual(fromString, canon)
+            self.assertEqual(fromList, canon)
+            self.assertEqual(canon, fromString)
+            self.assertEqual(canon, fromList)
 
             # DNs can be used interchangeably with their canonical
             # string representation as hash keys.
-            self.assertEquals(hash(fromString), hash(canon))
-            self.assertEquals(hash(fromList), hash(canon))
-            self.assertEquals(hash(canon), hash(fromString))
-            self.assertEquals(hash(canon), hash(fromList))
+            self.assertEqual(hash(fromString), hash(canon))
+            self.assertEqual(hash(fromList), hash(canon))
+            self.assertEqual(hash(canon), hash(fromString))
+            self.assertEqual(hash(canon), hash(fromList))
 
 
 class LDAPDistinguishedName_Escaping(TestCaseWithKnownValues):
@@ -120,7 +120,7 @@ class LDAPDistinguishedName_Escaping(TestCaseWithKnownValues):
             dn.RelativeDistinguishedName('dc=com'),
             ])
         got = str(got)
-        self.assertEquals(got,
+        self.assertEqual(got,
                           r'cn=test+owner=uid\=foo\,ou\=depar'
                           +r'tment\,dc\=example\,dc\=com,dc=ex'
                           +r'ample,dc=com')
@@ -304,22 +304,22 @@ class LDAPDistinguishedName_Prettify(unittest.TestCase):
 class DistinguishedName_Init(unittest.TestCase):
     def testString(self):
         d=dn.DistinguishedName('dc=example,dc=com')
-        self.assertEquals(str(d), 'dc=example,dc=com')
+        self.assertEqual(str(d), 'dc=example,dc=com')
 
     def testDN(self):
         proto=dn.DistinguishedName('dc=example,dc=com')
         d=dn.DistinguishedName(proto)
-        self.assertEquals(str(d), 'dc=example,dc=com')
+        self.assertEqual(str(d), 'dc=example,dc=com')
 
 class RelativeDistinguishedName_Init(unittest.TestCase):
     def testString(self):
         rdn=dn.RelativeDistinguishedName('dc=example')
-        self.assertEquals(str(rdn), 'dc=example')
+        self.assertEqual(str(rdn), 'dc=example')
 
     def testRDN(self):
         proto=dn.RelativeDistinguishedName('dc=example')
         rdn=dn.RelativeDistinguishedName(proto)
-        self.assertEquals(str(rdn), 'dc=example')
+        self.assertEqual(str(rdn), 'dc=example')
 
 class DistinguishedName_Comparison(unittest.TestCase):
     # TODO test more carefully

--- a/ldaptor/test/test_dns.py
+++ b/ldaptor/test/test_dns.py
@@ -7,73 +7,73 @@ from ldaptor import dns
 
 class NetmaskToNumbits(unittest.TestCase):
     def test_classA(self):
-        self.assertEquals(dns.netmaskToNumbits('255.0.0.0'), 8)
+        self.assertEqual(dns.netmaskToNumbits('255.0.0.0'), 8)
 
     def test_classB(self):
-        self.assertEquals(dns.netmaskToNumbits('255.255.0.0'), 16)
+        self.assertEqual(dns.netmaskToNumbits('255.255.0.0'), 16)
 
     def test_classC(self):
-        self.assertEquals(dns.netmaskToNumbits('255.255.255.0'), 24)
+        self.assertEqual(dns.netmaskToNumbits('255.255.255.0'), 24)
 
     def test_host(self):
-        self.assertEquals(dns.netmaskToNumbits('255.255.255.255'), 32)
+        self.assertEqual(dns.netmaskToNumbits('255.255.255.255'), 32)
 
     def test_numbits(self):
         for i in range(0, 33):
-            self.assertEquals(dns.netmaskToNumbits(str(i)), i)
+            self.assertEqual(dns.netmaskToNumbits(str(i)), i)
 
     def test_CIDR(self):
         for i in range(0, 33):
             mask = dns.ntoa(dns.aton(i))
-            self.assertEquals(dns.netmaskToNumbits(mask), i)
+            self.assertEqual(dns.netmaskToNumbits(mask), i)
 
 class PtrSoaName(unittest.TestCase):
     def test_classA(self):
-        self.assertEquals(dns.ptrSoaName('1.2.3.4', '255.0.0.0'),
+        self.assertEqual(dns.ptrSoaName('1.2.3.4', '255.0.0.0'),
                           '1.in-addr.arpa.')
-        self.assertEquals(dns.ptrSoaName('1.2.3.4', '8'),
+        self.assertEqual(dns.ptrSoaName('1.2.3.4', '8'),
                           '1.in-addr.arpa.')
 
     def test_classB(self):
-        self.assertEquals(dns.ptrSoaName('1.2.3.4', '255.255.0.0'),
+        self.assertEqual(dns.ptrSoaName('1.2.3.4', '255.255.0.0'),
                           '2.1.in-addr.arpa.')
-        self.assertEquals(dns.ptrSoaName('1.2.3.4', '16'),
+        self.assertEqual(dns.ptrSoaName('1.2.3.4', '16'),
                           '2.1.in-addr.arpa.')
 
     def test_classC(self):
-        self.assertEquals(dns.ptrSoaName('1.2.3.4', '255.255.255.0'),
+        self.assertEqual(dns.ptrSoaName('1.2.3.4', '255.255.255.0'),
                           '3.2.1.in-addr.arpa.')
-        self.assertEquals(dns.ptrSoaName('1.2.3.4', '24'),
+        self.assertEqual(dns.ptrSoaName('1.2.3.4', '24'),
                           '3.2.1.in-addr.arpa.')
 
     def test_CIDR_9(self):
-        self.assertEquals(dns.ptrSoaName('1.2.3.4', '9'),
+        self.assertEqual(dns.ptrSoaName('1.2.3.4', '9'),
                           '0/9.1.in-addr.arpa.')
-        self.assertEquals(dns.ptrSoaName('1.200.3.4', '9'),
+        self.assertEqual(dns.ptrSoaName('1.200.3.4', '9'),
                           '128/9.1.in-addr.arpa.')
 
     def test_CIDR_12(self):
-        self.assertEquals(dns.ptrSoaName('1.2.3.4', '12'),
+        self.assertEqual(dns.ptrSoaName('1.2.3.4', '12'),
                           '0/12.1.in-addr.arpa.')
-        self.assertEquals(dns.ptrSoaName('1.200.3.4', '12'),
+        self.assertEqual(dns.ptrSoaName('1.200.3.4', '12'),
                           '192/12.1.in-addr.arpa.')
 
     def test_CIDR_13(self):
-        self.assertEquals(dns.ptrSoaName('1.2.3.4', '13'),
+        self.assertEqual(dns.ptrSoaName('1.2.3.4', '13'),
                           '0/13.1.in-addr.arpa.')
-        self.assertEquals(dns.ptrSoaName('1.200.3.4', '13'),
+        self.assertEqual(dns.ptrSoaName('1.200.3.4', '13'),
                           '200/13.1.in-addr.arpa.')
 
     def test_CIDR_15(self):
-        self.assertEquals(dns.ptrSoaName('1.2.3.4', '15'),
+        self.assertEqual(dns.ptrSoaName('1.2.3.4', '15'),
                           '2/15.1.in-addr.arpa.')
-        self.assertEquals(dns.ptrSoaName('1.200.3.4', '15'),
+        self.assertEqual(dns.ptrSoaName('1.200.3.4', '15'),
                           '200/15.1.in-addr.arpa.')
 
     def test_CIDR_29(self):
-        self.assertEquals(dns.ptrSoaName('1.2.3.4', '29'),
+        self.assertEqual(dns.ptrSoaName('1.2.3.4', '29'),
                           '0/29.3.2.1.in-addr.arpa.')
 
     def test_CIDR_30(self):
-        self.assertEquals(dns.ptrSoaName('1.2.3.4', '30'),
+        self.assertEqual(dns.ptrSoaName('1.2.3.4', '30'),
                           '4/30.3.2.1.in-addr.arpa.')

--- a/ldaptor/test/test_entry_diff.py
+++ b/ldaptor/test/test_entry_diff.py
@@ -16,7 +16,7 @@ class TestDiffEntry(unittest.TestCase):
             'foo': ['bar'],
             })
         result = a.diff(b)
-        self.assertEquals(result, None)
+        self.assertEqual(result, None)
 
     def testAdd_New_OneType_OneValue(self):
         a = entry.BaseLDAPEntry(dn='dc=foo',
@@ -29,7 +29,7 @@ class TestDiffEntry(unittest.TestCase):
             'baz': ['quux'],
             })
         result = a.diff(b)
-        self.assertEquals(result,
+        self.assertEqual(result,
                           delta.ModifyOp('dc=foo',
                                          [
             delta.Add('baz', ['quux']),
@@ -46,7 +46,7 @@ class TestDiffEntry(unittest.TestCase):
             'baz': ['quux', 'thud', 'foo'],
             })
         result = a.diff(b)
-        self.assertEquals(result,
+        self.assertEqual(result,
                           delta.ModifyOp('dc=foo',
                                          [
             delta.Add('baz', ['quux', 'thud', 'foo']),
@@ -64,7 +64,7 @@ class TestDiffEntry(unittest.TestCase):
             'bang': ['thud'],
             })
         result = a.diff(b)
-        self.assertEquals(result,
+        self.assertEqual(result,
                           delta.ModifyOp('dc=foo',
                                          [
             delta.Add('bang', ['thud']),
@@ -81,7 +81,7 @@ class TestDiffEntry(unittest.TestCase):
             'foo': ['bar', 'quux'],
             })
         result = a.diff(b)
-        self.assertEquals(result,
+        self.assertEqual(result,
                           delta.ModifyOp('dc=foo',
                                          [
             delta.Add('foo', ['quux']),
@@ -97,7 +97,7 @@ class TestDiffEntry(unittest.TestCase):
             'foo': ['bar', 'quux', 'thud', 'foo'],
             })
         result = a.diff(b)
-        self.assertEquals(result,
+        self.assertEqual(result,
                           delta.ModifyOp('dc=foo',
                                          [
             delta.Add('foo', ['quux', 'thud', 'foo']),
@@ -116,7 +116,7 @@ class TestDiffEntry(unittest.TestCase):
             'bang': ['thud', 'barble'],
             })
         result = a.diff(b)
-        self.assertEquals(result,
+        self.assertEqual(result,
                           delta.ModifyOp('dc=foo',
                                          [
             delta.Add('bang', ['thud', 'barble']),
@@ -135,7 +135,7 @@ class TestDiffEntry(unittest.TestCase):
             'foo': ['bar'],
             })
         result = a.diff(b)
-        self.assertEquals(result,
+        self.assertEqual(result,
                           delta.ModifyOp('dc=foo',
                                          [
             delta.Delete('baz', ['quux', 'thud']),
@@ -153,7 +153,7 @@ class TestDiffEntry(unittest.TestCase):
             'baz': ['thud'],
             })
         result = a.diff(b)
-        self.assertEquals(result,
+        self.assertEqual(result,
                           delta.ModifyOp('dc=foo',
                                          [
             delta.Delete('baz', ['quux']),
@@ -172,7 +172,7 @@ class TestDiffEntry(unittest.TestCase):
             'telephonenumber': ['+1 408 555 1234', '+1 408 555 5678'],
             })
         result = a.diff(b)
-        self.assertEquals(result,
+        self.assertEqual(result,
                           delta.ModifyOp('cn=Paula Jensen,ou=Product Development,dc=airius,dc=com',
                                          [
             delta.Add('postalAddress', ['123 Anystreet $ Sunnyvale, CA $ 94086']),

--- a/ldaptor/test/test_examples.py
+++ b/ldaptor/test/test_examples.py
@@ -53,7 +53,7 @@ class LDAPServerWithUPNBind(unittest.TestCase):
                         dn=bind_dn,
                         auth=password),
                     id=4)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -87,7 +87,7 @@ class LDAPServerWithUPNBind(unittest.TestCase):
                         dn='bob@ad.example.com',
                         auth='invalid'),
                     id=734)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(

--- a/ldaptor/test/test_inmemory.py
+++ b/ldaptor/test/test_inmemory.py
@@ -57,7 +57,7 @@ class TestInMemoryDatabase(unittest.TestCase):
     def test_children_oneChild(self):
         d = self.oneChild.children()
         def cb(children):
-            self.assertEquals(len(children), 1)
+            self.assertEqual(len(children), 1)
             got = [e.dn for e in children]
             want = [distinguishedname.DistinguishedName('cn=theChild,ou=oneChild,dc=example,dc=com')]
             got.sort()
@@ -70,7 +70,7 @@ class TestInMemoryDatabase(unittest.TestCase):
         """Test that .children() returns a copy of the data so that modifying it does not affect behaviour."""
         d = self.oneChild.children()
         def cb1(children1):
-            self.assertEquals(len(children1), 1)
+            self.assertEqual(len(children1), 1)
 
             children1.pop()
 
@@ -79,14 +79,14 @@ class TestInMemoryDatabase(unittest.TestCase):
         d.addCallback(cb1)
 
         def cb2(children2):
-            self.assertEquals(len(children2), 1)
+            self.assertEqual(len(children2), 1)
         d.addCallback(cb2)
         return d
 
     def test_children_twoChildren(self):
         d = self.meta.children()
         def cb(children):
-            self.assertEquals(len(children), 2)
+            self.assertEqual(len(children), 2)
             want = [
                 distinguishedname.DistinguishedName('cn=foo,ou=metasyntactic,dc=example,dc=com'),
                 distinguishedname.DistinguishedName('cn=bar,ou=metasyntactic,dc=example,dc=com'),
@@ -105,7 +105,7 @@ class TestInMemoryDatabase(unittest.TestCase):
             })
         d = self.empty.children()
         def cb(children):
-            self.assertEquals(len(children), 1)
+            self.assertEqual(len(children), 1)
             got = [e.dn for e in children]
             want = [
                 distinguishedname.DistinguishedName('a=b,ou=empty,dc=example,dc=com'),
@@ -126,15 +126,15 @@ class TestInMemoryDatabase(unittest.TestCase):
             })
 
     def test_parent(self):
-        self.assertEquals(self.foo.parent(), self.meta)
-        self.assertEquals(self.meta.parent(), self.root)
-        self.assertEquals(self.root.parent(), None)
+        self.assertEqual(self.foo.parent(), self.meta)
+        self.assertEqual(self.meta.parent(), self.root)
+        self.assertEqual(self.root.parent(), None)
 
 
     def test_subtree_empty(self):
         d = self.empty.subtree()
         def cb(entries):
-            self.assertEquals(len(entries), 1)
+            self.assertEqual(len(entries), 1)
         d.addCallback(cb)
         return d
 
@@ -149,7 +149,7 @@ class TestInMemoryDatabase(unittest.TestCase):
     def test_subtree_oneChild_cb(self):
         got = []
         d = self.oneChild.subtree(got.append)
-        d.addCallback(self.assertEquals, None)
+        d.addCallback(self.assertEqual, None)
         def cb(dummy):
             want = [
                 self.oneChild,
@@ -180,7 +180,7 @@ class TestInMemoryDatabase(unittest.TestCase):
         got = []
         d = self.root.subtree(callback=got.append)
         def cb(r):
-            self.assertEquals(r, None)
+            self.assertEqual(r, None)
 
             want = [
                 self.root,
@@ -200,7 +200,7 @@ class TestInMemoryDatabase(unittest.TestCase):
         d = self.root.lookup(dn)
         def eb(fail):
             fail.trap(ldaperrors.LDAPNoSuchObject)
-            self.assertEquals(fail.value.message, dn)
+            self.assertEqual(fail.value.message, dn)
         d.addCallbacks(testutil.mustRaise, eb)
         return d
 
@@ -209,14 +209,14 @@ class TestInMemoryDatabase(unittest.TestCase):
         d = self.root.lookup(dn)
         def eb(fail):
             fail.trap(ldaperrors.LDAPNoSuchObject)
-            self.assertEquals(fail.value.message, dn)
+            self.assertEqual(fail.value.message, dn)
         d.addCallbacks(testutil.mustRaise, eb)
         return d
 
     def test_lookup_deep(self):
         dn = distinguishedname.DistinguishedName('cn=bar,ou=metasyntactic,dc=example,dc=com')
         d = self.root.lookup(dn)
-        d.addCallback(self.assertEquals, self.bar)
+        d.addCallback(self.assertEqual, self.bar)
         return d
 
     def test_delete_root(self):
@@ -237,14 +237,14 @@ class TestInMemoryDatabase(unittest.TestCase):
 
     def test_delete(self):
         d = self.foo.delete()
-        d.addCallback(self.assertEquals, self.foo)
+        d.addCallback(self.assertEqual, self.foo)
         d.addCallback(lambda _: self.meta.children())
         d.addCallback(self.assertItemsEqual, [self.bar])
         return d
 
     def test_deleteChild(self):
         d = self.meta.deleteChild('cn=bar')
-        d.addCallback(self.assertEquals, self.bar)
+        d.addCallback(self.assertEqual, self.bar)
         d.addCallback(lambda _: self.meta.children())
         d.addCallback(self.assertItemsEqual, [self.foo])
         return d
@@ -259,7 +259,7 @@ class TestInMemoryDatabase(unittest.TestCase):
     def test_setPassword(self):
         self.foo.setPassword('s3krit', salt='\xf2\x4a')
         self.failUnless('userPassword' in self.foo)
-        self.assertEquals(self.foo['userPassword'],
+        self.assertEqual(self.foo['userPassword'],
                           ['{SSHA}0n/Iw1NhUOKyaI9gm9v5YsO3ZInySg=='])
 
     def test_setPassword_noSalt(self):
@@ -278,7 +278,7 @@ class TestInMemoryDatabase(unittest.TestCase):
         d = self.root.search(filterText='(|(cn=foo)(cn=bar))',
                              callback=got.append)
         def cb(r):
-            self.assertEquals(r, None)
+            self.assertEqual(r, None)
 
             want = [
                 self.bar,
@@ -392,7 +392,7 @@ bValue: c
 ''')
         d = inmemory.fromLDIFFile(ldif)
         def cb1(db):
-            self.assertEquals(
+            self.assertEqual(
                 db.dn,
                 distinguishedname.DistinguishedName('cn=foo,dc=example,dc=com'))
             return db.children()
@@ -413,13 +413,13 @@ cn: foo
 ''')
         d = inmemory.fromLDIFFile(ldif)
         def cb1(db):
-            self.assertEquals(
+            self.assertEqual(
                 db.dn,
                 distinguishedname.DistinguishedName('dc=example,dc=com'))
             return db.subtree()
         d.addCallback(cb1)
         def cb2(children):
-            self.assertEquals(len(children), 2)
+            self.assertEqual(len(children), 2)
             want = [
                 distinguishedname.DistinguishedName('dc=example,dc=com'),
                 distinguishedname.DistinguishedName('cn=foo,dc=example,dc=com'),
@@ -461,7 +461,7 @@ class TestDiff(unittest.TestCase):
             'dc': ['example'],
             })
         d = a.diffTree(b)
-        d.addCallback(self.assertEquals, [])
+        d.addCallback(self.assertEqual, [])
         return d
 
     def testRootChange_Add(self):
@@ -475,7 +475,7 @@ class TestDiff(unittest.TestCase):
             'foo': ['bar'],
             })
         d = a.diffTree(b)
-        d.addCallback(self.assertEquals,
+        d.addCallback(self.assertEqual,
                       [ delta.ModifyOp('dc=example,dc=com',
                                        [
             delta.Add('foo', ['bar']),
@@ -500,7 +500,7 @@ class TestDiff(unittest.TestCase):
                      'foo': ['bar'],
                      })
         d = a.diffTree(b)
-        d.addCallback(self.assertEquals,
+        d.addCallback(self.assertEqual,
                       [ delta.ModifyOp('cn=foo,dc=example,dc=com',
                                        [
             delta.Add('foo', ['bar']),
@@ -528,7 +528,7 @@ class TestDiff(unittest.TestCase):
             })
 
         d = a.diffTree(b)
-        d.addCallback(self.assertEquals, [
+        d.addCallback(self.assertEqual, [
             delta.AddOp(bar),
             delta.AddOp(foo),
             ])
@@ -560,7 +560,7 @@ class TestDiff(unittest.TestCase):
             })
 
         d = a.diffTree(b)
-        d.addCallback(self.assertEquals, [
+        d.addCallback(self.assertEqual, [
             delta.AddOp(bar),
             delta.AddOp(foo),
             delta.AddOp(baz),
@@ -587,7 +587,7 @@ class TestDiff(unittest.TestCase):
             })
 
         d = a.diffTree(b)
-        d.addCallback(self.assertEquals, [
+        d.addCallback(self.assertEqual, [
             delta.DeleteOp(bar),
             delta.DeleteOp(foo),
             ])
@@ -619,7 +619,7 @@ class TestDiff(unittest.TestCase):
             })
 
         d = a.diffTree(b)
-        d.addCallback(self.assertEquals, [
+        d.addCallback(self.assertEqual, [
             delta.DeleteOp(bar),
             delta.DeleteOp(baz),
             delta.DeleteOp(foo),

--- a/ldaptor/test/test_ldapfilter.py
+++ b/ldaptor/test/test_ldapfilter.py
@@ -26,8 +26,8 @@ class RFC2254Examples(unittest.TestCase):
         filt = pureldap.LDAPFilter_equalityMatch(
             attributeDesc=pureldap.LDAPAttributeDescription(value='cn'),
             assertionValue=pureldap.LDAPAssertionValue(value='Babs Jensen'))
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_not_cn(self):
         text = '(!(cn=Tim Howes))'
@@ -35,8 +35,8 @@ class RFC2254Examples(unittest.TestCase):
             pureldap.LDAPFilter_equalityMatch(
             attributeDesc=pureldap.LDAPAttributeDescription(value='cn'),
             assertionValue=pureldap.LDAPAssertionValue(value='Tim Howes')))
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_and_or(self):
         text = '(&(objectClass=Person)(|(sn=Jensen)(cn=Babs J*)))'
@@ -53,8 +53,8 @@ class RFC2254Examples(unittest.TestCase):
                          ])
                                        ]),
               ])
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_substrings(self):
         text = '(o=univ*of*mich*)'
@@ -64,13 +64,13 @@ class RFC2254Examples(unittest.TestCase):
                          pureldap.LDAPFilter_substrings_any(value='of'),
                          pureldap.LDAPFilter_substrings_any(value='mich'),
                          ])
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
 
     def test_extensible_1(self):
         text = '(cn:1.2.3.4.5:=Fred Flintstone)'
-        self.assertEquals(ldapfilter.parseFilter(text),
+        self.assertEqual(ldapfilter.parseFilter(text),
                           pureldap.LDAPFilter_extensibleMatch(
             type='cn',
             dnAttributes=False,
@@ -80,7 +80,7 @@ class RFC2254Examples(unittest.TestCase):
 
     def test_extensible_2(self):
         text = '(sn:dn:2.4.6.8.10:=Barney Rubble)'
-        self.assertEquals(ldapfilter.parseFilter(text),
+        self.assertEqual(ldapfilter.parseFilter(text),
                           pureldap.LDAPFilter_extensibleMatch(
             type='sn',
             dnAttributes=True,
@@ -90,7 +90,7 @@ class RFC2254Examples(unittest.TestCase):
 
     def test_extensible_3(self):
         text = '(o:dn:=Ace Industry)'
-        self.assertEquals(ldapfilter.parseFilter(text),
+        self.assertEqual(ldapfilter.parseFilter(text),
                           pureldap.LDAPFilter_extensibleMatch(
             type='o',
             dnAttributes=True,
@@ -100,7 +100,7 @@ class RFC2254Examples(unittest.TestCase):
 
     def test_extensible_4(self):
         text = '(:dn:2.4.6.8.10:=Dino)'
-        self.assertEquals(ldapfilter.parseFilter(text),
+        self.assertEqual(ldapfilter.parseFilter(text),
                           pureldap.LDAPFilter_extensibleMatch(
             type=None,
             dnAttributes=True,
@@ -113,8 +113,8 @@ class RFC2254Examples(unittest.TestCase):
         filt = pureldap.LDAPFilter_equalityMatch(
             attributeDesc=pureldap.LDAPAttributeDescription(value='o'),
             assertionValue=pureldap.LDAPAssertionValue(value='Parens R Us (for all your parenthetical needs)'))
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_escape_asterisk(self):
         text = r'(cn=*\2A*)'
@@ -122,46 +122,46 @@ class RFC2254Examples(unittest.TestCase):
             type='cn',
             substrings=[ pureldap.LDAPFilter_substrings_any(value='*'),
                          ])
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text.lower())
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text.lower())
 
     def test_escape_backslash(self):
         text = r'(filename=C:\5cMyFile)'
         filt = pureldap.LDAPFilter_equalityMatch(
             attributeDesc=pureldap.LDAPAttributeDescription(value='filename'),
             assertionValue=pureldap.LDAPAssertionValue(value=r'C:\MyFile'))
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_escape_binary(self):
         text = r'(bin=\00\00\00\04)'
         filt = pureldap.LDAPFilter_equalityMatch(
             attributeDesc=pureldap.LDAPAttributeDescription(value='bin'),
             assertionValue=pureldap.LDAPAssertionValue(value='\00\00\00\04'))
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
 
     def test_escape_utf8(self):
         text = r'(sn=Lu\c4\8di\c4\87)'
         filt = pureldap.LDAPFilter_equalityMatch(
             attributeDesc=pureldap.LDAPAttributeDescription(value='sn'),
             assertionValue=pureldap.LDAPAssertionValue(value='Lu\xc4\x8di\xc4\x87'))
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        #self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        #self.assertEqual(filt.asText(), text)
 
 class TestValid(unittest.TestCase):
     def test_item_present(self):
         text = r'(cn=*)'
         filt = pureldap.LDAPFilter_present(value='cn')
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_item_simple(self):
         text = r'(cn=foo)'
         filt = pureldap.LDAPFilter_equalityMatch(
             attributeDesc=pureldap.LDAPAttributeDescription(value='cn'),
             assertionValue=pureldap.LDAPAssertionValue(value='foo'))
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_item_substring_init(self):
         text = r'(cn=foo*)'
@@ -169,8 +169,8 @@ class TestValid(unittest.TestCase):
             type='cn',
             substrings=[pureldap.LDAPFilter_substrings_initial('foo'),
                         ])
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_item_substring_final(self):
         text = r'(cn=*foo)'
@@ -178,8 +178,8 @@ class TestValid(unittest.TestCase):
             type='cn',
             substrings=[pureldap.LDAPFilter_substrings_final('foo'),
                         ])
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_item_substring_any(self):
         text = r'(cn=*foo*)'
@@ -187,8 +187,8 @@ class TestValid(unittest.TestCase):
             type='cn',
             substrings=[pureldap.LDAPFilter_substrings_any('foo'),
                         ])
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_item_substring_aa(self):
         text = r'(cn=*foo*bar*)'
@@ -197,8 +197,8 @@ class TestValid(unittest.TestCase):
             substrings=[pureldap.LDAPFilter_substrings_any('foo'),
                         pureldap.LDAPFilter_substrings_any('bar'),
                         ])
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_item_substring_ia(self):
         text = r'(cn=foo*bar*)'
@@ -207,8 +207,8 @@ class TestValid(unittest.TestCase):
             substrings=[pureldap.LDAPFilter_substrings_initial('foo'),
                         pureldap.LDAPFilter_substrings_any('bar'),
                         ])
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_item_substring_iaa(self):
         text = r'(cn=foo*bar*baz*)'
@@ -218,8 +218,8 @@ class TestValid(unittest.TestCase):
                         pureldap.LDAPFilter_substrings_any('bar'),
                         pureldap.LDAPFilter_substrings_any('baz'),
                         ])
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_item_substring_if(self):
         text = r'(cn=foo*bar)'
@@ -228,8 +228,8 @@ class TestValid(unittest.TestCase):
             substrings=[pureldap.LDAPFilter_substrings_initial('foo'),
                         pureldap.LDAPFilter_substrings_final('bar'),
                         ])
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_item_substring_iaf(self):
         text = r'(cn=foo*bar*baz)'
@@ -239,8 +239,8 @@ class TestValid(unittest.TestCase):
                         pureldap.LDAPFilter_substrings_any('bar'),
                         pureldap.LDAPFilter_substrings_final('baz'),
                         ])
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_item_substring_iaaf(self):
         text = r'(cn=foo*bar*baz*quux)'
@@ -251,8 +251,8 @@ class TestValid(unittest.TestCase):
                         pureldap.LDAPFilter_substrings_any('baz'),
                         pureldap.LDAPFilter_substrings_final('quux'),
                         ])
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_item_substring_af(self):
         text = r'(cn=*foo*bar)'
@@ -261,8 +261,8 @@ class TestValid(unittest.TestCase):
             substrings=[pureldap.LDAPFilter_substrings_any('foo'),
                         pureldap.LDAPFilter_substrings_final('bar'),
                         ])
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_item_substring_aaf(self):
         text = r'(cn=*foo*bar*baz)'
@@ -272,8 +272,8 @@ class TestValid(unittest.TestCase):
                         pureldap.LDAPFilter_substrings_any('bar'),
                         pureldap.LDAPFilter_substrings_final('baz'),
                         ])
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_not_item(self):
         text = r'(!(cn=foo))'
@@ -281,8 +281,8 @@ class TestValid(unittest.TestCase):
             pureldap.LDAPFilter_equalityMatch(
             attributeDesc=pureldap.LDAPAttributeDescription(value='cn'),
             assertionValue=pureldap.LDAPAssertionValue(value='foo')))
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_or_item(self):
         text = r'(|(cn=foo)(cn=bar))'
@@ -294,8 +294,8 @@ class TestValid(unittest.TestCase):
             attributeDesc=pureldap.LDAPAttributeDescription(value='cn'),
             assertionValue=pureldap.LDAPAssertionValue(value='bar')),
             ])
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_and_item(self):
         text = r'(&(cn=foo)(cn=bar))'
@@ -307,8 +307,8 @@ class TestValid(unittest.TestCase):
             attributeDesc=pureldap.LDAPAttributeDescription(value='cn'),
             assertionValue=pureldap.LDAPAssertionValue(value='bar')),
             ])
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_andornot(self):
         text = r'(&(!(|(cn=foo)(cn=bar)))(sn=a*b*c*d))'
@@ -329,16 +329,16 @@ class TestValid(unittest.TestCase):
                         pureldap.LDAPFilter_substrings_any('c'),
                         pureldap.LDAPFilter_substrings_final('d'),
                         ])])
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_whitespace_beforeCloseParen(self):
         text = r'(cn=foo )'
         filt = pureldap.LDAPFilter_equalityMatch(
             attributeDesc=pureldap.LDAPAttributeDescription(value='cn'),
             assertionValue=pureldap.LDAPAssertionValue(value='foo '))
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
 
     def test_whitespace_afterEq(self):
@@ -346,8 +346,8 @@ class TestValid(unittest.TestCase):
         filt = pureldap.LDAPFilter_equalityMatch(
             attributeDesc=pureldap.LDAPAttributeDescription(value='cn'),
             assertionValue=pureldap.LDAPAssertionValue(value=' foo'))
-        self.assertEquals(ldapfilter.parseFilter(text), filt)
-        self.assertEquals(filt.asText(), text)
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
 class TestInvalid(unittest.TestCase):
     def test_closeParen_1(self):
@@ -415,14 +415,14 @@ class TestMaybeSubstring(unittest.TestCase):
     def test_item_present(self):
         text = r'*'
         filt = pureldap.LDAPFilter_present(value='cn')
-        self.assertEquals(ldapfilter.parseMaybeSubstring('cn', text), filt)
+        self.assertEqual(ldapfilter.parseMaybeSubstring('cn', text), filt)
 
     def test_item_simple(self):
         text = r'foo'
         filt = pureldap.LDAPFilter_equalityMatch(
             attributeDesc=pureldap.LDAPAttributeDescription(value='cn'),
             assertionValue=pureldap.LDAPAssertionValue(value='foo'))
-        self.assertEquals(ldapfilter.parseMaybeSubstring('cn', text), filt)
+        self.assertEqual(ldapfilter.parseMaybeSubstring('cn', text), filt)
 
     def test_item_substring_init(self):
         text = r'foo*'
@@ -430,7 +430,7 @@ class TestMaybeSubstring(unittest.TestCase):
             type='cn',
             substrings=[pureldap.LDAPFilter_substrings_initial('foo'),
                         ])
-        self.assertEquals(ldapfilter.parseMaybeSubstring('cn', text), filt)
+        self.assertEqual(ldapfilter.parseMaybeSubstring('cn', text), filt)
 
     def test_item_substring_final(self):
         text = r'*foo'
@@ -438,7 +438,7 @@ class TestMaybeSubstring(unittest.TestCase):
             type='cn',
             substrings=[pureldap.LDAPFilter_substrings_final('foo'),
                         ])
-        self.assertEquals(ldapfilter.parseMaybeSubstring('cn', text), filt)
+        self.assertEqual(ldapfilter.parseMaybeSubstring('cn', text), filt)
 
     def test_item_substring_any(self):
         text = r'*foo*'
@@ -446,7 +446,7 @@ class TestMaybeSubstring(unittest.TestCase):
             type='cn',
             substrings=[pureldap.LDAPFilter_substrings_any('foo'),
                         ])
-        self.assertEquals(ldapfilter.parseMaybeSubstring('cn', text), filt)
+        self.assertEqual(ldapfilter.parseMaybeSubstring('cn', text), filt)
 
     def test_item_substring_aa(self):
         text = r'*foo*bar*'
@@ -455,7 +455,7 @@ class TestMaybeSubstring(unittest.TestCase):
             substrings=[pureldap.LDAPFilter_substrings_any('foo'),
                         pureldap.LDAPFilter_substrings_any('bar'),
                         ])
-        self.assertEquals(ldapfilter.parseMaybeSubstring('cn', text), filt)
+        self.assertEqual(ldapfilter.parseMaybeSubstring('cn', text), filt)
 
     def test_item_substring_ia(self):
         text = r'foo*bar*'
@@ -464,7 +464,7 @@ class TestMaybeSubstring(unittest.TestCase):
             substrings=[pureldap.LDAPFilter_substrings_initial('foo'),
                         pureldap.LDAPFilter_substrings_any('bar'),
                         ])
-        self.assertEquals(ldapfilter.parseMaybeSubstring('cn', text), filt)
+        self.assertEqual(ldapfilter.parseMaybeSubstring('cn', text), filt)
 
     def test_item_substring_iaa(self):
         text = r'foo*bar*baz*'
@@ -474,7 +474,7 @@ class TestMaybeSubstring(unittest.TestCase):
                         pureldap.LDAPFilter_substrings_any('bar'),
                         pureldap.LDAPFilter_substrings_any('baz'),
                         ])
-        self.assertEquals(ldapfilter.parseMaybeSubstring('cn', text), filt)
+        self.assertEqual(ldapfilter.parseMaybeSubstring('cn', text), filt)
 
     def test_item_substring_if(self):
         text = r'foo*bar'
@@ -483,7 +483,7 @@ class TestMaybeSubstring(unittest.TestCase):
             substrings=[pureldap.LDAPFilter_substrings_initial('foo'),
                         pureldap.LDAPFilter_substrings_final('bar'),
                         ])
-        self.assertEquals(ldapfilter.parseMaybeSubstring('cn', text), filt)
+        self.assertEqual(ldapfilter.parseMaybeSubstring('cn', text), filt)
 
     def test_item_substring_iaf(self):
         text = r'foo*bar*baz'
@@ -493,7 +493,7 @@ class TestMaybeSubstring(unittest.TestCase):
                         pureldap.LDAPFilter_substrings_any('bar'),
                         pureldap.LDAPFilter_substrings_final('baz'),
                         ])
-        self.assertEquals(ldapfilter.parseMaybeSubstring('cn', text), filt)
+        self.assertEqual(ldapfilter.parseMaybeSubstring('cn', text), filt)
 
     def test_item_substring_iaaf(self):
         text = r'foo*bar*baz*quux'
@@ -504,7 +504,7 @@ class TestMaybeSubstring(unittest.TestCase):
                         pureldap.LDAPFilter_substrings_any('baz'),
                         pureldap.LDAPFilter_substrings_final('quux'),
                         ])
-        self.assertEquals(ldapfilter.parseMaybeSubstring('cn', text), filt)
+        self.assertEqual(ldapfilter.parseMaybeSubstring('cn', text), filt)
 
     def test_item_substring_af(self):
         text = r'*foo*bar'
@@ -513,7 +513,7 @@ class TestMaybeSubstring(unittest.TestCase):
             substrings=[pureldap.LDAPFilter_substrings_any('foo'),
                         pureldap.LDAPFilter_substrings_final('bar'),
                         ])
-        self.assertEquals(ldapfilter.parseMaybeSubstring('cn', text), filt)
+        self.assertEqual(ldapfilter.parseMaybeSubstring('cn', text), filt)
 
     def test_item_substring_aaf(self):
         text = r'*foo*bar*baz'
@@ -523,14 +523,14 @@ class TestMaybeSubstring(unittest.TestCase):
                         pureldap.LDAPFilter_substrings_any('bar'),
                         pureldap.LDAPFilter_substrings_final('baz'),
                         ])
-        self.assertEquals(ldapfilter.parseMaybeSubstring('cn', text), filt)
+        self.assertEqual(ldapfilter.parseMaybeSubstring('cn', text), filt)
 
     def test_escape_simple(self):
         text = r'f\2aoo(bar'
         filt = pureldap.LDAPFilter_equalityMatch(
             attributeDesc=pureldap.LDAPAttributeDescription(value='cn'),
             assertionValue=pureldap.LDAPAssertionValue(value='f*oo(bar'))
-        self.assertEquals(ldapfilter.parseMaybeSubstring('cn', text), filt)
+        self.assertEqual(ldapfilter.parseMaybeSubstring('cn', text), filt)
 
 class TestWhitespace(unittest.TestCase):
     def test_escape(self):

--- a/ldaptor/test/test_ldapsyntax.py
+++ b/ldaptor/test/test_ldapsyntax.py
@@ -584,7 +584,7 @@ class LDAPSyntaxSearch(unittest.TestCase):
                    attributes=['bar'],
                    callback=process)
         def cb(val):
-            self.assertEquals(val, None)
+            self.assertEqual(val, None)
 
             client.assertSent(pureldap.LDAPSearchRequest(
                 baseObject='dc=example,dc=com',
@@ -627,7 +627,7 @@ class LDAPSyntaxSearch(unittest.TestCase):
         d=o.search(filterText='(foo=a)')
         def eb(fail):
             fail.trap(ldaperrors.LDAPBusy)
-            self.assertEquals(fail.value.message, 'Go away')
+            self.assertEqual(fail.value.message, 'Go away')
 
             client.assertSent(pureldap.LDAPSearchRequest(
                 baseObject='dc=example,dc=com',
@@ -754,7 +754,7 @@ class LDAPSyntaxDelete(unittest.TestCase):
         d=o.delete()
         def eb(fail):
             fail.trap(ldaperrors.LDAPBusy)
-            self.assertEquals(fail.value.message, 'Go away')
+            self.assertEqual(fail.value.message, 'Go away')
 
             client.assertSent(pureldap.LDAPDelRequest(
                 entry='cn=foo,dc=example,dc=com',
@@ -777,7 +777,7 @@ class LDAPSyntaxDelete(unittest.TestCase):
         d=o.delete()
         def eb(fail):
             fail.trap(ldaperrors.LDAPProtocolError)
-            self.assertEquals(fail.value.message, 'Unknown request')
+            self.assertEqual(fail.value.message, 'Unknown request')
 
             client.assertSent(pureldap.LDAPDelRequest(
                 entry='cn=foo,dc=example,dc=com',
@@ -960,7 +960,7 @@ class LDAPSyntaxPasswords(unittest.TestCase):
         d=defer.maybeDeferred(o.setPassword_Samba, newPasswd='new', style='foo')
         def eb(fail):
             fail.trap(RuntimeError)
-            self.assertEquals(fail.getErrorMessage(),
+            self.assertEqual(fail.getErrorMessage(),
                               "Unknown samba password style 'foo'")
             client.assertNothingSent()
         d.addCallbacks(testutil.mustRaise, eb)
@@ -1230,7 +1230,7 @@ class LDAPSyntaxPasswords(unittest.TestCase):
         def chainMustErrback(dummy):
             raise RuntimeError('Should never get here')
         d.addCallbacks(callback=chainMustErrback, errback=checkError)
-        d.addCallback(self.assertEquals, 'This test run should succeed')
+        d.addCallback(self.assertEqual, 'This test run should succeed')
         def cb(dummy):
             client.assertSent(
                 pureldap.LDAPPasswordModifyRequest(userIdentity='cn=foo,dc=example,dc=com',
@@ -1268,12 +1268,12 @@ class LDAPSyntaxPasswords(unittest.TestCase):
             assert len(l)==2
 
             assert len(l[0])==2
-            self.assertEquals(l[0][0], 'ExtendedOperation')
+            self.assertEqual(l[0][0], 'ExtendedOperation')
             assert isinstance(l[0][1], failure.Failure)
             l[0][1].trap(ldaperrors.LDAPInsufficientAccessRights)
 
             assert len(l[1])==2
-            self.assertEquals(l[1][0], 'Samba')
+            self.assertEqual(l[1][0], 'Samba')
             assert isinstance(l[1][1], failure.Failure)
             l[1][1].trap(ldapsyntax.PasswordSetAborted)
 
@@ -1322,9 +1322,9 @@ class LDAPSyntaxFetch(unittest.TestCase):
             has.sort()
             want=['foo', 'bar']
             want.sort()
-            self.assertEquals(has, want)
-            self.assertEquals(o['foo'], ['a'])
-            self.assertEquals(o['bar'], ['b', 'c'])
+            self.assertEqual(has, want)
+            self.assertEqual(o['foo'], ['a'])
+            self.assertEqual(o['bar'], ['b', 'c'])
         d.addCallback(cb)
         return d
 
@@ -1357,9 +1357,9 @@ class LDAPSyntaxFetch(unittest.TestCase):
             has.sort()
             want=['foo', 'bar']
             want.sort()
-            self.assertEquals(has, want)
-            self.assertEquals(o['foo'], ['a'])
-            self.assertEquals(o['bar'], ['b', 'c'])
+            self.assertEqual(has, want)
+            self.assertEqual(o['foo'], ['a'])
+            self.assertEqual(o['bar'], ['b', 'c'])
         d.addCallback(cb)
         return d
 
@@ -1393,10 +1393,10 @@ class LDAPSyntaxFetch(unittest.TestCase):
             has.sort()
             want=['foo', 'bar', 'quux']
             want.sort()
-            self.assertEquals(has, want)
-            self.assertEquals(o['foo'], ['a'])
-            self.assertEquals(o['bar'], ['b', 'c'])
-            self.assertEquals(o['quux'], ['baz', 'xyzzy'])
+            self.assertEqual(has, want)
+            self.assertEqual(o['foo'], ['a'])
+            self.assertEqual(o['bar'], ['b', 'c'])
+            self.assertEqual(o['quux'], ['baz', 'xyzzy'])
         d.addCallback(cb)
         return d
 
@@ -1493,7 +1493,7 @@ class LDAPSyntaxMove(unittest.TestCase):
                 newSuperior='ou=somewhere,dc=example,dc=com',
                 ))
 
-            self.assertEquals(o.dn, 'cn=bar,ou=somewhere,dc=example,dc=com')
+            self.assertEqual(o.dn, 'cn=bar,ou=somewhere,dc=example,dc=com')
         d.addCallback(cb)
         return d
 

--- a/ldaptor/test/test_ldiftree.py
+++ b/ldaptor/test/test_ldiftree.py
@@ -100,7 +100,7 @@ objectClass: top
         d = ldiftree.get(self.tree, 'cn=foo,dc=example,dc=com')
         def eb(fail):
             fail.trap(IOError)
-            self.assertEquals(fail.value.errno, errno.EACCES)
+            self.assertEqual(fail.value.errno, errno.EACCES)
         d.addCallbacks(testutil.mustRaise, eb)
         return d
 
@@ -350,7 +350,7 @@ cn: theChild
     def test_children_empty(self):
         d = self.empty.children()
         def cb(children):
-            self.assertEquals(children, [])
+            self.assertEqual(children, [])
         d.addCallback(cb)
         return d
 
@@ -360,12 +360,12 @@ cn: theChild
         return d
 
     def _cb_test_children_oneChild(self, children):
-        self.assertEquals(len(children), 1)
+        self.assertEqual(len(children), 1)
         got = [e.dn for e in children]
         want = ['cn=theChild,ou=oneChild,dc=example,dc=com']
         got.sort()
         want.sort()
-        self.assertEquals(got, want)
+        self.assertEqual(got, want)
 
     def test_children_repeat(self):
         """Test that .children() returns a copy of the data so that modifying it does not affect behaviour."""
@@ -374,7 +374,7 @@ cn: theChild
         return d
 
     def _cb_test_children_repeat_1(self, children1):
-        self.assertEquals(len(children1), 1)
+        self.assertEqual(len(children1), 1)
 
         children1.pop()
 
@@ -383,7 +383,7 @@ cn: theChild
         return d
 
     def _cb_test_children_repeat_2(self, children2):
-        self.assertEquals(len(children2), 1)
+        self.assertEqual(len(children2), 1)
 
     def test_children_twoChildren(self):
         d = self.meta.children()
@@ -391,7 +391,7 @@ cn: theChild
         return d
 
     def _cb_test_children_twoChildren(self, children):
-        self.assertEquals(len(children), 2)
+        self.assertEqual(len(children), 2)
         want = [
             'cn=foo,ou=metasyntactic,dc=example,dc=com',
             'cn=bar,ou=metasyntactic,dc=example,dc=com',
@@ -399,7 +399,7 @@ cn: theChild
         got = [e.dn for e in children]
         got.sort()
         want.sort()
-        self.assertEquals(got, want)
+        self.assertEqual(got, want)
 
     def test_children_twoChildren_callback(self):
         children = []
@@ -409,7 +409,7 @@ cn: theChild
 
     def _cb_test_children_twoChildren_callback(self, r, children):
         self.assertIdentical(r, None)
-        self.assertEquals(len(children), 2)
+        self.assertEqual(len(children), 2)
         want = [
             'cn=foo,ou=metasyntactic,dc=example,dc=com',
             'cn=bar,ou=metasyntactic,dc=example,dc=com',
@@ -417,14 +417,14 @@ cn: theChild
         got = [e.dn for e in children]
         got.sort()
         want.sort()
-        self.assertEquals(got, want)
+        self.assertEqual(got, want)
 
     def test_children_noAccess_dir_noRead(self):
         os.chmod(self.meta.path, 0300)
         d = self.meta.children()
         def eb(fail):
             fail.trap(OSError)
-            self.assertEquals(fail.value.errno, errno.EACCES)
+            self.assertEqual(fail.value.errno, errno.EACCES)
             os.chmod(self.meta.path, 0755)
         d.addCallbacks(testutil.mustRaise, eb)
         return d
@@ -437,7 +437,7 @@ cn: theChild
         d = self.meta.children()
         def eb(fail):
             fail.trap(IOError)
-            self.assertEquals(fail.value.errno, errno.EACCES)
+            self.assertEqual(fail.value.errno, errno.EACCES)
             os.chmod(self.meta.path, 0755)
         d.addCallbacks(testutil.mustRaise, eb)
         return d
@@ -450,7 +450,7 @@ cn: theChild
         d = self.meta.children()
         def eb(fail):
             fail.trap(IOError)
-            self.assertEquals(fail.value.errno, errno.EACCES)
+            self.assertEqual(fail.value.errno, errno.EACCES)
         d.addCallbacks(testutil.mustRaise, eb)
         return d
 
@@ -469,14 +469,14 @@ cn: theChild
         return d
 
     def _cb_test_addChild(self, children):
-        self.assertEquals(len(children), 1)
+        self.assertEqual(len(children), 1)
         got = [e.dn for e in children]
         want = [
             'a=b,ou=empty,dc=example,dc=com',
             ]
         got.sort()
         want.sort()
-        self.assertEquals(got, want)
+        self.assertEqual(got, want)
 
     def test_addChild_Exists(self):
         self.assertRaises(ldaperrors.LDAPEntryAlreadyExists,
@@ -488,9 +488,9 @@ cn: theChild
             })
 
     def test_parent(self):
-        self.assertEquals(self.foo.parent(), self.meta)
-        self.assertEquals(self.meta.parent(), self.example)
-        self.assertEquals(self.root.parent(), None)
+        self.assertEqual(self.foo.parent(), self.meta)
+        self.assertEqual(self.meta.parent(), self.example)
+        self.assertEqual(self.root.parent(), None)
 
 
     def test_subtree_empty(self):
@@ -499,7 +499,7 @@ cn: theChild
         return d
 
     def _cb_test_subtree_empty(self, entries):
-        self.assertEquals(len(entries), 1)
+        self.assertEqual(len(entries), 1)
 
     def test_subtree_oneChild(self):
         d = self.oneChild.subtree()
@@ -512,7 +512,7 @@ cn: theChild
             self.oneChild,
             self.theChild,
             ]
-        self.assertEquals(got, want)
+        self.assertEqual(got, want)
 
     def test_subtree_oneChild_cb(self):
         got = []
@@ -521,13 +521,13 @@ cn: theChild
         return d
 
     def _cb_test_subtree_oneChild_cb(self, r, got):
-        self.assertEquals(r, None)
+        self.assertEqual(r, None)
 
         want = [
             self.oneChild,
             self.theChild,
             ]
-        self.assertEquals(got, want)
+        self.assertEqual(got, want)
 
     def test_subtree_many(self):
         d = self.example.subtree()
@@ -547,7 +547,7 @@ cn: theChild
             ]
         got.sort()
         want.sort()
-        self.assertEquals(got, want)
+        self.assertEqual(got, want)
 
     def test_subtree_many_cb(self):
         got = []
@@ -556,7 +556,7 @@ cn: theChild
         return d
 
     def _cb_test_subtree_many_cb(self, r, got):
-        self.assertEquals(r, None)
+        self.assertEqual(r, None)
 
         want = [
             self.example,
@@ -569,14 +569,14 @@ cn: theChild
             ]
         got.sort()
         want.sort()
-        self.assertEquals(got, want)
+        self.assertEqual(got, want)
 
     def test_lookup_fail(self):
         dn = 'cn=thud,ou=metasyntactic,dc=example,dc=com'
         d = self.root.lookup(dn)
         def eb(fail):
             fail.trap(ldaperrors.LDAPNoSuchObject)
-            self.assertEquals(fail.value.message, dn)
+            self.assertEqual(fail.value.message, dn)
         d.addCallbacks(testutil.mustRaise, eb)
         return d
 
@@ -585,7 +585,7 @@ cn: theChild
         d = self.root.lookup(dn)
         def eb(fail):
             fail.trap(ldaperrors.LDAPNoSuchObject)
-            self.assertEquals(fail.value.message, dn)
+            self.assertEqual(fail.value.message, dn)
         d.addCallbacks(testutil.mustRaise, eb)
         return d
 
@@ -594,7 +594,7 @@ cn: theChild
         d = self.example.lookup(dn)
         def eb(fail):
             fail.trap(ldaperrors.LDAPNoSuchObject)
-            self.assertEquals(fail.value.message, dn)
+            self.assertEqual(fail.value.message, dn)
         d.addCallbacks(testutil.mustRaise, eb)
 
     def test_lookup_fail_multipleError(self):
@@ -631,7 +631,7 @@ objectClass: top
         return d
 
     def _cb_test_lookup_deep(self, r):
-        self.assertEquals(r, self.bar)
+        self.assertEqual(r, self.bar)
 
     def test_delete_root(self):
         d = self.root.delete()
@@ -653,13 +653,13 @@ objectClass: top
         return d
 
     def _cb_test_delete_1(self, r):
-        self.assertEquals(r, self.foo)
+        self.assertEqual(r, self.foo)
         d = self.meta.children()
         d.addCallback(self._cb_test_delete_2)
         return d
 
     def _cb_test_delete_2(self, r):
-        self.assertEquals(r, [self.bar])
+        self.assertEqual(r, [self.bar])
 
     def test_deleteChild(self):
         d = self.meta.deleteChild('cn=bar')
@@ -667,13 +667,13 @@ objectClass: top
         return d
 
     def _cb_test_deleteChild_1(self, r):
-        self.assertEquals(r, self.bar)
+        self.assertEqual(r, self.bar)
         d = self.meta.children()
         d.addCallback(self._cb_test_deleteChild_2)
         return d
 
     def _cb_test_deleteChild_2(self, r):
-        self.assertEquals(r, [self.foo])
+        self.assertEqual(r, [self.foo])
 
     def test_deleteChild_NonExisting(self):
         d = self.root.deleteChild('cn=not-exist')
@@ -685,7 +685,7 @@ objectClass: top
     def test_setPassword(self):
         self.foo.setPassword('s3krit', salt='\xf2\x4a')
         self.failUnless('userPassword' in self.foo)
-        self.assertEquals(self.foo['userPassword'],
+        self.assertEqual(self.foo['userPassword'],
                           ['{SSHA}0n/Iw1NhUOKyaI9gm9v5YsO3ZInySg=='])
 
     def test_setPassword_noSalt(self):
@@ -701,7 +701,7 @@ objectClass: top
 
     def test_diffTree_self(self):
         d = self.root.diffTree(self.root)
-        d.addCallback(self.assertEquals, [])
+        d.addCallback(self.assertEqual, [])
         return d
 
     def test_diffTree_copy(self):
@@ -709,7 +709,7 @@ objectClass: top
         shutil.copytree(self.tree, otherDir)
         other = ldiftree.LDIFTreeEntry(otherDir)
         d = self.root.diffTree(other)
-        d.addCallback(self.assertEquals, [])
+        d.addCallback(self.assertEqual, [])
         return d
 
     def test_diffTree_addChild(self):
@@ -725,7 +725,7 @@ objectClass: top
 
         def cb2(r):
             d = self.root.diffTree(other)
-            d.addCallback(self.assertEquals, [delta.AddOp(r)])
+            d.addCallback(self.assertEqual, [delta.AddOp(r)])
             return d
         d.addCallback(cb2)
         return d
@@ -744,7 +744,7 @@ objectClass: top
             return self.root.diffTree(other)
         d.addCallback(cb2)
         def cb3(got):
-            self.assertEquals(got, [delta.DeleteOp(self.empty)])
+            self.assertEqual(got, [delta.DeleteOp(self.empty)])
         d.addCallback(cb3)
         return d
 
@@ -764,7 +764,7 @@ objectClass: top
         d.addCallback(cb2)
 
         def cb3(got):
-            self.assertEquals(got, [
+            self.assertEqual(got, [
                 delta.ModifyOp(self.empty.dn,
                                [delta.Add('foo', ['bar'])],
                                ),
@@ -779,7 +779,7 @@ objectClass: top
             return self.example.children()
         d.addCallback(getChildren)
         d.addCallback(set)
-        d.addCallback(self.assertEquals, set([
+        d.addCallback(self.assertEqual, set([
             self.meta,
             BaseLDAPEntry(
             dn='ou=moved,dc=example,dc=com',
@@ -796,7 +796,7 @@ objectClass: top
             return self.example.children()
         d.addCallback(getChildren)
         d.addCallback(set)
-        d.addCallback(self.assertEquals, set([
+        d.addCallback(self.assertEqual, set([
             BaseLDAPEntry(dn='ou=moved,dc=example,dc=com',
                           attributes={ 'objectClass': ['a', 'b'],
                                        'ou': ['moved'],
@@ -813,7 +813,7 @@ objectClass: top
             return self.example.children()
         d.addCallback(getChildren)
         d.addCallback(set)
-        d.addCallback(self.assertEquals, set([
+        d.addCallback(self.assertEqual, set([
             self.meta,
             self.oneChild,
             ]))
@@ -821,7 +821,7 @@ objectClass: top
             return self.oneChild.children()
         d.addCallback(getChildren2)
         d.addCallback(set)
-        d.addCallback(self.assertEquals, set([
+        d.addCallback(self.assertEqual, set([
             self.theChild,
             BaseLDAPEntry(
             dn='ou=moved,ou=oneChild,dc=example,dc=com',
@@ -837,7 +837,7 @@ objectClass: top
             return self.example.children()
         d.addCallback(getChildren)
         d.addCallback(set)
-        d.addCallback(self.assertEquals, set([
+        d.addCallback(self.assertEqual, set([
             self.empty,
             self.oneChild,
             ]))
@@ -845,7 +845,7 @@ objectClass: top
             return self.oneChild.children()
         d.addCallback(getChildren2)
         d.addCallback(set)
-        d.addCallback(self.assertEquals, set([
+        d.addCallback(self.assertEqual, set([
             self.theChild,
             BaseLDAPEntry(dn='ou=moved,ou=oneChild,dc=example,dc=com',
                           attributes={ 'objectClass': ['a', 'b'],

--- a/ldaptor/test/test_match.py
+++ b/ldaptor/test/test_match.py
@@ -16,7 +16,7 @@ class TestEntryMatch(unittest.TestCase):
             'bValue': ['b'],
             })
         result = o.match(pureldap.LDAPFilterMatchAll)
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
     def test_present_match(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -26,7 +26,7 @@ class TestEntryMatch(unittest.TestCase):
             'bValue': ['b'],
             })
         result = o.match(pureldap.LDAPFilter_present('aValue'))
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
 
     def test_present_noMatch(self):
@@ -37,7 +37,7 @@ class TestEntryMatch(unittest.TestCase):
             'bValue': ['b'],
             })
         result = o.match(pureldap.LDAPFilter_present('noSuchValue'))
-        self.assertEquals(result, False)
+        self.assertEqual(result, False)
 
     def test_and_match(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -51,7 +51,7 @@ class TestEntryMatch(unittest.TestCase):
             pureldap.LDAPFilter_present('aValue'),
             pureldap.LDAPFilter_present('bValue'),
             ]))
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
     def test_and_noMatch(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -65,7 +65,7 @@ class TestEntryMatch(unittest.TestCase):
             pureldap.LDAPFilter_present('cValue'),
             pureldap.LDAPFilter_present('dValue'),
             ]))
-        self.assertEquals(result, False)
+        self.assertEqual(result, False)
 
     def test_or_match(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -79,7 +79,7 @@ class TestEntryMatch(unittest.TestCase):
             pureldap.LDAPFilter_present('cValue'),
             pureldap.LDAPFilter_present('bValue'),
             ]))
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
     def test_or_noMatch(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -93,7 +93,7 @@ class TestEntryMatch(unittest.TestCase):
             pureldap.LDAPFilter_present('cValue'),
             pureldap.LDAPFilter_present('dValue'),
             ]))
-        self.assertEquals(result, False)
+        self.assertEqual(result, False)
 
     def test_not(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -108,7 +108,7 @@ class TestEntryMatch(unittest.TestCase):
             pureldap.LDAPFilter_present('cValue'),
             pureldap.LDAPFilter_present('dValue'),
             ])))
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
     def test_equality_match(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -120,7 +120,7 @@ class TestEntryMatch(unittest.TestCase):
         result = o.match(pureldap.LDAPFilter_equalityMatch(
             attributeDesc=pureber.BEROctetString('aValue'),
             assertionValue=pureber.BEROctetString('a')))
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
     def test_equality_match_caseInsensitive(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -132,7 +132,7 @@ class TestEntryMatch(unittest.TestCase):
         result = o.match(pureldap.LDAPFilter_equalityMatch(
             attributeDesc=pureber.BEROctetString('avaLUe'),
             assertionValue=pureber.BEROctetString('A')))
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
 
     def test_equality_noMatch(self):
@@ -145,7 +145,7 @@ class TestEntryMatch(unittest.TestCase):
         result = o.match(pureldap.LDAPFilter_equalityMatch(
             attributeDesc=pureber.BEROctetString('aValue'),
             assertionValue=pureber.BEROctetString('b')))
-        self.assertEquals(result, False)
+        self.assertEqual(result, False)
 
     def test_substrings_match(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -159,7 +159,7 @@ class TestEntryMatch(unittest.TestCase):
             substrings=[
             pureldap.LDAPFilter_substrings_initial('a'),
             ]))
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
     def test_substrings_match2(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -174,7 +174,7 @@ class TestEntryMatch(unittest.TestCase):
             pureldap.LDAPFilter_substrings_initial('a'),
             pureldap.LDAPFilter_substrings_final('e'),
             ]))
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
     def test_substrings_match3(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -190,7 +190,7 @@ class TestEntryMatch(unittest.TestCase):
             pureldap.LDAPFilter_substrings_any('c'),
             pureldap.LDAPFilter_substrings_final('e'),
             ]))
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
     def test_substrings_match4(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -208,7 +208,7 @@ class TestEntryMatch(unittest.TestCase):
             pureldap.LDAPFilter_substrings_any('d'),
             pureldap.LDAPFilter_substrings_final('e'),
             ]))
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
     def test_substrings_match5(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -226,7 +226,7 @@ class TestEntryMatch(unittest.TestCase):
             pureldap.LDAPFilter_substrings_any('d'),
             pureldap.LDAPFilter_substrings_final('e'),
             ]))
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
     def test_substrings_match6(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -244,7 +244,7 @@ class TestEntryMatch(unittest.TestCase):
             pureldap.LDAPFilter_substrings_any('D'),
             pureldap.LDAPFilter_substrings_final('e'),
             ]))
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
     def test_substrings_match7(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -257,7 +257,7 @@ class TestEntryMatch(unittest.TestCase):
             substrings=[
             pureldap.LDAPFilter_substrings_initial('f'),
             ]))
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
     def test_substrings_noMatch(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -274,7 +274,7 @@ class TestEntryMatch(unittest.TestCase):
             pureldap.LDAPFilter_substrings_any('no'),
             pureldap.LDAPFilter_substrings_final('bone'),
             ]))
-        self.assertEquals(result, False)
+        self.assertEqual(result, False)
 
     def test_substrings_noMatch2(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -292,7 +292,7 @@ class TestEntryMatch(unittest.TestCase):
             pureldap.LDAPFilter_substrings_any('d'),
             pureldap.LDAPFilter_substrings_final('e'),
             ]))
-        self.assertEquals(result, False)
+        self.assertEqual(result, False)
 
     def test_greaterOrEqual_noMatch_nosuchattr(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -303,7 +303,7 @@ class TestEntryMatch(unittest.TestCase):
             })
         result = o.match(pureldap.LDAPFilter_greaterOrEqual(pureber.BEROctetString('foo'),
                                                             pureber.BERInteger(42)))
-        self.assertEquals(result, False)
+        self.assertEqual(result, False)
 
     def test_greaterOrEqual_match_greater(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -314,7 +314,7 @@ class TestEntryMatch(unittest.TestCase):
             })
         result = o.match(pureldap.LDAPFilter_greaterOrEqual(pureber.BEROctetString('num'),
                                                             pureber.BERInteger(3)))
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
     def test_greaterOrEqual_match_equal(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -325,7 +325,7 @@ class TestEntryMatch(unittest.TestCase):
             })
         result = o.match(pureldap.LDAPFilter_greaterOrEqual(pureber.BEROctetString('num'),
                                                             pureber.BERInteger(4)))
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
     def test_greaterOrEqual_noMatch(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -336,7 +336,7 @@ class TestEntryMatch(unittest.TestCase):
             })
         result = o.match(pureldap.LDAPFilter_greaterOrEqual(pureber.BEROctetString('num'),
                                                             pureber.BERInteger(5)))
-        self.assertEquals(result, False)
+        self.assertEqual(result, False)
 
 
     def test_lessOrEqual_noMatch_nosuchattr(self):
@@ -348,7 +348,7 @@ class TestEntryMatch(unittest.TestCase):
             })
         result = o.match(pureldap.LDAPFilter_lessOrEqual(pureber.BEROctetString('foo'),
                                                          pureber.BERInteger(42)))
-        self.assertEquals(result, False)
+        self.assertEqual(result, False)
 
     def test_lessOrEqual_match_less(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -359,7 +359,7 @@ class TestEntryMatch(unittest.TestCase):
             })
         result = o.match(pureldap.LDAPFilter_lessOrEqual(pureber.BEROctetString('num'),
                                                          pureber.BERInteger(5)))
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
     def test_lessOrEqual_match_equal(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -370,7 +370,7 @@ class TestEntryMatch(unittest.TestCase):
             })
         result = o.match(pureldap.LDAPFilter_lessOrEqual(pureber.BEROctetString('num'),
                                                          pureber.BERInteger(4)))
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
     def test_lessOrEqual_noMatch(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',
@@ -381,7 +381,7 @@ class TestEntryMatch(unittest.TestCase):
             })
         result = o.match(pureldap.LDAPFilter_lessOrEqual(pureber.BEROctetString('num'),
                                                          pureber.BERInteger(3)))
-        self.assertEquals(result, False)
+        self.assertEqual(result, False)
 
     def test_extensibleMatch4(self):
         """
@@ -402,7 +402,7 @@ class TestEntryMatch(unittest.TestCase):
                 'num': [4],
             })
         result = o.match(m)
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
     def test_extensibleMatch4_noMatch(self):
         """
@@ -423,7 +423,7 @@ class TestEntryMatch(unittest.TestCase):
                 'num': [4],
             })
         result = o.match(m)
-        self.assertEquals(result, False)
+        self.assertEqual(result, False)
 
     def test_notImplemented(self):
         o=inmemory.ReadOnlyInMemoryLDAPEntry(dn='cn=foo,dc=example,dc=com',

--- a/ldaptor/test/test_merger.py
+++ b/ldaptor/test/test_merger.py
@@ -52,7 +52,7 @@ class MergedLDAPServerTest(unittest.TestCase):
         def test_f(server):
             server.dataReceived(str(LDAPMessage(LDAPBindRequest(), id=4)))
 
-            self.assertEquals(server.transport.value(),
+            self.assertEqual(server.transport.value(),
                               str(LDAPMessage(LDAPBindResponse(resultCode=0), id=4)))
 
         d.addCallback(test_f)
@@ -65,7 +65,7 @@ class MergedLDAPServerTest(unittest.TestCase):
 
         def test_f(server):
             server.dataReceived(str(LDAPMessage(LDAPBindRequest(), id=4)))
-            self.assertEquals(server.transport.value(),
+            self.assertEqual(server.transport.value(),
                               str(LDAPMessage(LDAPBindResponse(resultCode=0), id=4))) 
         d.addCallback(test_f)
         return d
@@ -76,7 +76,7 @@ class MergedLDAPServerTest(unittest.TestCase):
 
         def test_f(server):
             server.dataReceived(str(LDAPMessage(LDAPBindRequest(), id=4)))
-            self.assertEquals(server.transport.value(),
+            self.assertEqual(server.transport.value(),
                               str(LDAPMessage(LDAPBindResponse(resultCode=ldaperrors.LDAPInvalidCredentials.resultCode), id=4)))
 
         d.addCallback(test_f)
@@ -92,7 +92,7 @@ class MergedLDAPServerTest(unittest.TestCase):
 
         def test_f(server):
             server.dataReceived(str(LDAPMessage(LDAPSearchRequest(), id=3)))
-            self.assertEquals(server.transport.value(),
+            self.assertEqual(server.transport.value(),
                               str(LDAPMessage(LDAPSearchResultEntry('cn=foo,dc=example,dc=com', [('a', ['b'])]), id=3))
                               +str(LDAPMessage(LDAPSearchResultEntry('cn=bar2,dc=example,dc=com', [('b', ['c'])]), id=3))
                               +str(LDAPMessage(LDAPSearchResultEntry('cn=foo,dc=example,dc=com', [('a', ['b'])]), id=3))
@@ -112,7 +112,7 @@ class MergedLDAPServerTest(unittest.TestCase):
 
         def test_f(server):
             server.dataReceived(str(LDAPMessage(LDAPSearchRequest(), id=3)))
-            self.assertEquals(server.transport.value(),
+            self.assertEqual(server.transport.value(),
                               str(LDAPMessage(LDAPSearchResultEntry('cn=foo,dc=example,dc=com', [('a', ['b'])]), id=3))
                               +str(LDAPMessage(LDAPSearchResultEntry('cn=bar,dc=example,dc=com', [('b', ['c'])]), id=3))
                               +str(LDAPMessage(LDAPSearchResultDone(ldaperrors.Success.resultCode), id=3)))
@@ -129,7 +129,7 @@ class MergedLDAPServerTest(unittest.TestCase):
             server.connectionLost(error.ConnectionDone)
             for c in self.clients:
                 c.assertSent(LDAPUnbindRequest())
-            self.assertEquals(server.transport.value(), "")
+            self.assertEqual(server.transport.value(), "")
         d.addCallback(test_f)
 
         return d
@@ -141,7 +141,7 @@ class MergedLDAPServerTest(unittest.TestCase):
             server.connectionLost(error.ConnectionDone)
             for c in server.clients:
                 c.assertSent('fake-unbind-by-LDAPClientTestDriver')
-            self.assertEquals(server.transport.value(), "")
+            self.assertEqual(server.transport.value(), "")
 
         d.addCallback(test_f)
 
@@ -159,7 +159,7 @@ class MergedLDAPServerTest(unittest.TestCase):
             for c in server.clients:
                 c.assertNothingSent()
 
-            self.assertEquals(server.transport.value(),
+            self.assertEqual(server.transport.value(),
                               str(LDAPMessage(LDAPAddResponse(resultCode=ldaperrors.LDAPUnwillingToPerform.resultCode), id=3))
                               +str(LDAPMessage(LDAPDelResponse(resultCode=ldaperrors.LDAPUnwillingToPerform.resultCode), id=4))
                               +str(LDAPMessage(LDAPModifyResponse(resultCode=ldaperrors.LDAPUnwillingToPerform.resultCode), id=5))

--- a/ldaptor/test/test_proxy.py
+++ b/ldaptor/test/test_proxy.py
@@ -17,7 +17,7 @@ class Proxy(unittest.TestCase):
                                      ])
         server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=4)))
         reactor.iterate() #TODO
-        self.assertEquals(server.transport.value(),
+        self.assertEqual(server.transport.value(),
                           str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=4)))
 
     def test_search(self):
@@ -31,7 +31,7 @@ class Proxy(unittest.TestCase):
         server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=2)))
         server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPSearchRequest(), id=3)))
         reactor.iterate() #TODO
-        self.assertEquals(server.transport.value(),
+        self.assertEqual(server.transport.value(),
                           str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2))
                           +str(pureldap.LDAPMessage(pureldap.LDAPSearchResultEntry('cn=foo,dc=example,dc=com', [('a', ['b'])]), id=3))
                           +str(pureldap.LDAPMessage(pureldap.LDAPSearchResultEntry('cn=bar,dc=example,dc=com', [('b', ['c'])]), id=3))
@@ -46,14 +46,14 @@ class Proxy(unittest.TestCase):
         reactor.iterate() #TODO
         client = server.client
         client.assertSent(pureldap.LDAPBindRequest())
-        self.assertEquals(server.transport.value(),
+        self.assertEqual(server.transport.value(),
                           str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
         server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPUnbindRequest(), id=3)))
         server.connectionLost(error.ConnectionDone)
         reactor.iterate() #TODO
         client.assertSent(pureldap.LDAPBindRequest(),
                           pureldap.LDAPUnbindRequest())
-        self.assertEquals(server.transport.value(),
+        self.assertEqual(server.transport.value(),
                           str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
 
     def test_unbind_clientEOF(self):
@@ -65,11 +65,11 @@ class Proxy(unittest.TestCase):
         reactor.iterate() #TODO
         client = server.client
         client.assertSent(pureldap.LDAPBindRequest())
-        self.assertEquals(server.transport.value(),
+        self.assertEqual(server.transport.value(),
                           str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
         server.connectionLost(error.ConnectionDone)
         reactor.iterate() #TODO
         client.assertSent(pureldap.LDAPBindRequest(),
                           'fake-unbind-by-LDAPClientTestDriver')
-        self.assertEquals(server.transport.value(),
+        self.assertEqual(server.transport.value(),
                           str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))

--- a/ldaptor/test/test_proxybase.py
+++ b/ldaptor/test/test_proxybase.py
@@ -104,7 +104,7 @@ class ProxyBase(unittest.TestCase):
         server = self.createServer([pureldap.LDAPBindResponse(resultCode=0)])
         server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=4)))
         server.reactor.advance(1)
-        self.assertEquals(server.transport.value(),
+        self.assertEqual(server.transport.value(),
                           str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=4)))
 
     def test_search(self):
@@ -120,7 +120,7 @@ class ProxyBase(unittest.TestCase):
         server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=2)))
         server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPSearchRequest(), id=3)))
         server.reactor.advance(1)
-        self.assertEquals(server.transport.value(),
+        self.assertEqual(server.transport.value(),
                           str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2))
                           + str(pureldap.LDAPMessage(pureldap.LDAPSearchResultEntry('cn=foo,dc=example,dc=com', [('a', ['b'])]), id=3))
                           + str(pureldap.LDAPMessage(pureldap.LDAPSearchResultEntry('cn=bar,dc=example,dc=com', [('b', ['c'])]), id=3))
@@ -136,14 +136,14 @@ class ProxyBase(unittest.TestCase):
         server.reactor.advance(1)
         client = server.client
         client.assertSent(pureldap.LDAPBindRequest())
-        self.assertEquals(server.transport.value(),
+        self.assertEqual(server.transport.value(),
                           str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
         server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPUnbindRequest(), id=3)))
         server.connectionLost(error.ConnectionDone)
         server.reactor.advance(1)
         client.assertSent(pureldap.LDAPBindRequest(),
                           pureldap.LDAPUnbindRequest())
-        self.assertEquals(server.transport.value(),
+        self.assertEqual(server.transport.value(),
                           str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
 
     def test_unbind_clientEOF(self):
@@ -156,7 +156,7 @@ class ProxyBase(unittest.TestCase):
         server.reactor.advance(1)
         client = server.client
         client.assertSent(pureldap.LDAPBindRequest())
-        self.assertEquals(
+        self.assertEqual(
             server.transport.value(),
             str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
         server.connectionLost(error.ConnectionDone)
@@ -164,7 +164,7 @@ class ProxyBase(unittest.TestCase):
         client.assertSent(
             pureldap.LDAPBindRequest(),
             'fake-unbind-by-LDAPClientTestDriver')
-        self.assertEquals(server.transport.value(),
+        self.assertEqual(server.transport.value(),
                           str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
 
     def test_intercepted_search_request(self):
@@ -185,8 +185,8 @@ class ProxyBase(unittest.TestCase):
             pureldap.LDAPSearchResultDone(ldaperrors.Success.resultCode)]
         server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPSearchRequest(), id=1)))
         server.reactor.advance(1)
-        self.assertEquals(len(server.clientTestDriver.sent), 0)
-        self.assertEquals(server.transport.value(),
+        self.assertEqual(len(server.clientTestDriver.sent), 0)
+        self.assertEqual(server.transport.value(),
                           str(pureldap.LDAPMessage(pureldap.LDAPSearchResultEntry('cn=xyzzy,dc=example,dc=com', [('frobnitz', ['zork'])]), id=1))
                           + str(pureldap.LDAPMessage(pureldap.LDAPSearchResultDone(ldaperrors.Success.resultCode), id=1)))
 
@@ -204,7 +204,7 @@ class ProxyBase(unittest.TestCase):
         server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPSearchRequest(), id=3)))
         server.reactor.advance(1)
         server.reactor.advance(5)
-        self.assertEquals(server.transport.value(),
+        self.assertEqual(server.transport.value(),
                           str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2))
                           + str(pureldap.LDAPMessage(pureldap.LDAPSearchResultEntry('cn=foo,dc=example,dc=com', [('a', ['b']), ('frotz', ['xyzzy'])]), id=3))
                           + str(pureldap.LDAPMessage(pureldap.LDAPSearchResultEntry('cn=bar,dc=example,dc=com', [('b', ['c']), ('frotz', ['xyzzy'])]), id=3))
@@ -221,9 +221,9 @@ class ProxyBase(unittest.TestCase):
             [], 
             clientConnector=connector, 
             clock=clock)
-        self.assertEquals(connector, server.clientConnector)
+        self.assertEqual(connector, server.clientConnector)
         server.reactor.advance(1)
-        self.assertEquals(server.transport.value(), "")
+        self.assertEqual(server.transport.value(), "")
 
     def test_cannot_connect_to_proxied_server_pending_requests(self):
         """
@@ -237,9 +237,9 @@ class ProxyBase(unittest.TestCase):
             [], 
             clientConnector=connector, 
             clock=clock)
-        self.assertEquals(connector, server.clientConnector)
+        self.assertEqual(connector, server.clientConnector)
         server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=4)))
         server.reactor.advance(2)
-        self.assertEquals(
+        self.assertEqual(
             server.transport.value(),
             str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=52), id=4)))

--- a/ldaptor/test/test_pureber.py
+++ b/ldaptor/test/test_pureber.py
@@ -56,14 +56,14 @@ class BerLengths(unittest.TestCase):
             got = pureber.int2berlen(integer)
             got = str(got)
             got = map(ord, got)
-            self.assertEquals(got, encoded)
+            self.assertEqual(got, encoded)
 
     def testFromBER(self):
         for integer, encoded in self.knownValues:
             m=s(*encoded)
             got, bytes = pureber.berDecodeLength(m)
-            self.assertEquals(bytes, len(m))
-            self.assertEquals(got, integer)
+            self.assertEqual(bytes, len(m))
+            self.assertEqual(got, integer)
 
     def testPartialBER(self):
         m=str(pureber.int2berlen(3*256))
@@ -138,7 +138,7 @@ class BERIntegerKnownValues(unittest.TestCase):
         for integer, encoded in self.knownValues:
             m=s(*encoded)
             result, bytes = pureber.berDecodeObject(pureber.BERDecoderContext(), m)
-            self.assertEquals(bytes, len(m))
+            self.assertEqual(bytes, len(m))
             assert isinstance(result, pureber.BERInteger)
             result = result.value
             assert integer==result
@@ -149,7 +149,7 @@ class BERIntegerKnownValues(unittest.TestCase):
         assert len(m)==3
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeObject, pureber.BERDecoderContext(), m[:2])
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeObject, pureber.BERDecoderContext(), m[:1])
-        self.assertEquals((None, 0), pureber.berDecodeObject(pureber.BERDecoderContext(), ''))
+        self.assertEqual((None, 0), pureber.berDecodeObject(pureber.BERDecoderContext(), ''))
 
 class BERIntegerSanityCheck(unittest.TestCase):
     def testSanity(self):
@@ -157,7 +157,7 @@ class BERIntegerSanityCheck(unittest.TestCase):
         for n in range(-1000, 1001, 10):
             encoded = str(pureber.BERInteger(n))
             result, bytes = pureber.berDecodeObject(pureber.BERDecoderContext(), encoded)
-            self.assertEquals(bytes, len(encoded))
+            self.assertEqual(bytes, len(encoded))
             assert isinstance(result, pureber.BERInteger)
             result = result.value
             assert n==result
@@ -189,7 +189,7 @@ class BEROctetStringKnownValues(unittest.TestCase):
         for st, encoded in self.knownValues:
             m=s(*encoded)
             result, bytes = pureber.berDecodeObject(pureber.BERDecoderContext(), m)
-            self.assertEquals(bytes, len(m))
+            self.assertEqual(bytes, len(m))
             assert isinstance(result, pureber.BEROctetString)
             result = str(result)
             result = map(ord, result)
@@ -201,7 +201,7 @@ class BEROctetStringKnownValues(unittest.TestCase):
         assert len(m)==3
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeObject, pureber.BERDecoderContext(), m[:2])
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeObject, pureber.BERDecoderContext(), m[:1])
-        self.assertEquals((None, 0), pureber.berDecodeObject(pureber.BERDecoderContext(), ''))
+        self.assertEqual((None, 0), pureber.berDecodeObject(pureber.BERDecoderContext(), ''))
 
 class BEROctetStringSanityCheck(unittest.TestCase):
     def testSanity(self):
@@ -209,7 +209,7 @@ class BEROctetStringSanityCheck(unittest.TestCase):
         for n in 0,1,2,3,4,5,6,100,126,127,128,129,1000,2000:
             encoded = str(pureber.BEROctetString(n*'x'))
             result, bytes = pureber.berDecodeObject(pureber.BERDecoderContext(), encoded)
-            self.assertEquals(bytes, len(encoded))
+            self.assertEqual(bytes, len(encoded))
             assert isinstance(result, pureber.BEROctetString)
             result = result.value
             assert n*'x'==result
@@ -238,7 +238,7 @@ class BERNullKnownValues(unittest.TestCase):
         encoded=[0x05, 0x00]
         m=s(*encoded)
         result, bytes = pureber.berDecodeObject(pureber.BERDecoderContext(), m)
-        self.assertEquals(bytes, len(m))
+        self.assertEqual(bytes, len(m))
         assert isinstance(result, pureber.BERNull)
         assert 0x05==result.tag
 
@@ -247,7 +247,7 @@ class BERNullKnownValues(unittest.TestCase):
         m=str(pureber.BERNull())
         assert len(m)==2
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeObject, pureber.BERDecoderContext(), m[:1])
-        self.assertEquals((None, 0), pureber.berDecodeObject(pureber.BERDecoderContext(), ''))
+        self.assertEqual((None, 0), pureber.berDecodeObject(pureber.BERDecoderContext(), ''))
 
 
 
@@ -288,7 +288,7 @@ class BERBooleanKnownValues(unittest.TestCase):
         for integer, encoded, canon in self.knownValues:
             m=s(*encoded)
             result, bytes = pureber.berDecodeObject(pureber.BERDecoderContext(), m)
-            self.assertEquals(bytes, len(m))
+            self.assertEqual(bytes, len(m))
             assert isinstance(result, pureber.BERBoolean)
             result = result.value
             assert result==canon
@@ -299,7 +299,7 @@ class BERBooleanKnownValues(unittest.TestCase):
         assert len(m)==3
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeObject, pureber.BERDecoderContext(), m[:2])
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeObject, pureber.BERDecoderContext(), m[:1])
-        self.assertEquals((None, 0), pureber.berDecodeObject(pureber.BERDecoderContext(), ''))
+        self.assertEqual((None, 0), pureber.berDecodeObject(pureber.BERDecoderContext(), ''))
 
 
 
@@ -340,7 +340,7 @@ class BEREnumeratedKnownValues(unittest.TestCase):
         for integer, encoded in self.knownValues:
             m=s(*encoded)
             result, bytes = pureber.berDecodeObject(pureber.BERDecoderContext(), m)
-            self.assertEquals(bytes, len(m))
+            self.assertEqual(bytes, len(m))
             assert isinstance(result, pureber.BEREnumerated)
             result = result.value
             assert integer==result
@@ -351,7 +351,7 @@ class BEREnumeratedKnownValues(unittest.TestCase):
         assert len(m)==3
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeObject, pureber.BERDecoderContext(), m[:2])
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeObject, pureber.BERDecoderContext(), m[:1])
-        self.assertEquals((None, 0), pureber.berDecodeObject(pureber.BERDecoderContext(), ''))
+        self.assertEqual((None, 0), pureber.berDecodeObject(pureber.BERDecoderContext(), ''))
 
 
 class BEREnumeratedSanityCheck(unittest.TestCase):
@@ -360,7 +360,7 @@ class BEREnumeratedSanityCheck(unittest.TestCase):
         for n in range(-1000, 1001, 10):
             encoded = str(pureber.BEREnumerated(n))
             result, bytes = pureber.berDecodeObject(pureber.BERDecoderContext(), encoded)
-            self.assertEquals(bytes, len(encoded))
+            self.assertEqual(bytes, len(encoded))
             assert isinstance(result, pureber.BEREnumerated)
             result = result.value
             assert n==result
@@ -389,7 +389,7 @@ class BERSequenceKnownValues(unittest.TestCase):
         for content, encoded in self.knownValues:
             m=s(*encoded)
             result, bytes = pureber.berDecodeObject(pureber.BERDecoderContext(), m)
-            self.assertEquals(bytes, len(m))
+            self.assertEqual(bytes, len(m))
             assert isinstance(result, pureber.BERSequence)
             result = result.data
             assert len(content)==len(result)
@@ -406,7 +406,7 @@ class BERSequenceKnownValues(unittest.TestCase):
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeObject, pureber.BERDecoderContext(), m[:3])
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeObject, pureber.BERDecoderContext(), m[:2])
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeObject, pureber.BERDecoderContext(), m[:1])
-        self.assertEquals((None, 0), pureber.berDecodeObject(pureber.BERDecoderContext(), ''))
+        self.assertEqual((None, 0), pureber.berDecodeObject(pureber.BERDecoderContext(), ''))
 
 # TODO BERSequenceOf
 # TODO BERSet

--- a/ldaptor/test/test_pureldap.py
+++ b/ldaptor/test/test_pureldap.py
@@ -632,7 +632,7 @@ class KnownValues(unittest.TestCase):
                     fallback=pureber.BERDecoderContext())
             m=s(*encoded)
             result, bytes = pureber.berDecodeObject(decoder, m)
-            self.assertEquals(bytes, len(m))
+            self.assertEqual(bytes, len(m))
 
             shouldBe = klass(*args, **kwargs)
             #TODO shouldn't use str below
@@ -653,7 +653,7 @@ class KnownValues(unittest.TestCase):
                 self.assertRaises(pureber.BERExceptionInsufficientData,
                                   pureber.berDecodeObject,
                                   decoder, m)
-            self.assertEquals((None, 0), pureber.berDecodeObject(decoder, ''))
+            self.assertEqual((None, 0), pureber.berDecodeObject(decoder, ''))
 
 class TestEquality(unittest.TestCase):
     valuesToTest=(
@@ -673,8 +673,8 @@ class TestEquality(unittest.TestCase):
         for class_, args in self.valuesToTest:
             x=class_(*args)
             y=class_(*args)
-            self.assertEquals(x, x)
-            self.assertEquals(x, y)
+            self.assertEqual(x, x)
+            self.assertEqual(x, y)
 
     def testInEquality(self):
         """LDAP objects do not equal LDAP objects with different type or content"""
@@ -702,7 +702,7 @@ class Substrings(unittest.TestCase):
         # filt.substrings was left as a BERSequence, which under the
         # current str()-to-wire-protocol system had len() > 1 even
         # when empty, and that tripped e.g. entry.match()
-        self.assertEquals(len(filt.substrings), 1)
+        self.assertEqual(len(filt.substrings), 1)
 
 class TestEscaping(unittest.TestCase):
     def test_escape(self):
@@ -711,7 +711,7 @@ class TestEscaping(unittest.TestCase):
         result = pureldap.escape(s)
         expected = '\\5c\\2a\\28\\29\\00'
 
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     def test_binary_escape(self):
         s = 'HELLO'
@@ -719,7 +719,7 @@ class TestEscaping(unittest.TestCase):
         result = pureldap.binary_escape(s)
         expected = '\\48\\45\\4c\\4c\\4f'
 
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     def test_smart_escape_regular(self):
         s = 'HELLO'
@@ -727,7 +727,7 @@ class TestEscaping(unittest.TestCase):
         result = pureldap.smart_escape(s)
         expected = 'HELLO'
 
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     def test_smart_escape_binary(self):
         s = '\x10\x11\x12\x13\x14'
@@ -735,7 +735,7 @@ class TestEscaping(unittest.TestCase):
         result = pureldap.smart_escape(s)
         expected = '\\10\\11\\12\\13\\14'
 
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     def test_smart_escape_threshold(self):
         s = '\x10\x11ABC'
@@ -743,7 +743,7 @@ class TestEscaping(unittest.TestCase):
         result = pureldap.smart_escape(s, threshold=0.10)
         expected = '\\10\\11\\41\\42\\43'
 
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     def test_default_escaper(self):
         chars = '\\*()\0'

--- a/ldaptor/test/test_pureldap.py
+++ b/ldaptor/test/test_pureldap.py
@@ -869,6 +869,7 @@ class TestEscaping(unittest.TestCase):
             result = filt.asText()
             self.assertEqual(expected, result)
 
+
 class TestFilterSetEquality(unittest.TestCase):
     def test_basic_and_equal(self):
         filter1 = pureldap.LDAPFilter_and([

--- a/ldaptor/test/test_schema.py
+++ b/ldaptor/test/test_schema.py
@@ -168,11 +168,11 @@ class AttributeType_KnownValues(unittest.TestCase):
                 if key in defaults:
                     del defaults[key]
                 got = getattr(a, key)
-                self.assertEquals(got, want)
+                self.assertEqual(got, want)
 
             for key, want in defaults.items():
                 got = getattr(a, key)
-                self.assertEquals(got, want)
+                self.assertEqual(got, want)
 
     def testStringification(self):
         for want, values in self.knownValues:
@@ -182,7 +182,7 @@ class AttributeType_KnownValues(unittest.TestCase):
 
             want = ' '.join(want.split(None))
             got = ' '.join(str(a).split(None))
-            self.assertEquals(got, want)
+            self.assertEqual(got, want)
 
 class ObjectClass_KnownValues(unittest.TestCase):
     knownValues = [
@@ -241,11 +241,11 @@ class ObjectClass_KnownValues(unittest.TestCase):
                 if key in defaults:
                     del defaults[key]
                 got = getattr(a, key)
-                self.assertEquals(got, want)
+                self.assertEqual(got, want)
 
             for key, want in defaults.items():
                 got = getattr(a, key)
-                self.assertEquals(got, want)
+                self.assertEqual(got, want)
 
     def testStringification(self):
         for want, values in self.knownValues:
@@ -255,7 +255,7 @@ class ObjectClass_KnownValues(unittest.TestCase):
 
             want = ' '.join(want.split(None))
             got = ' '.join(str(a).split(None))
-            self.assertEquals(got, want)
+            self.assertEqual(got, want)
 
 
 class TestComparison(unittest.TestCase):

--- a/ldaptor/test/test_server.py
+++ b/ldaptor/test/test_server.py
@@ -117,7 +117,7 @@ class LDAPServerTest(unittest.TestCase):
     def test_bind(self):
         self.server.dataReceived(
             str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=4)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -133,7 +133,7 @@ class LDAPServerTest(unittest.TestCase):
                         dn='cn=thingie,ou=stuff,dc=example,dc=com',
                         auth='secret'),
                     id=4)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -150,7 +150,7 @@ class LDAPServerTest(unittest.TestCase):
                         dn='cn=thingie,ou=stuff,dc=example,dc=com',
                         auth='invalid'),
                     id=734)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -166,7 +166,7 @@ class LDAPServerTest(unittest.TestCase):
                         dn='cn=non-existing,dc=example,dc=com',
                         auth='invalid'),
                     id=78)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -180,7 +180,7 @@ class LDAPServerTest(unittest.TestCase):
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindRequest(version=1),
                     id=32)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -195,7 +195,7 @@ class LDAPServerTest(unittest.TestCase):
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindRequest(version=2),
                     id=32)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -210,7 +210,7 @@ class LDAPServerTest(unittest.TestCase):
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindRequest(version=4),
                     id=32)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -230,7 +230,7 @@ class LDAPServerTest(unittest.TestCase):
                         dn='cn=non-existing,dc=example,dc=com',
                         auth='invalid'),
                     id=11)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -242,7 +242,7 @@ class LDAPServerTest(unittest.TestCase):
     def test_unbind(self):
         self.server.dataReceived(
             str(pureldap.LDAPMessage(pureldap.LDAPUnbindRequest(), id=7)))
-        self.assertEquals(self.server.transport.value(), '')
+        self.assertEqual(self.server.transport.value(), '')
 
     def test_compare_outOfTree(self):
         dn = 'dc=invalid'
@@ -256,7 +256,7 @@ class LDAPServerTest(unittest.TestCase):
                     pureldap.LDAPCompareRequest(entry=dn, ava=ava),
                     id=2)))
 
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -276,7 +276,7 @@ class LDAPServerTest(unittest.TestCase):
                     pureldap.LDAPCompareRequest(entry=dn, ava=ava),
                     id=2)))
 
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -296,7 +296,7 @@ class LDAPServerTest(unittest.TestCase):
                     pureldap.LDAPCompareRequest(entry=dn, ava=ava),
                     id=2)))
 
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -311,7 +311,7 @@ class LDAPServerTest(unittest.TestCase):
                     pureldap.LDAPSearchRequest(
                         baseObject='dc=invalid'),
                     id=2)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -371,7 +371,7 @@ class LDAPServerTest(unittest.TestCase):
                         baseObject='cn=thingie,ou=stuff,dc=example,dc=com',
                         attributes=['xyzzy']),
                     id=2)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -542,7 +542,7 @@ class LDAPServerTest(unittest.TestCase):
                 pureldap.LDAPMessage(
                     pureldap.LDAPDelRequest(str(self.thingie.dn)),
                     id=2)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -569,7 +569,7 @@ class LDAPServerTest(unittest.TestCase):
                             )
                         ]),
                     id=2)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -605,7 +605,7 @@ class LDAPServerTest(unittest.TestCase):
                             )
                         ]),
                     id=2)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -628,7 +628,7 @@ class LDAPServerTest(unittest.TestCase):
                         newrdn=newrdn,
                         deleteoldrdn=True),
                     id=2)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -660,7 +660,7 @@ class LDAPServerTest(unittest.TestCase):
                         newrdn=newrdn,
                         deleteoldrdn=False),
                     id=2)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -679,6 +679,7 @@ class LDAPServerTest(unittest.TestCase):
                         'cn': ['thingamagic', 'thingie']
                     })})
         return d
+
     test_modifyDN_rdnOnly_noDeleteOldRDN_success.todo = 'Not supported yet.'
 
     def test_modify(self):
@@ -691,7 +692,7 @@ class LDAPServerTest(unittest.TestCase):
                             delta.Add('foo', ['bar']).asLDAP(),
                         ]),
                     id=2)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -699,7 +700,7 @@ class LDAPServerTest(unittest.TestCase):
                         resultCode=ldaperrors.Success.resultCode),
                     id=2)))
         # tree changed
-        self.assertEquals(
+        self.assertEqual(
             self.stuff,
             inmemory.ReadOnlyInMemoryLDAPEntry(
                 'ou=stuff,dc=example,dc=com',
@@ -717,7 +718,7 @@ class LDAPServerTest(unittest.TestCase):
                         requestName='42.42.42',
                         requestValue='foo'),
                     id=2)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -734,7 +735,7 @@ class LDAPServerTest(unittest.TestCase):
                         userIdentity='cn=thingie,ou=stuff,dc=example,dc=com',
                         newPasswd='hushhush'),
                     id=2)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -759,7 +760,7 @@ class LDAPServerTest(unittest.TestCase):
                     dn='cn=thingie,ou=stuff,dc=example,dc=com',
                     auth='secret'),
                 id=4)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -775,8 +776,8 @@ class LDAPServerTest(unittest.TestCase):
                         userIdentity='cn=thingie,ou=stuff,dc=example,dc=com',
                         newPasswd='hushhush'),
                     id=2)))
-        self.assertEquals(data['committed'], True, "Server never committed data.")
-        self.assertEquals(
+        self.assertEqual(data['committed'], True, "Server never committed data.")
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -786,22 +787,23 @@ class LDAPServerTest(unittest.TestCase):
                     id=2)))
         # tree changed
         secrets = self.thingie.get('userPassword', [])
-        self.assertEquals(len(secrets), 1)
+        self.assertEqual(len(secrets), 1)
         for secret in secrets:
-            self.assertEquals(secret[:len('{SSHA}')], '{SSHA}')
+            self.assertEqual(secret[:len('{SSHA}')], '{SSHA}')
             raw = base64.decodestring(secret[len('{SSHA}'):])
             salt = raw[20:]
-            self.assertEquals(entry.sshaDigest('hushhush', salt), secret)
+            self.assertEqual(entry.sshaDigest('hushhush', salt), secret)
 
     def test_unknownRequest(self):
         # make server miss one of the handle_* attributes
         # without having to modify the LDAPServer class
         class MockServer(ldapserver.LDAPServer):
             handle_LDAPBindRequest = property()
+
         self.server.__class__ = MockServer
         self.server.dataReceived(str(pureldap.LDAPMessage(
             pureldap.LDAPBindRequest(), id=2)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -816,7 +818,7 @@ class LDAPServerTest(unittest.TestCase):
             pureldap.LDAPBindRequest(), id=2,
             controls=[('42.42.42.42', True, None),
                       ])))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(
@@ -832,7 +834,7 @@ class LDAPServerTest(unittest.TestCase):
                                      auth='secret'),
             controls=[('42.42.42.42', False, None)],
             id=4)))
-        self.assertEquals(
+        self.assertEqual(
             self.server.transport.value(),
             str(
                 pureldap.LDAPMessage(

--- a/ldaptor/test/test_smbpassword.py
+++ b/ldaptor/test/test_smbpassword.py
@@ -43,7 +43,7 @@ class TestLMHash(unittest.TestCase):
         for password, expected_result in self.knownValues:
             cfg.set('samba', 'use-lmhash', 'no')
             disabled = smbpassword.lmhash(password)
-            self.assertEquals(disabled, 32*'X',
+            self.assertEqual(disabled, 32*'X',
                               "Disabled lmhash must be X's: %r" % disabled)
 
             cfg.set('samba', 'use-lmhash', 'yes')

--- a/ldaptor/test/test_svcbindproxy.py
+++ b/ldaptor/test/test_svcbindproxy.py
@@ -83,7 +83,7 @@ class ServiceBindingProxy(unittest.TestCase):
                                                                      +')'),
                                        attributes=('1.1',)),
             )
-        self.assertEquals(server.transport.value(),
+        self.assertEqual(server.transport.value(),
                           str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=ldaperrors.LDAPInvalidCredentials.resultCode), id=4)))
 
     def test_bind_noMatchingServicesFound_fallback_success(self):
@@ -144,7 +144,7 @@ class ServiceBindingProxy(unittest.TestCase):
                                                                      +')'),
                                        attributes=('1.1',)),
             pureldap.LDAPBindRequest(dn='cn=jack,dc=example,dc=com', auth='s3krit'))
-        self.assertEquals(server.transport.value(),
+        self.assertEqual(server.transport.value(),
                           str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=ldaperrors.Success.resultCode), id=4)))
 
     def test_bind_noMatchingServicesFound_fallback_badAuth(self):
@@ -206,7 +206,7 @@ class ServiceBindingProxy(unittest.TestCase):
                                                                      +')'),
                                        attributes=('1.1',)),
             pureldap.LDAPBindRequest(dn='cn=jack,dc=example,dc=com', auth='wrong-s3krit'))
-        self.assertEquals(server.transport.value(),
+        self.assertEqual(server.transport.value(),
                           str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=ldaperrors.LDAPInvalidCredentials.resultCode), id=4)))
 
 
@@ -246,7 +246,7 @@ class ServiceBindingProxy(unittest.TestCase):
                                        attributes=('1.1',)),
             pureldap.LDAPBindRequest(dn=r'cn=svc1+owner=cn\=jack\,dc\=example\,dc\=com,dc=example,dc=com', auth='secret'),
             )
-        self.assertEquals(server.transport.value(),
+        self.assertEqual(server.transport.value(),
                           str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=ldaperrors.Success.resultCode,
                                                                              matchedDN='cn=jack,dc=example,dc=com'), id=4)))
 
@@ -322,7 +322,7 @@ class ServiceBindingProxy(unittest.TestCase):
                                        attributes=('1.1',)),
             pureldap.LDAPBindRequest(dn='cn=svc3+owner=cn\=jack\,dc\=example\,dc\=com,dc=example,dc=com', auth='secret'),
             )
-        self.assertEquals(server.transport.value(),
+        self.assertEqual(server.transport.value(),
                           str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=ldaperrors.Success.resultCode,
                                                                              matchedDN='cn=jack,dc=example,dc=com'), id=4)))
 
@@ -400,5 +400,5 @@ class ServiceBindingProxy(unittest.TestCase):
             pureldap.LDAPBindRequest(dn='cn=svc3+owner=cn\=jack\,dc\=example\,dc\=com,dc=example,dc=com', auth='wrong-s3krit'),
             pureldap.LDAPBindRequest(version=3, dn='cn=jack,dc=example,dc=com', auth='wrong-s3krit'),
             )
-        self.assertEquals(server.transport.value(),
+        self.assertEqual(server.transport.value(),
                           str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=ldaperrors.LDAPInvalidCredentials.resultCode), id=4)))

--- a/ldaptor/test/util.py
+++ b/ldaptor/test/util.py
@@ -8,17 +8,22 @@ from StringIO import StringIO
 class FakeTransport(protocol.FileWrapper):
     disconnecting = False
     disconnect_done = False
+
     def __init__(self, addr, peerAddr):
         self.data = StringIO()
         protocol.FileWrapper.__init__(self, self.data)
         self.addr = addr
         self.peerAddr = peerAddr
+
     def getHost(self):
         return self.addr
+
     def getPeer(self):
         return self.peerAddr
+
     def loseConnection(self):
         self.disconnecting = True
+
 
 class FasterIOPump(testutils.IOPump):
     def pump(self):
@@ -41,8 +46,10 @@ class FasterIOPump(testutils.IOPump):
         else:
             return 0
 
+
 class IOPump(FasterIOPump):
     active = []
+
     def __init__(self,
                  client, server,
                  clientTransport, serverTransport):
@@ -54,6 +61,7 @@ class IOPump(FasterIOPump):
                                   clientIO=clientTransport.data,
                                   serverIO=serverTransport.data)
         self.active.append(self)
+
     def pump(self):
         FasterIOPump.pump(self)
         if (self.clientTransport.disconnecting
@@ -79,8 +87,9 @@ class IOPump(FasterIOPump):
             self.clientIO.getvalue(),
             self.server,
             self.serverIO.getvalue(),
-
             )
+
+
 def returnConnected(server, client,
                     clientAddress=None,
                     serverAddress=None):
@@ -103,8 +112,10 @@ def returnConnected(server, client,
     pump.flush()
     return pump
 
+
 def _append(result, lst):
     lst.append(result)
+
 
 def _getDeferredResult(d, timeout=None):
     if timeout is not None:
@@ -116,6 +127,7 @@ def _getDeferredResult(d, timeout=None):
             pump.pump()
         reactor.iterate()
     return resultSet[0]
+
 
 def pumpingDeferredResult(d, timeout=None):
     result = _getDeferredResult(d, timeout)
@@ -132,4 +144,4 @@ def pumpingDeferredError(d, timeout=None):
     if isinstance(result, failure.Failure):
         return result
     else:
-        raise unittest.FailTest, "Deferred did not fail: %r" % (result,)
+        raise unittest.FailTest("Deferred did not fail: %r" % (result,))

--- a/ldaptor/testutil.py
+++ b/ldaptor/testutil.py
@@ -6,18 +6,23 @@ from twisted.trial import unittest
 from twisted.test import proto_helpers
 from ldaptor import config
 
+
 def mustRaise(dummy):
     raise unittest.FailTest('Should have raised an exception.')
 
+
 def calltrace():
     """Print out all function calls. For debug use only."""
+
     def printfuncnames(frame, event, arg):
-        print "|%s: %s:%d:%s" % (event,
-                                 frame.f_code.co_filename,
-                                 frame.f_code.co_firstlineno,
-                                 frame.f_code.co_name)
+        print("|%s: %s:%d:%s" %
+              (event, frame.f_code.co_filename,
+               frame.f_code.co_firstlineno,
+               frame.f_code.co_name))
+
     import sys
     sys.setprofile(printfuncnames)
+
 
 class FakeTransport:
     def __init__(self, proto):
@@ -25,6 +30,7 @@ class FakeTransport:
 
     def loseConnection(self):
         self.proto.connectionLost()
+
 
 class LDAPClientTestDriver:
     """
@@ -44,8 +50,8 @@ class LDAPClientTestDriver:
     fakeUnbindResponse = 'fake-unbind-by-LDAPClientTestDriver'
 
     def __init__(self, *responses):
-        self.sent=[]
-        self.responses=list(responses)
+        self.sent = []
+        self.responses = list(responses)
         self.connected = None
         self.transport = FakeTransport(self)
 
@@ -133,6 +139,7 @@ class LDAPClientTestDriver:
         self.send_noResponse(r)
         self.transport.loseConnection()
 
+
 def createServer(proto, *responses, **kw):
     """
     Create an LDAP server for testing.
@@ -145,16 +152,18 @@ def createServer(proto, *responses, **kw):
         del kw['proto_args']
     else:
         proto_args = {}
+
     def createClient(factory):
         factory.doStart()
         proto = factory.buildProtocol(addr=None)
         proto.connectionMade()
+
     overrides = kw.setdefault('serviceLocationOverrides', {})
     overrides.setdefault('', createClient)
     conf = config.LDAPConfig(**kw)
     server = proto(conf, **proto_args)
     clientTestDriver = LDAPClientTestDriver(*responses)
-    server.protocol = lambda : clientTestDriver
+    server.protocol = lambda: clientTestDriver
     server.clientTestDriver = clientTestDriver
     server.transport = proto_helpers.StringTransport()
     server.connectionMade()


### PR DESCRIPTION
Scope
========

As part for #55 @psi29a  has created https://github.com/psi29a/ldaptor/tree/python3 but beside py3 changes it contains a lot of non-py3 changes.

That branch hasa conflict with latest master so make a future merge simpler this takes those non-py3 changes

You can see the diff here https://github.com/twisted/ldaptor/compare/master...psi29a:python3

Changes 
=======

I tried to only put non-controversial changes.

For some simple cases I tried to update the way raises is used, but this is not a complete change for all exception raising or catching.

In preparation for py3 unit testing I have renamed all assertEquals to assertEqual

How to check
=============


This is huge but I hope that most of the changes will only need time to check.

