### PR TITLE
Update the dev docs to reflect the current process.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ env:
     - TOX_ENV=py27-tw160
     - TOX_ENV=py27-tw150
     - TOX_ENV=py27-tw140
-    - TOX_ENV=pyflakes
-    - TOX_ENV=manifest
+    - TOX_ENV=linters
 
 matrix:
   fast_finish: true

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,11 +1,26 @@
 How to Contribute
 =================
 
-Head over to: https://github.com/twisted/ldaptor and submit your bugs or feature requests.
-If you wish to contribute code, just fork it, make a branch and send us a pull request.
+Head over to: https://github.com/twisted/ldaptor and submit your bugs or
+feature requests.
+
+If you wish to contribute code, just fork it,
+make a branch and send us a pull request.
 We'll review it, and push back if necessary.
 
-Ldaptor generally follows the coding and documentation standards of the Twisted project.
+Check docs/PULL_REQUEST_TEMPLATE.md for more info about how to pull request
+process.
+
+Ldaptor generally follows the coding and documentation standards of the Twisted
+project.
+
+
+Release notes
+-------------
+
+To simplify the release process each change should be recorded into the
+docs/source/NEWS.rst in a wording targeted to end users.
+Try not to write the release notes as a commit message.
 
 
 Building the documentation

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include docs/source/examples/ldif2ldif
 include ldaptor.schema
 include test-ldapserver.tac
 include tox.ini
+exclude docs/PULL_REQUEST_TEMPLATE.md
 prune docs/build/html
 prune ldaptor/test/ldif/webtests.tmp
 recursive-include docs *.cfg

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,4 @@ https://github.com/twisted/ldaptor/blob/master/CONTRIBUTING.rst
 
 * [ ] I have updated the release notes at `docs/source/NEWS.rst` 
 * [ ] I have updated the automated tests.
-* [ ] All tests pass on your local system for `tox -e py27-twlatest,pyflakes`
+* [ ] All tests pass on your local system for `tox -e py27-twlatest,linters`

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Remove this paragraph
+
+Please have a look at our dev docs before submitting your PR:
+https://github.com/twisted/ldaptor/blob/master/CONTRIBUTING.rst
+
+
+### Contributor Checklist:
+
+* [ ] I have updated the release notes at `docs/source/NEWS.rst` 
+* [ ] I have updated the automated tests.
+* [ ] All tests pass on your local system for `tox -e py27-twlatest,pyflakes`

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 envlist =
     {py27}-{twlatest,twtrunk,tw162,tw160,tw154,tw150,tw140},{py33,py34,py35}-{twtrunk},
-    pyflakes,
-    manifest,
+    linters,
     documentation,
 
 
@@ -27,15 +26,13 @@ commands =
     coverage report --omit=ldaptor/test/* --show-missing
 
 
-[testenv:pyflakes]
-deps = pyflakes
-commands = pyflakes ldaptor
-
-
-[testenv:manifest]
+[testenv:linters]
 deps =
+    pyflakes
     check-manifest
+basepython=python2.7
 commands =
+    pyflakes ldaptor
     check-manifest
 
 


### PR DESCRIPTION
Scope
=====

This updated dev docs to guide existing and new developers in the dev process.


Changes
======

Add GitHub PR template

To reduce the load on travis-ci, and the noise on the PR I am recomending to some tests on local machine to make sure the branch is green.

If you are working only on ldaptor you might remember that beside `tox -e pyflakes` you should also run the manifest checker, but for example I forgot to do that for this PR and only run pyflakes,

Update CONTRIB docs to talk about release notes requirements.

I have merged pyflakes and manifest checker into a single tox env. I find it easier to use.
Later we can add pep8 checks or other checks and we will not have to add new env each time and update docs to instruct devs to use them.

--------

The dev docs talk about code compatibility with Twisted style, but I think that is better to go with pep8.
It should require fewer changes ... and we will have a tool to check the style... the twisted codestyle checker is broken.


How to check
==========

I am still not sure what type of changes should go in release notes and which not.
If we want everything, maybe we should make sure PR merge messages are valid and auto-generate the release notes from that.

Check that the information is valid.

The github PR can't be check unless this is merged into master.

To see how MD looks you can use https://stackedit.io/editor

   