### PR TITLE
Add codecov reporting for coverage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,13 @@ matrix:
     - env: TOX_ENV=py34-twtrunk
 
 install:
-  - pip install tox coveralls
+  - pip install tox coveralls codecov
 
 script:
   - tox -e $TOX_ENV
 
 after_success:
+  - codecov
   - coveralls
 
 notifications:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include docs/source/examples/ldif2ldif
 include ldaptor.schema
 include test-ldapserver.tac
 include tox.ini
+exclude codecov.yml
 exclude docs/PULL_REQUEST_TEMPLATE.md
 prune docs/build/html
 prune ldaptor/test/ldif/webtests.tmp

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+# See https://github.com/codecov/support/wiki/Codecov-Yaml
+codecov:
+  notify:
+    require_ci_to_pass: no
+
+coverage:
+  precision: 2
+  round: down
+  range: 80..100
+  status:
+    patch:
+      default:
+        target: 100%
+    project:
+      default:
+        target: auto
+      tests:
+        target: 100%
+        paths:
+          - "ldaptor/tests/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -17,4 +17,4 @@ coverage:
       tests:
         target: 100%
         paths:
-          - "ldaptor/test/*"
+          - "ldaptor/test/test_*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -17,4 +17,4 @@ coverage:
       tests:
         target: 100%
         paths:
-          - "ldaptor/tests/*"
+          - "ldaptor/test/*"

--- a/ldaptor/test/test_autofill_posix.py
+++ b/ldaptor/test/test_autofill_posix.py
@@ -18,16 +18,13 @@ class LDAPAutoFill_Posix(unittest.TestCase):
             'objectClass': ['something', 'other'],
             })
         autoFiller = posixAccount.Autofill_posix(baseDN='dc=example,dc=com')
+
         d = o.addAutofiller(autoFiller)
-        def _cbMustRaise(_):
-            raise unittest.FailTest('Should have raised an exception')
-        def _eb(fail):
-            client.assertNothingSent()
-            fail.trap(autofill.ObjectMissingObjectClassException)
-            return None
-        d.addCallbacks(_cbMustRaise,
-                       _eb)
-        return d
+
+        failure = self.failureResultOf(d)
+        self.assertIsInstance(
+          failure.value, autofill.ObjectMissingObjectClassException)
+        client.assertNothingSent()
 
     def testDefaultSetting(self):
         """Test that fields get their default values."""

--- a/ldaptor/test/test_ldapfilter.py
+++ b/ldaptor/test/test_ldapfilter.py
@@ -7,18 +7,6 @@ from ldaptor.protocols import pureldap
 from ldaptor import ldapfilter
 import types
 
-def s(*l):
-    """Join all members of list to a string. Integer members are chr()ed"""
-    r=''
-    for e in l:
-        if isinstance(e, types.IntType):
-            e=chr(e)
-        r=r+str(e)
-    return r
-
-def l(s):
-    """Split a string to ord's of chars."""
-    return map(lambda x: ord(x), s)
 
 class RFC2254Examples(unittest.TestCase):
     def test_cn(self):

--- a/ldaptor/test/test_ldapfilter.py
+++ b/ldaptor/test/test_ldapfilter.py
@@ -5,7 +5,6 @@ Test cases for ldaptor.protocols.ldap.ldapfilter module.
 from twisted.trial import unittest
 from ldaptor.protocols import pureldap
 from ldaptor import ldapfilter
-import types
 
 
 class RFC2254Examples(unittest.TestCase):

--- a/ldaptor/test/test_ldiftree.py
+++ b/ldaptor/test/test_ldiftree.py
@@ -248,8 +248,6 @@ cn: create-me
             'objectClass': ['top'],
             'cn': ['bad-create'],
             })
-        failures = []
-
 
         d = ldiftree.put(self.tree, e)
 

--- a/ldaptor/test/test_merger.py
+++ b/ldaptor/test/test_merger.py
@@ -30,8 +30,6 @@ class MergedLDAPServerTest(unittest.TestCase):
 
         clients = []
         for r in responses:
-            if not isinstance(r, list):
-                raise Exception()
             clients.append(testutil.LDAPClientTestDriver(*r))
 
         conf = config.LDAPConfig(serviceLocationOverrides={"": createClient})
@@ -135,12 +133,16 @@ class MergedLDAPServerTest(unittest.TestCase):
         return d
 
     def test_unbind_clientEOF(self):
+        """
+        No connection is done when client has nothing to say.
+        """
         d = self.createMergedServer([[]], [[]])
 
         def test_f(server):
             server.connectionLost(error.ConnectionDone)
-            for c in server.clients:
-                c.assertSent('fake-unbind-by-LDAPClientTestDriver')
+
+            self.assertEqual(
+              [], server.clients, 'A connection should not be done.')
             self.assertEqual(server.transport.value(), "")
 
         d.addCallback(test_f)

--- a/ldaptor/test/test_pureber.py
+++ b/ldaptor/test/test_pureber.py
@@ -19,7 +19,7 @@ Test cases for ldaptor.protocols.pureber module.
 
 from twisted.trial import unittest
 from ldaptor.protocols import pureber
-import types
+
 
 def s(*l):
     """Join all members of list to a string. Integer members are chr()ed"""

--- a/ldaptor/test/test_pureber.py
+++ b/ldaptor/test/test_pureber.py
@@ -25,9 +25,8 @@ def s(*l):
     """Join all members of list to a string. Integer members are chr()ed"""
     r=''
     for e in l:
-        if isinstance(e, types.IntType):
-            e=chr(e)
-        r=r+str(e)
+        e = chr(e)
+        r = r + str(e)
     return r
 
 def l(s):

--- a/ldaptor/test/test_pureldap.py
+++ b/ldaptor/test/test_pureldap.py
@@ -617,12 +617,12 @@ class KnownValues(unittest.TestCase):
             result = klass(*args, **kwargs)
             result = str(result)
             result = map(ord, result)
-            if result!=encoded:
-                raise AssertionError(
-                      "Class %s(*%s, **%s) doesn't encode properly: "
-                      "%s != %s" % (klass.__name__,
-                                    repr(args), repr(kwargs),
-                                    repr(result), repr(encoded)))
+
+            message = (
+                "Class %s(*%r, **%r) doesn't encode properly: "
+                "%r != %r" % (
+                    klass.__name__, args, kwargs, result, encoded))
+            self.assertEqual(encoded, result, message)
 
     def testFromLDAP(self):
         """LDAPClass(encoded="...") should give known result with known input"""
@@ -1012,14 +1012,11 @@ class TestFilterSetEquality(unittest.TestCase):
         self.assertEqual(filter1, filter2)
 
     def test_escape_and_equal(self):
-        def custom_escaper(s):
-            return ''.join(bin(ord(c)) for c in s)
 
         filter1 = pureldap.LDAPFilter_and([
             pureldap.LDAPFilter_equalityMatch(
                 attributeDesc=pureldap.LDAPAttributeDescription('foo'),
                 assertionValue=pureldap.LDAPAttributeValue('1'),
-                escaper=custom_escaper
             ),
             pureldap.LDAPFilter_equalityMatch(
                 attributeDesc=pureldap.LDAPAttributeDescription('foo'),
@@ -1034,7 +1031,6 @@ class TestFilterSetEquality(unittest.TestCase):
             pureldap.LDAPFilter_equalityMatch(
                 attributeDesc=pureldap.LDAPAttributeDescription('foo'),
                 assertionValue=pureldap.LDAPAttributeValue('2'),
-                escaper=custom_escaper
             ),
         ])
 

--- a/ldaptor/test/test_server.py
+++ b/ldaptor/test/test_server.py
@@ -104,10 +104,7 @@ class LDAPServerTest(unittest.TestCase):
         buffer = s
         value = []
         while 1:
-            try:
-                o, bytes = pureber.berDecodeObject(berdecoder, buffer)
-            except pureber.BERExceptionInsufficientData:
-                o, bytes = None, 0
+            o, bytes = pureber.berDecodeObject(berdecoder, buffer)
             buffer = buffer[bytes:]
             if not o:
                 break
@@ -649,38 +646,6 @@ class LDAPServerTest(unittest.TestCase):
                 self.another,
             ])
         return d
-
-    def test_modifyDN_rdnOnly_noDeleteOldRDN_success(self):
-        newrdn = 'cn=thingamagic'
-        self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPModifyDNRequest(
-                        entry=self.thingie.dn,
-                        newrdn=newrdn,
-                        deleteoldrdn=False),
-                    id=2)))
-        self.assertEqual(
-            self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPModifyDNResponse(
-                        resultCode=ldaperrors.Success.resultCode),
-                    id=2)))
-        # tree changed
-        d = self.stuff.children()
-        d.addCallback(
-            self.assertItemsEqual,
-            {self.another,
-                inmemory.ReadOnlyInMemoryLDAPEntry(
-                    '%s,ou=stuff,dc=example,dc=com' % newrdn,
-                    {
-                        'objectClass': ['a', 'b'],
-                        'cn': ['thingamagic', 'thingie']
-                    })})
-        return d
-
-    test_modifyDN_rdnOnly_noDeleteOldRDN_success.todo = 'Not supported yet.'
 
     def test_modify(self):
         self.server.dataReceived(

--- a/ldaptor/test/test_smbpassword.py
+++ b/ldaptor/test/test_smbpassword.py
@@ -18,11 +18,12 @@ class TestNTHash(unittest.TestCase):
 
     def testKnownValues(self):
         """nthash(...) gives known results"""
-        for password, expected_result in self.knownValues:
+        for password, expected in self.knownValues:
+
             result = smbpassword.nthash(password)
-            if result != expected_result:
-                raise AssertionError('nthash(%s)=%s, expected %s' % (
-                    repr(password), repr(result), repr(expected_result)))
+
+            self.assertEqual(expected, result)
+
 
 class TestLMHash(unittest.TestCase):
     knownValues=( # password, expected_result
@@ -40,14 +41,14 @@ class TestLMHash(unittest.TestCase):
     def testKnownValues(self):
         """lmhash(...) gives known results"""
         cfg = config.loadConfig()
-        for password, expected_result in self.knownValues:
+        for password, expected in self.knownValues:
             cfg.set('samba', 'use-lmhash', 'no')
             disabled = smbpassword.lmhash(password)
             self.assertEqual(disabled, 32*'X',
                               "Disabled lmhash must be X's: %r" % disabled)
 
             cfg.set('samba', 'use-lmhash', 'yes')
+
             result = smbpassword.lmhash(password)
-            if result != expected_result:
-                raise AssertionError('lmhash(%s)=%s, expected %s' % (
-                        repr(password), repr(result), repr(expected_result)))
+
+            self.assertEqual(expected, result)

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands =
     {envpython} --version
     trial --version
     coverage run --source ldaptor --branch {envdir}/bin/trial ldaptor
-    coverage report --omit=ldaptor/test/* --show-missing
+    coverage report --show-missing
 
 
 [testenv:linters]


### PR DESCRIPTION
Scope
=====

This add codecov.io reporting when running on Travis

This  should give status for PR diff coverage.

Also, codecov.io can be configured via a file hosted on the repo so it should be much easier for other to configure it... no need to mess with webpage config.


Changes
=======

I set up the patch status to fail if diff is not 100%

I have also set up a custom report for the test code to make sure that we have 100%  test coverage... that is all tests are executed and we don't have tests which sit there and are not executed

I also kept the coveralls.

--------

As part of making the report useful and not have master red, I have updated the test code to have 100% coverage.

I have removed the .todo tests and move them to separate issues.
I find them annoying as after each run I see them fail... and then I have to ignore them. 

--------

A lot of the tests are synchronous and don't need to spin to reactor... so there is no point in returning a deferred and we can use the sync assertions like self.successResultOf and self.failureResultOf


How to test
=========

You should see the commit status reports from codecov.io

