### PR TITLE
Fix coverage reporting for local dev environment.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+branch = True
+source = ldaptor
+
+[paths]
+source =
+    ldaptor
+    */ldaptor
+    *\ldaptor

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.pyc
 *.pyo
 _trial_temp/
-.tox/
 ldaptor.test.*/
 ldaptor/test/ldif/webtests.tmp
 docs/*.png

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ python:
 env:
   - TOX_ENV=py27-twlatest
   - TOX_ENV=py27-twtrunk
-  - TOX_ENV=py27-tw162
-  - TOX_ENV=py27-tw160
-  - TOX_ENV=py27-tw150
-  - TOX_ENV=py27-tw140
   - TOX_ENV=py34-twtrunk
   - TOX_ENV=linters
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -15,6 +15,20 @@ Ldaptor generally follows the coding and documentation standards of the Twisted
 project.
 
 
+Development environment
+-----------------------
+
+Tox is used to manage both local development and CI environment.
+
+The recommended local dev enviroment is `tox -e py27-dev`
+
+When running on local dev env, you will get a coverage report for whole
+code as well as for the changes since `master.
+The reports are also produced in HTML at:
+* build/coverage-html/index.html
+* build/coverage-diff.html
+
+
 Release notes
 -------------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,10 +6,6 @@ include docs/source/examples/ldif2ldif
 include ldaptor.schema
 include test-ldapserver.tac
 include tox.ini
-exclude codecov.yml
-exclude docs/PULL_REQUEST_TEMPLATE.md
-prune docs/build/html
-prune ldaptor/test/ldif/webtests.tmp
 recursive-include docs *.cfg
 recursive-include docs *.conf
 recursive-include docs *.dia
@@ -26,3 +22,14 @@ recursive-include docs Makefile
 recursive-include docs/source/examples/addressbook run
 recursive-include docs/source/examples/addressbook summary
 recursive-include ldaptor *.ldif
+
+# This is only needed by CI when reporting coverage.
+exclude codecov.yml
+
+# This is only needed by GitHub.
+exclude docs/PULL_REQUEST_TEMPLATE.md
+
+# This is only needed for dev purporse.
+exclude .coveragerc
+prune docs/build/html
+prune ldaptor/test/ldif/webtests.tmp

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,4 @@ https://github.com/twisted/ldaptor/blob/master/CONTRIBUTING.rst
 
 * [ ] I have updated the release notes at `docs/source/NEWS.rst` 
 * [ ] I have updated the automated tests.
-* [ ] All tests pass on your local system for `tox -e py27-twlatest,linters`
+* [ ] All tests pass on your local system for `tox -e py27-dev,linters`

--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -16,6 +16,8 @@ Changes
 - Using modern classmethod decorator instead of old-style method call.
 - Usage of zope.interfaces was updated in preparation for python3 port.
 - Code was updated to pass `python3 -m compileall` in preparation for py3 port.
+- Continuous test are executed only against latest related Twisted and latest
+  Twisted trunk branch.
 
 Bugfixes
 ^^^^^^^^

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,13 @@
+; tox configuration file for running tests on local dev env and Travis CI.
+;
+; The local dev environment will be executed against latest released Twisted.
+; The coverage is reported only and local dev and not on Travis-CI as there
+; we have separate reported (ex codecov.io)
+
 [tox]
+toxworkdir=build/
 envlist =
-    {py27}-{twlatest,twtrunk,tw162,tw160,tw154,tw150,tw140},{py33,py34,py35}-{twtrunk},
+    {py27}-{twlatest,dev,twtrunk},{py33,py34,py35}-{twtrunk,dev},
     linters,
     documentation,
 
@@ -19,11 +26,22 @@ deps =
     tw154: Twisted==15.4
     tw150: Twisted==15.0
     tw140: Twisted==14.0
+    ; Dependecies for local dev environment.
+    dev: Twisted
+    dev: diff_cover
+
+; All environment variables are passed.
+passenv = *
+
 commands =
     {envpython} --version
     trial --version
-    coverage run --source ldaptor --branch {envdir}/bin/trial ldaptor
-    coverage report --show-missing
+    coverage run --rcfile={toxinidir}/.coveragerc -m twisted.trial ldaptor
+    ; Only run on local dev env.
+    dev: coverage report --show-missing
+    dev: coverage xml -o {toxinidir}/build/coverage.xml
+    dev: coverage html -d build/coverage-html
+    dev: diff-cover --fail-under 100 --html-report {toxinidir}/build/coverage-diff.html {toxinidir}/build/coverage.xml
 
 
 [testenv:linters]


### PR DESCRIPTION
Scope
=====

This updates the development environment to report coverage.

Based on that it will produce coverage reports in HTML, as well as a diff coverage since master.

Changes
========

The important thing was to run trial with '-m' and in this way the coverage was reported.
I think that coverage was confusing ldaptor source with ldaptor package.

I have created a dedicated configurate for coverage so that we don't have to pass a long list of arguments.

I have moved the whole .tox files to build/ as this should be the standard folder for dev related things.

On the build folder I am putting the HTML reports, and all other intermediary files.

I have recognized the tox file so that the linters are also run for the dev environment.
In this way it should be easier to detect errors and reduce the change of pushing bad commits, and creating extra work for Travis-CI

While working on this, I have tested this by working on ldaptor/attributeset.py

I have removed the unused methods as in py2.7 we have different methods.
It looks like the test pass with default set inheritance.


How to test
========

Check that the updated dev docs make sense and that you get coverage reporting on local tox, as well as in buildbot