### PR TITLE
Fix simple-app.rst: 'server' was meant here

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,6 +14,7 @@ coverage:
     project:
       default:
         target: auto
+        threshold: 0.05
       tests:
         target: 100%
         paths:

--- a/docs/source/simple-app.rst
+++ b/docs/source/simple-app.rst
@@ -79,7 +79,7 @@ Following Along with the Examples
 
 If you are following along with the interactive examples, you will need an LDAP 
 directory server to which the example client can connect.  A script that 
-creates such a client is available in the section :ref:`quickstart-server-label`.
+creates such a server is available in the section :ref:`quickstart-server-label`.
 Copy the script to a file `quickstart_server.py` and run it in another terminal::
 
     $ python quickstart_server.py 10389


### PR DESCRIPTION
Just a documentation fix. The example server of course creates a server, not a client :) 

As this is only a documentation fix I have not done the checklist for contribution. Thank you for understanding.
