### PR TITLE
Fix proxy race condition with immediately disconnecting clients (#105)

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -32,6 +32,7 @@ Bugfixes
 ^^^^^^^^
 
 - DN matching is now case insensitive.
+- Proxies now terminate the connection to the proxied server in case a client immediately closes the connection.
 
 
 Release 16.0 (2016-06-07)

--- a/ldaptor/protocols/ldap/proxybase.py
+++ b/ldaptor/protocols/ldap/proxybase.py
@@ -62,10 +62,11 @@ class ProxyBase(ldapserver.BaseLDAPServer):
             return d
         else:
             self.client = proto
-            if not self.connected and not self.queuedRequests:
-                # Client has disconnected in the meantime without sending any requests
+            if not self.connected:
+                # Client no longer connected, proxy shouldn't be either
                 self.client.transport.loseConnection()
                 self.client = None
+                self.queuedRequests = []
             else:
                 self._processBacklog()
 

--- a/ldaptor/protocols/ldap/proxybase.py
+++ b/ldaptor/protocols/ldap/proxybase.py
@@ -62,7 +62,12 @@ class ProxyBase(ldapserver.BaseLDAPServer):
             return d
         else:
             self.client = proto
-            self._processBacklog()
+            if not self.connected and not self.queuedRequests:
+                # Client has disconnected in the meantime without sending any requests
+                self.client.transport.loseConnection()
+                self.client = None
+            else:
+                self._processBacklog()
 
     def _establishedTLS(self, proto):
         """

--- a/ldaptor/test/test_proxybase.py
+++ b/ldaptor/test/test_proxybase.py
@@ -247,3 +247,14 @@ class ProxyBase(unittest.TestCase):
         self.assertEqual(
             server.transport.value(),
             str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=52), id=4)))
+
+    def test_health_check_closes_connection_to_proxied_server(self):
+        """
+        When the client disconnects immediately and before the connection to the proxied server has
+        been established, the proxy terminates the connection to the proxied server.
+        """
+        server = self.createServer()
+        server.connectionLost(error.ConnectionDone)
+        server.reactor.advance(1)
+        self.assertIsNone(server.client)
+        self.assertFalse(server.clientTestDriver.connected)


### PR DESCRIPTION
This should fix #105.

I'm not sure if this completely rules out the race condition: This only handles clients that disconnect without having sent any data. Might a client be able to even send some LDAP requests before the connection to the proxied server has been established? In that case, they are added to ``queuedRequests``, and the connection persists.

I'm happy about any comments :)

### Contributor Checklist:

* [x] I have updated the release notes at `docs/source/NEWS.rst` 
* [x] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
