### PR TITLE
LDAPResponseEntry representation error

### DIFF
--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -883,22 +883,16 @@ class LDAPSearchResultEntry(LDAPProtocolResponse, BERSequence):
 
     def __repr__(self):
         if self.tag==self.__class__.tag:
-            return self.__class__.__name__\
-                   +"(objectName=%s, attributes=%s"\
-                   %(repr(str(self.objectName)),
-                     repr(map(lambda a, l:
-                              (str(a),
-                               map(lambda i, l=l: str(i), l)),
-                              self.attributes)))
+            return self.__class__.__name__ + "(objectName={}, attributes={}".format(
+                repr(str(self.objectName)),
+                repr([(a, [str(v) for v in l]) for (a, l) in self.attributes])
+            )
         else:
-            return self.__class__.__name__\
-                   +"(objectName=%s, attributes=%s, tag=%d"\
-                   %(repr(str(self.objectName)),
-                     repr(map(lambda a,l:
-                              (str(a),
-                               map(lambda i, l=l: str(i), l)),
-                              self.attributes)),
-                     self.tag)
+            return self.__class__.__name__ + "(objectName={}, attributes={}, tag={}".format(
+                repr(str(self.objectName)),
+                repr([(a, [str(v) for v in l]) for (a, l) in self.attributes]),
+                self.tag
+            )
 
 
 class LDAPSearchResultDone(LDAPResult):

--- a/ldaptor/test/test_pureldap.py
+++ b/ldaptor/test/test_pureldap.py
@@ -1069,10 +1069,13 @@ class TestRepresentations(unittest.TestCase):
     """
 
     def test_search_result_repr(self):
-        resp = pureldap.LDAPSearchResultEntry(
-            objectName='uid=mohamed,ou=people,dc=example,dc=fr',
-            attributes=[
-                ('uid', ['mohamed'])
-            ]
-        )
-        representation = repr(resp)
+        tags = [pureldap.LDAPSearchResultEntry.tag, "foobaz"]
+        for tag in tags:
+            resp = pureldap.LDAPSearchResultEntry(
+                objectName='uid=mohamed,ou=people,dc=example,dc=fr',
+                attributes=[
+                    ('uid', ['mohamed'])
+                ],
+                tag=tag
+            )
+            repr(resp)

--- a/ldaptor/test/test_pureldap.py
+++ b/ldaptor/test/test_pureldap.py
@@ -1061,3 +1061,18 @@ class Representations(unittest.TestCase):
         self.assertEqual(
             expected_value,
             repr(ldap_msg))
+
+
+class TestRepresentations(unittest.TestCase):
+    """
+    Test representations of common LDAP opbjects.
+    """
+
+    def test_search_result_repr(self):
+        resp = pureldap.LDAPSearchResultEntry(
+            objectName='uid=mohamed,ou=people,dc=example,dc=fr',
+            attributes=[
+                ('uid', ['mohamed'])
+            ]
+        )
+        representation = repr(resp)


### PR DESCRIPTION
A bug was introduced on 2018-01-07 in commit a7d0b3c7bad2.  It had to do with the representation of an `pureldap.LDAPResponseEntry` object.  A lambda function changed signature from `lambda x, y:` to `lambda (x, y):`.  The former takes 2 arguments; the latter takes only 1 argument.

* [x ] I have updated the automated tests.
* [ x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
