### PR TITLE
add parentheses around print() in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Quick Usage Example
       o = ldapsyntax.LDAPEntry(client, basedn)
       results = yield o.search(filterText=query)
       for entry in results:
-         print entry
+         print(entry)
 
    if __name__ == '__main__':
       df = example()


### PR DESCRIPTION
No reason to commit a python2-ism right there on the front page.  Hopefully the contributor checklist does not apply to a tiny change like this :)