### PR TITLE
Modernize syntax of the scripts in bin/

### DIFF
--- a/bin/ldaptor-fetchschema
+++ b/bin/ldaptor-fetchschema
@@ -30,7 +30,7 @@ def error(fail):
 def main(cfg):
     try:
         baseDN = cfg.getBaseDN()
-    except config.MissingBaseDNError, e:
+    except config.MissingBaseDNError as e:
         print("%s: %s." % (sys.argv[0], e), file=sys.stderr)
         sys.exit(1)
 
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     try:
         opts = MyOptions()
         opts.parseOptions()
-    except usage.UsageError, ue:
+    except usage.UsageError as ue:
         sys.stderr.write('%s: %s\n' % (sys.argv[0], ue))
         sys.exit(1)
 

--- a/bin/ldaptor-fetchschema
+++ b/bin/ldaptor-fetchschema
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import print_function
 import sys
 from ldaptor.protocols.ldap import ldapclient, ldapconnector, fetchschema
 from ldaptor import usage, config
@@ -10,19 +11,19 @@ def _printResults(x):
 
     something = False
     for at in attributeTypes:
-        print 'attributetype', at
+        print('attributetype', at)
         something = True
 
     if something:
-        print
+        print()
 
     for oc in objectClasses:
-        print 'objectclass', oc
+        print('objectclass', oc)
 
 exitStatus=0
 
 def error(fail):
-    print >>sys.stderr, 'fail:', fail.getErrorMessage()
+    print('fail:', fail.getErrorMessage(), file=sys.stderr)
     global exitStatus
     exitStatus=1
 
@@ -30,7 +31,7 @@ def main(cfg):
     try:
         baseDN = cfg.getBaseDN()
     except config.MissingBaseDNError, e:
-        print >>sys.stderr, "%s: %s." % (sys.argv[0], e)
+        print("%s: %s." % (sys.argv[0], e), file=sys.stderr)
         sys.exit(1)
 
     c = ldapconnector.LDAPClientCreator(reactor,

--- a/bin/ldaptor-find-server
+++ b/bin/ldaptor-find-server
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import print_function
 import sys
 from ldaptor.protocols.ldap.distinguishedname import DistinguishedName
 from twisted.internet.defer import DeferredList
@@ -10,12 +11,12 @@ def printAnswer(answers, dn):
     for rrlist in answers:
         for rr in rrlist:
             if isinstance(rr.payload, dns.Record_SRV):
-                print '%s\tpri=%d weight=%d %s:%d' % (dn,
+                print('%s\tpri=%d weight=%d %s:%d' % (dn,
                                                   rr.payload.priority,
                                                   rr.payload.weight,
                                                   rr.payload.target,
                                                   rr.payload.port,
-                                                  )
+                                                  ))
             else:
                 # suppress additional records
                 pass
@@ -24,7 +25,7 @@ def printAnswer(answers, dn):
 exitStatus = 0
 
 def errback(data):
-    print "ERROR:", data.getErrorMessage()
+    print("ERROR:", data.getErrorMessage())
     global exitStatus
     exitStatus=1
 
@@ -47,7 +48,7 @@ def main(dns):
 
 if __name__ == "__main__":
     if not sys.argv[1:]:
-        print >>sys.stderr, '%s: usage:' % sys.argv[0]
-        print >>sys.stderr, '  %s DN..' % sys.argv[0]
+        print('%s: usage:' % sys.argv[0], file=sys.stderr)
+        print('  %s DN..' % sys.argv[0], file=sys.stderr)
     else:
         main(sys.argv[1:])

--- a/bin/ldaptor-getfreenumber
+++ b/bin/ldaptor-getfreenumber
@@ -17,7 +17,7 @@ def error(fail):
 def main(cfg):
     try:
         baseDN = cfg.getBaseDN()
-    except config.MissingBaseDNError, e:
+    except config.MissingBaseDNError as e:
         print("%s: %s." % (sys.argv[0], e), file=sys.stderr)
         sys.exit(1)
 
@@ -48,7 +48,7 @@ if __name__ == "__main__":
     try:
         opts = MyOptions()
         opts.parseOptions()
-    except usage.UsageError, ue:
+    except usage.UsageError as ue:
         sys.stderr.write('%s: %s\n' % (sys.argv[0], ue))
         sys.exit(1)
 

--- a/bin/ldaptor-getfreenumber
+++ b/bin/ldaptor-getfreenumber
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import print_function
 import sys
 from ldaptor.protocols.ldap import ldapclient, ldapsyntax, ldapconnector
 from ldaptor import usage, numberalloc, config
@@ -8,8 +9,8 @@ from twisted.internet import reactor
 exitStatus=0
 
 def error(fail):
-    print fail
-    print >>sys.stderr, 'fail:', fail.getErrorMessage()
+    print(fail)
+    print('fail:', fail.getErrorMessage(), file=sys.stderr)
     global exitStatus
     exitStatus=1
 
@@ -17,7 +18,7 @@ def main(cfg):
     try:
         baseDN = cfg.getBaseDN()
     except config.MissingBaseDNError, e:
-        print >>sys.stderr, "%s: %s." % (sys.argv[0], e)
+        print("%s: %s." % (sys.argv[0], e), file=sys.stderr)
         sys.exit(1)
 
     c = ldapconnector.LDAPClientCreator(reactor,

--- a/bin/ldaptor-ldap2dhcpconf
+++ b/bin/ldaptor-ldap2dhcpconf
@@ -15,6 +15,7 @@
 #shared-network "foo" {
 #}
 
+from __future__ import print_function
 from ldaptor.protocols.ldap import ldapclient, ldapconnector, ldapsyntax
 from ldaptor.protocols import pureber, pureldap
 from ldaptor import usage, ldapfilter, config
@@ -75,7 +76,7 @@ class HostIPAddress:
                 yield '\tfilename "%s";' % self.host.bootFile
             yield '}'
 
-        print '\n'.join([prefix+line for line in output()])
+        print('\n'.join([prefix+line for line in output()]))
 
     def __repr__(self):
         return (self.__class__.__name__
@@ -92,9 +93,9 @@ class Group:
 
     def addHost(self, host):
         if host.group is not None:
-            print >>sys.stderr, (
+            print((
                 'Host %s is in two groups: %r and %r'
-                % (host.dn, host.group, self))
+                % (host.dn, host.group, self)), file=sys.stderr)
         else:
             host.group = self
             self.hosts.add(host)
@@ -107,17 +108,17 @@ class Group:
         addrs.difference_update(addresses)
 
         if addresses:
-            print prefix+'# '+str(self.dn)
-            print prefix+'group {'
+            print(prefix+'# '+str(self.dn))
+            print(prefix+'group {')
 
             if self.bootFile is not None:
                 # TODO quote bootFile
-                print prefix+'\tfilename "%s";' % self.bootFile
+                print(prefix+'\tfilename "%s";' % self.bootFile)
 
             for addr in addresses:
                 addr.printDHCP(domain, prefix=prefix+'\t')
 
-            print prefix+'}'
+            print(prefix+'}')
 
 class Host:
     group = None
@@ -186,7 +187,7 @@ class Net:
             r.append('\toption domain-name-servers %s;' % (', '.join(self.domainNameServers)))
         r.append('}')
 
-        print '\n'.join([prefix+line for line in r])
+        print('\n'.join([prefix+line for line in r]))
 
         addrs = sets.Set()
         for addr in self.hosts:
@@ -221,11 +222,11 @@ class SharedNet:
         self.nets.append(net)
 
     def printDHCP(self, domain):
-        print 'shared-network "%s" {' % self.name
+        print('shared-network "%s" {' % self.name)
         for net in self.nets:
             net.printDHCP(domain, prefix='\t')
-        print '}'
-        print
+        print('}')
+        print()
 
 def _cbGetGroups(entries, hosts):
     dnToHost = {}
@@ -403,7 +404,7 @@ def search(client, baseDN, filter, dnsDomain):
 exitStatus=0
 
 def error(fail):
-    print >>sys.stderr, 'fail:', fail.getErrorMessage()
+    print('fail:', fail.getErrorMessage(), file=sys.stderr)
     global exitStatus
     exitStatus=1
 
@@ -411,7 +412,7 @@ def main(cfg, filter_text, dnsDomain):
     try:
         baseDN = cfg.getBaseDN()
     except config.MissingBaseDNError, e:
-        print >>sys.stderr, "%s: %s." % (sys.argv[0], e)
+        print("%s: %s." % (sys.argv[0], e), file=sys.stderr)
         sys.exit(1)
 
     from twisted.python import log

--- a/bin/ldaptor-ldap2dhcpconf
+++ b/bin/ldaptor-ldap2dhcpconf
@@ -402,7 +402,7 @@ def error(fail):
 def main(cfg, filter_text, dnsDomain):
     try:
         baseDN = cfg.getBaseDN()
-    except config.MissingBaseDNError, e:
+    except config.MissingBaseDNError as e:
         print("%s: %s." % (sys.argv[0], e), file=sys.stderr)
         sys.exit(1)
 
@@ -443,7 +443,7 @@ if __name__ == "__main__":
     try:
         opts = MyOptions()
         opts.parseOptions()
-    except usage.UsageError, ue:
+    except usage.UsageError as ue:
         sys.stderr.write('%s: %s\n' % (sys.argv[0], ue))
         sys.exit(1)
 

--- a/bin/ldaptor-ldap2dhcpconf
+++ b/bin/ldaptor-ldap2dhcpconf
@@ -21,7 +21,6 @@ from ldaptor.protocols import pureber, pureldap
 from ldaptor import usage, ldapfilter, config
 from twisted.internet import reactor
 from socket import inet_aton, inet_ntoa
-import sets
 import struct
 
 
@@ -80,7 +79,7 @@ class Group:
     def __init__(self, dn, bootFile=None):
         self.dn = dn
         self.bootFile = bootFile
-        self.hosts = sets.Set()
+        self.hosts = set()
 
     def addHost(self, host):
         if host.group is not None:
@@ -92,9 +91,9 @@ class Group:
             self.hosts.add(host)
 
     def printDHCP(self, domain, addrs, prefix=''):
-        addresses = sets.Set([addr
-                              for host in self.hosts
-                              for addr in host.ipAddresses])
+        addresses = set(addr
+                        for host in self.hosts
+                        for addr in host.ipAddresses)
         addresses.intersection_update(addrs)
         addrs.difference_update(addresses)
 
@@ -180,9 +179,7 @@ class Net:
 
         print('\n'.join([prefix+line for line in r]))
 
-        addrs = sets.Set()
-        for addr in self.hosts:
-            addrs.add(addr)
+        addrs = set(self.hosts)
 
         for addr in self.hosts:
             g = addr.host.group
@@ -271,9 +268,9 @@ def haveGroups(hosts, nets, sharedNets, dnsDomain):
     for host in hosts:
         for hostIP in host.ipAddresses:
             parent=None
-            for net in nets + reduce(lambda x,y: x+y,
-                                          [x.nets for x in sharedNets.values()],
-                                          []):
+            for net in nets + list(net_
+                                   for x in sharedNets.values()
+                                   for net_ in x.nets):
                 if net.isInNet(hostIP.ipAddress):
                     parent=net
                     break
@@ -310,8 +307,8 @@ def _cbGetHosts(entries):
         cn = only(e, 'cn')
         hosts.append(Host(str(e.dn),
                           str(cn),
-                          map(str, e['ipHostNumber']),
-                          map(str, e.get('macAddress', ())),
+                          list(str(i) for i in e['ipHostNumber']),
+                          tuple(str(i) for i in e.get('macAddress', ())),
                           bootFile=only(e, 'bootFile', default=None),
                           ))
     return hosts
@@ -354,9 +351,9 @@ def _cbGetNets(entries):
                   winsServers=e.get('winsServer', ()),
                   domainNameServers=e.get('domainNameServer', ()),
                   )
-        if e.has_key('sharedNetworkName'):
+        if 'sharedNetworkName' in e:
             name = only(e, 'sharedNetworkName')
-            if not sharedNetworks.has_key(name):
+            if name not in sharedNetworks:
                 sharedNetworks[name]=SharedNet(name)
             sharedNetworks[name].addNet(net)
         else:

--- a/bin/ldaptor-ldap2dhcpconf
+++ b/bin/ldaptor-ldap2dhcpconf
@@ -22,15 +22,11 @@ from ldaptor import usage, ldapfilter, config
 from twisted.internet import reactor
 from socket import inet_aton, inet_ntoa
 import sets
+import struct
 
 
 def my_aton_octets(ip):
-    s=inet_aton(ip)
-    octets=map(None, s)
-    n=0L
-    for o in octets:
-        n=n<<8
-        n+=ord(o)
+    n, = struct.unpack('!I', inet_aton(ip))
     return n
 
 def my_aton_numbits(num):
@@ -50,12 +46,7 @@ def my_aton(ip):
         return my_aton_numbits(i)
 
 def my_ntoa(n):
-    s=(
-        chr((n>>24)&0xFF)
-        + chr((n>>16)&0xFF)
-        + chr((n>>8)&0xFF)
-        + chr(n&0xFF)
-       )
+    s=struct.pack('!I', n)
     ip=inet_ntoa(s)
     return ip
 

--- a/bin/ldaptor-ldap2dnszones
+++ b/bin/ldaptor-ldap2dnszones
@@ -161,7 +161,7 @@ def getHosts(nets, e, domain, forward, reverse, filter):
     def _cbGotHost(e):
         host = Host(str(e.dn),
                     str(only(e, 'cn')),
-                    map(str, e['ipHostNumber']))
+                    list(str(i) for i in e['ipHostNumber']))
         for hostIP in host.ipAddresses:
             parent=None
             for net in nets:
@@ -237,7 +237,7 @@ def main(cfg, domain, forward, reverse, filter_text):
         filt = None
 
     forwardTmp = '%s.%d.tmp' % (forward, os.getpid())
-    forwardFile = file(forwardTmp, 'w')
+    forwardFile = open(forwardTmp, 'w')
 
     print('$ORIGIN\t%s.' % domain, file=forwardFile)
     print(file=forwardFile)

--- a/bin/ldaptor-ldap2dnszones
+++ b/bin/ldaptor-ldap2dnszones
@@ -227,7 +227,7 @@ def main(cfg, domain, forward, reverse, filter_text):
 
     try:
         baseDN = cfg.getBaseDN()
-    except config.MissingBaseDNError, e:
+    except config.MissingBaseDNError as e:
         print("%s: %s." % (sys.argv[0], e), file=sys.stderr)
         sys.exit(1)
 
@@ -275,12 +275,12 @@ class MyOptions(usage.Options, usage.Options_service_location, usage.Options_bas
 
         try:
             address = dns.aton(addressString)
-        except socket.error, e:
+        except socket.error as e:
             raise usage.UsageError('--reverse= address is invalid: %s' % e)
 
         try:
             netmask = dns.aton(netmaskString)
-        except socket.error, e:
+        except socket.error as e:
             raise usage.UsageError('--reverse= netmask is invalid: %s' % e)
 
         self.opts.setdefault('reverse', []).append({
@@ -299,7 +299,7 @@ if __name__ == "__main__":
     try:
         opts = MyOptions()
         opts.parseOptions()
-    except usage.UsageError, ue:
+    except usage.UsageError as ue:
         sys.stderr.write('%s: %s\n' % (sys.argv[0], ue))
         sys.exit(1)
 

--- a/bin/ldaptor-ldap2dnszones
+++ b/bin/ldaptor-ldap2dnszones
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import print_function
 from ldaptor.protocols.ldap import distinguishedname, ldapconnector, ldapsyntax, ldapclient
 from ldaptor.protocols import pureber, pureldap
 from ldaptor import usage, ldapfilter, config, dns
@@ -106,7 +107,7 @@ class Net:
 exitStatus=0
 
 def error(fail):
-    print >>sys.stderr, 'fail:', str(fail) #.getErrorMessage()
+    print('fail:', str(fail), file=sys.stderr) #.getErrorMessage()
     global exitStatus
     exitStatus=1
 
@@ -137,7 +138,7 @@ def getNets(e, domain, forward, reverse, filter):
                       str(only(e, 'cn')),
                       str(only(e, 'ipNetworkNumber')),
                       str(only(e, 'ipNetmaskNumber')))
-            print >>forward, net.getForward()
+            print(net.getForward(), file=forward)
 
             for data in reverse:
                 ip = dns.aton(net.address)
@@ -145,7 +146,7 @@ def getNets(e, domain, forward, reverse, filter):
                     if 'file' not in data:
                         data['tempname'] = '%s.%d.tmp' % (data['filename'], os.getpid())
                         data['file'] = open(data['tempname'], 'w')
-                    print >>data['file'], net.getReverse(domain)
+                    print(net.getReverse(domain), file=data['file'])
                     net.reverseZone = data
             r.append(net)
         return r
@@ -169,13 +170,13 @@ def getHosts(nets, e, domain, forward, reverse, filter):
                     break
 
             if parent:
-                print >>forward, hostIP.getForward(parent.name)
+                print(hostIP.getForward(parent.name), file=forward)
                 if parent.reverseZone:
-                    print >>parent.reverseZone['file'], hostIP.getReverse(parent.name
+                    print(hostIP.getReverse(parent.name
                                                                           + '.'
-                                                                          + domain)
+                                                                          + domain), file=parent.reverseZone['file'])
                 else:
-                    print >>sys.stderr, "Not writing PTR for %s." % hostIP
+                    print("Not writing PTR for %s." % hostIP, file=sys.stderr)
             else:
                 sys.stderr.write("IP address %s is in no net, discarding.\n" % hostIP)
     d = e.search(filterObject=filt,
@@ -227,7 +228,7 @@ def main(cfg, domain, forward, reverse, filter_text):
     try:
         baseDN = cfg.getBaseDN()
     except config.MissingBaseDNError, e:
-        print >>sys.stderr, "%s: %s." % (sys.argv[0], e)
+        print("%s: %s." % (sys.argv[0], e), file=sys.stderr)
         sys.exit(1)
 
     if filter_text is not None:
@@ -238,8 +239,8 @@ def main(cfg, domain, forward, reverse, filter_text):
     forwardTmp = '%s.%d.tmp' % (forward, os.getpid())
     forwardFile = file(forwardTmp, 'w')
 
-    print >>forwardFile, '$ORIGIN\t%s.' % domain
-    print >>forwardFile
+    print('$ORIGIN\t%s.' % domain, file=forwardFile)
+    print(file=forwardFile)
 
     c=ldapconnector.LDAPClientCreator(reactor, ldapclient.LDAPClient)
     d = c.connectAnonymously(

--- a/bin/ldaptor-ldap2maradns
+++ b/bin/ldaptor-ldap2maradns
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import print_function
 from ldaptor.protocols.ldap import distinguishedname, ldapconnector, ldapsyntax, ldapclient
 from ldaptor.protocols import pureber, pureldap
 from ldaptor import usage, ldapfilter, config, dns
@@ -7,13 +8,13 @@ import sys
 from twisted.internet import protocol, defer, reactor
 
 def printIPAddress(name, ip):
-    print 'A'+name+'.%|86400|'+ip
+    print('A'+name+'.%|86400|'+ip)
 
 def printPTR(name, ip):
     octets = ip.split('.')
     octets.reverse()
     octets.append('in-addr.arpa.')
-    print 'P'+('.'.join(octets))+'|86400|'+name+'.%'
+    print('P'+('.'.join(octets))+'|86400|'+name+'.%')
 
 class HostIPAddress:
     def __init__(self, host, ipAddress):
@@ -21,7 +22,7 @@ class HostIPAddress:
         self.ipAddress=ipAddress
 
     def printZone(self, domain):
-        print '#  '+self.host.dn
+        print('#  '+self.host.dn)
         printIPAddress(self.host.name+'.'+domain, self.ipAddress)
         printPTR(self.host.name+'.'+domain, self.ipAddress)
 
@@ -62,7 +63,7 @@ class Net:
         return 0
 
     def printZone(self):
-        print '#'+self.dn
+        print('#'+self.dn)
         printIPAddress(self.name, self.address)
         printPTR(self.name, self.address)
         ip = dns.aton(self.address)
@@ -87,7 +88,7 @@ class Net:
 exitStatus=0
 
 def error(fail):
-    print >>sys.stderr, 'fail:', str(fail) #.getErrorMessage()
+    print('fail:', str(fail), file=sys.stderr) #.getErrorMessage()
     global exitStatus
     exitStatus=1
 
@@ -167,7 +168,7 @@ def main(cfg, filter_text):
     try:
         baseDN = cfg.getBaseDN()
     except config.MissingBaseDNError, e:
-        print >>sys.stderr, "%s: %s." % (sys.argv[0], e)
+        print("%s: %s." % (sys.argv[0], e), file=sys.stderr)
         sys.exit(1)
 
     if filter_text is not None:

--- a/bin/ldaptor-ldap2maradns
+++ b/bin/ldaptor-ldap2maradns
@@ -133,7 +133,7 @@ def getHosts(nets, e, filter):
     def _cbGotHost(e):
         host = Host(str(e.dn),
                     str(only(e, 'cn')),
-                    map(str, e['ipHostNumber']))
+                    list(str(i) for i in e['ipHostNumber']))
         for hostIP in host.ipAddresses:
             parent=None
             for net in nets:

--- a/bin/ldaptor-ldap2maradns
+++ b/bin/ldaptor-ldap2maradns
@@ -167,7 +167,7 @@ def main(cfg, filter_text):
 
     try:
         baseDN = cfg.getBaseDN()
-    except config.MissingBaseDNError, e:
+    except config.MissingBaseDNError as e:
         print("%s: %s." % (sys.argv[0], e), file=sys.stderr)
         sys.exit(1)
 
@@ -197,7 +197,7 @@ if __name__ == "__main__":
     try:
         opts = MyOptions()
         opts.parseOptions()
-    except usage.UsageError, ue:
+    except usage.UsageError as ue:
         sys.stderr.write('%s: %s\n' % (sys.argv[0], ue))
         sys.exit(1)
 

--- a/bin/ldaptor-ldap2passwd
+++ b/bin/ldaptor-ldap2passwd
@@ -10,8 +10,8 @@ def _cbSearch(obj):
     a={}
     for attr, vals in obj.items():
         attr=str(attr)
-        assert not a.has_key(attr)
-        a[attr]=map(str, vals)
+        assert attr not in a
+        a[attr]=list(str(val) for val in vals)
 
     print(':'.join((
         a['uid'][0],

--- a/bin/ldaptor-ldap2passwd
+++ b/bin/ldaptor-ldap2passwd
@@ -47,7 +47,7 @@ def error(fail):
 def main(cfg, filter_text):
     try:
         baseDN = cfg.getBaseDN()
-    except config.MissingBaseDNError, e:
+    except config.MissingBaseDNError as e:
         print("%s: %s." % (sys.argv[0], e), file=sys.stderr)
         sys.exit(1)
 
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     try:
         opts = MyOptions()
         opts.parseOptions()
-    except usage.usage.UsageError, ue:
+    except usage.usage.UsageError as ue:
         sys.stderr.write('%s: %s\n' % (sys.argv[0], ue))
         sys.exit(1)
 

--- a/bin/ldaptor-ldap2passwd
+++ b/bin/ldaptor-ldap2passwd
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+from __future__ import print_function
 import sys
 from ldaptor.protocols.ldap import ldapclient, ldif, distinguishedname, ldapconnector, ldapsyntax
 from ldaptor.protocols import pureber, pureldap
@@ -12,7 +13,7 @@ def _cbSearch(obj):
         assert not a.has_key(attr)
         a[attr]=map(str, vals)
 
-    print ':'.join((
+    print(':'.join((
         a['uid'][0],
         'x',
         a['uidNumber'][0],
@@ -20,7 +21,7 @@ def _cbSearch(obj):
         a.get('gecos', a.get('cn', ['']))[0],
         a['homeDirectory'][0],
         a.get('loginShell', [''])[0],
-        ))
+        )))
 
 def search(client, baseDN, filt):
     e=ldapsyntax.LDAPEntry(client=client, dn=baseDN)
@@ -39,7 +40,7 @@ def search(client, baseDN, filt):
 exitStatus=0
 
 def error(fail):
-    print >>sys.stderr, 'fail:', fail.getErrorMessage()
+    print('fail:', fail.getErrorMessage(), file=sys.stderr)
     global exitStatus
     exitStatus=1
 
@@ -47,7 +48,7 @@ def main(cfg, filter_text):
     try:
         baseDN = cfg.getBaseDN()
     except config.MissingBaseDNError, e:
-        print >>sys.stderr, "%s: %s." % (sys.argv[0], e)
+        print("%s: %s." % (sys.argv[0], e), file=sys.stderr)
         sys.exit(1)
 
     filt = ldapfilter.parseFilter('(objectClass=posixAccount)')

--- a/bin/ldaptor-ldap2pdns
+++ b/bin/ldaptor-ldap2pdns
@@ -237,7 +237,7 @@ class MyLDAPClient(ldapclient.LDAPClient):
 def main(cfg, dnsDomain):
     try:
         baseDN = cfg.getBaseDN()
-    except config.MissingBaseDNError, e:
+    except config.MissingBaseDNError as e:
         print("%s: %s." % (sys.argv[0], e), file=sys.stderr)
         sys.exit(1)
 
@@ -274,7 +274,7 @@ if __name__ == "__main__":
     try:
         opts = MyOptions()
         opts.parseOptions()
-    except usage.UsageError, ue:
+    except usage.UsageError as ue:
         sys.stderr.write('%s: %s\n' % (sys.argv[0], ue))
         sys.exit(1)
 

--- a/bin/ldaptor-ldap2pdns
+++ b/bin/ldaptor-ldap2pdns
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import print_function
 import sys
 from twisted.internet.defer import succeed, fail
 from twisted.internet import defer, reactor
@@ -220,7 +221,7 @@ class PdnsPipeProtocol(LineReceiver):
 exitStatus = 0
 
 def error(fail):
-    print >>sys.stderr, 'fail:', fail.getErrorMessage()
+    print('fail:', fail.getErrorMessage(), file=sys.stderr)
     global exitStatus
     exitStatus=1
 
@@ -237,7 +238,7 @@ def main(cfg, dnsDomain):
     try:
         baseDN = cfg.getBaseDN()
     except config.MissingBaseDNError, e:
-        print >>sys.stderr, "%s: %s." % (sys.argv[0], e)
+        print("%s: %s." % (sys.argv[0], e), file=sys.stderr)
         sys.exit(1)
 
     def ldapEntryFactory(pdnsProto):

--- a/bin/ldaptor-ldifdiff
+++ b/bin/ldaptor-ldifdiff
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import print_function
 import sys
 from ldaptor.protocols.ldap import ldif
 from ldaptor import usage, inmemory
@@ -8,7 +9,7 @@ from twisted.internet import protocol, reactor, defer
 exitStatus=0
 
 def error(fail):
-    print >>sys.stderr, 'fail:', fail.getErrorMessage()
+    print('fail:', fail.getErrorMessage(), file=sys.stderr)
     global exitStatus
     exitStatus=1
 

--- a/bin/ldaptor-ldifdiff
+++ b/bin/ldaptor-ldifdiff
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     try:
         config = MyOptions()
         config.parseOptions()
-    except usage.UsageError, ue:
+    except usage.UsageError as ue:
         sys.stderr.write('%s: %s\n' % (sys.argv[0], ue))
         sys.exit(1)
 

--- a/bin/ldaptor-ldifpatch
+++ b/bin/ldaptor-ldifpatch
@@ -49,7 +49,7 @@ if __name__ == "__main__":
     try:
         config = MyOptions()
         config.parseOptions()
-    except usage.UsageError, ue:
+    except usage.UsageError as ue:
         sys.stderr.write('%s: %s\n' % (sys.argv[0], ue))
         sys.exit(1)
 

--- a/bin/ldaptor-ldifpatch
+++ b/bin/ldaptor-ldifpatch
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import print_function
 import sys
 from ldaptor.protocols.ldap import ldif, ldifdelta
 from ldaptor import usage, inmemory
@@ -9,7 +10,7 @@ from twisted.internet import protocol, reactor, defer
 exitStatus=0
 
 def error(fail):
-    print >>sys.stderr, 'fail:', fail.getErrorMessage()
+    print('fail:', fail.getErrorMessage(), file=sys.stderr)
     global exitStatus
     exitStatus=1
 

--- a/bin/ldaptor-namingcontexts
+++ b/bin/ldaptor-namingcontexts
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import print_function
 import sys
 from ldaptor.protocols.ldap import ldapclient, ldapsyntax
 from ldaptor.protocols import pureber, pureldap
@@ -14,7 +15,7 @@ class Search(ldapclient.LDAPClient):
 
     def _printResults(self, result, host):
         for context in result['namingContexts']:
-            print '%s\t%s' % (host, context)
+            print('%s\t%s' % (host, context))
 
     def _handle_bind_success(self, x):
         matchedDN, serverSaslCreds = x
@@ -40,7 +41,7 @@ class SearchFactory(protocol.ClientFactory):
 exitStatus = 0
 
 def errback(data):
-    print "ERROR:", data.getErrorMessage()
+    print("ERROR:", data.getErrorMessage())
     global exitStatus
     exitStatus=1
 
@@ -59,7 +60,7 @@ def main(servers):
 
 if __name__ == "__main__":
     if not sys.argv[1:]:
-        print >>sys.stderr, '%s: usage:' % sys.argv[0]
-        print >>sys.stderr, '  %s HOST..' % sys.argv[0]
+        print('%s: usage:' % sys.argv[0], file=sys.stderr)
+        print('  %s HOST..' % sys.argv[0], file=sys.stderr)
     else:
         main(sys.argv[1:])

--- a/bin/ldaptor-passwd
+++ b/bin/ldaptor-passwd
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import print_function
 import sys, getpass
 from ldaptor.protocols.ldap import ldapclient, distinguishedname, ldapconnector, ldapsyntax
 from ldaptor.protocols import pureber, pureldap
@@ -20,7 +21,7 @@ class PasswdClient(ldapclient.LDAPClient):
                        self._handle_bind_fail)
 
     def _report_ldap_error(self, fail):
-        print >>sys.stderr, "fail:", fail.getErrorMessage()
+        print("fail:", fail.getErrorMessage(), file=sys.stderr)
         global exitStatus
         exitStatus=1
         return fail
@@ -53,7 +54,7 @@ class PasswdClient(ldapclient.LDAPClient):
 
     def _report_new_password(self, dummy, dn, password):
         if self.factory.generatePasswords:
-            print dn, password
+            print(dn, password)
 
     def _got_password(self, password, dn):
         assert len(password)==1
@@ -67,7 +68,7 @@ class PasswdClient(ldapclient.LDAPClient):
 
     def _report_pwgen_error(self, fail):
         fail.trap(PwgenException)
-        print >>sys.stderr, 'pwgen:', fail.getErrorMessage()
+        print('pwgen:', fail.getErrorMessage(), file=sys.stderr)
         return fail
 
 class PasswdClientFactory(protocol.ClientFactory):
@@ -104,7 +105,7 @@ if __name__ == "__main__":
         config = MyOptions()
         config.parseOptions()
     except usage.UsageError, ue:
-        print >>sys.stderr, '%s:'%sys.argv[0], ue
+        print('%s:'%sys.argv[0], ue, file=sys.stderr)
         sys.exit(1)
 
     bindPassword=None

--- a/bin/ldaptor-passwd
+++ b/bin/ldaptor-passwd
@@ -104,7 +104,7 @@ if __name__ == "__main__":
     try:
         config = MyOptions()
         config.parseOptions()
-    except usage.UsageError, ue:
+    except usage.UsageError as ue:
         print('%s:'%sys.argv[0], ue, file=sys.stderr)
         sys.exit(1)
 

--- a/bin/ldaptor-rename
+++ b/bin/ldaptor-rename
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     try:
         opts = MyOptions()
         opts.parseOptions()
-    except usage.UsageError, ue:
+    except usage.UsageError as ue:
         sys.stderr.write('%s: %s\n' % (sys.argv[0], ue))
         sys.exit(1)
 

--- a/bin/ldaptor-rename
+++ b/bin/ldaptor-rename
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import print_function
 import sys, os, getpass
 from ldaptor.protocols.ldap import ldapclient, ldif, ldapsyntax, distinguishedname, ldapconnector
 from ldaptor.protocols import pureber, pureldap
@@ -15,7 +16,7 @@ def move(client, fromDN, toDN):
 exitStatus=0
 
 def error(fail):
-    print >>sys.stderr, 'fail:', fail.getErrorMessage()
+    print('fail:', fail.getErrorMessage(), file=sys.stderr)
     global exitStatus
     exitStatus=1
 

--- a/bin/ldaptor-search
+++ b/bin/ldaptor-search
@@ -27,7 +27,7 @@ def error(fail):
 def main(cfg, filter_text, attributes):
     try:
         baseDN = cfg.getBaseDN()
-    except config.MissingBaseDNError, e:
+    except config.MissingBaseDNError as e:
         print("%s: %s." % (sys.argv[0], e), file=sys.stderr)
         sys.exit(1)
 
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     try:
         opts = MyOptions()
         opts.parseOptions()
-    except usage.UsageError, ue:
+    except usage.UsageError as ue:
         sys.stderr.write('%s: %s\n' % (sys.argv[0], ue))
         sys.exit(1)
 

--- a/bin/ldaptor-search
+++ b/bin/ldaptor-search
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import print_function
 import sys
 from ldaptor.protocols.ldap import ldapclient, ldif, ldapsyntax, ldapconnector
 from ldaptor.protocols import pureber, pureldap
@@ -19,7 +20,7 @@ def search(client, baseDN, filter_text, attributes):
 exitStatus=0
 
 def error(fail):
-    print >>sys.stderr, 'fail:', fail.getErrorMessage()
+    print('fail:', fail.getErrorMessage(), file=sys.stderr)
     global exitStatus
     exitStatus=1
 
@@ -27,7 +28,7 @@ def main(cfg, filter_text, attributes):
     try:
         baseDN = cfg.getBaseDN()
     except config.MissingBaseDNError, e:
-        print >>sys.stderr, "%s: %s." % (sys.argv[0], e)
+        print("%s: %s." % (sys.argv[0], e), file=sys.stderr)
         sys.exit(1)
 
     c = ldapconnector.LDAPClientCreator(reactor,

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ if __name__ == '__main__':
               'Twisted',
               'pyOpenSSL',
               'pyparsing',
-              'six',
+              'six >= 1.7',
               'zope.interface',
           ],
           classifiers=[


### PR DESCRIPTION
* [ ] I have updated the release notes at `docs/source/NEWS.rst` 
* [X] I have updated the automated tests.
* [X] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.

This PR updates the syntax in the scripts in `bin/` so that they are parsable in python 3 (as well as 2.6 and 2.7).

The exception is the `my_aton_numbits` function in `ldaptor-ldap2dhcpconf`, whose purpose I'm not sure I understand, so I didn't touch it.

I haven't updated `NEWS.rst` since I think this is covered by notes that are already in there because of py3k modernization efforts elsewhere in the codebase.