### PR TITLE
document the return type for startTLS

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -27,7 +27,7 @@ Changes
 - `six` package is now a direct dependency in preparation for the Python 3
   port.
 - Remove Python 3.3 from tox as it is EOL.
-- Add API documentation for ``LDAPAttributeSet``
+- Add API documentation for ``LDAPAttributeSet`` and ``startTLS``.
 
 Bugfixes
 ^^^^^^^^

--- a/ldaptor/protocols/ldap/ldapclient.py
+++ b/ldaptor/protocols/ldap/ldapclient.py
@@ -266,7 +266,8 @@ class LDAPClient(protocol.Protocol):
         are not happening at the same time.
 
         @todo: server hostname check, see rfc2830 section 3.6.
-
+        @return: a deferred that will complete when the TLS handshake is
+        complete.
         """
         if ctx is None:
             ctx = ssl.ClientContextFactory()


### PR DESCRIPTION
Document that `startTLS` returns a deferred.


* [ ] I have updated the release notes at `docs/source/NEWS.rst` 
* [ ] I have updated the automated tests.
* [ ] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.