### PR TITLE
Py3compatibility

### DIFF
--- a/ldaptor/delta.py
+++ b/ldaptor/delta.py
@@ -32,7 +32,7 @@ class Modification(attributeset.LDAPAttributeSet):
                 value = tmplist[x]
                 newlist.append(value) 
         
-        return str(pureber.BERSequence([
+        return bytes(pureber.BERSequence([
             pureber.BEREnumerated(self._LDAP_OP),
             pureber.BERSequence([ pureldap.LDAPAttributeDescription(self.key),
                                   pureber.BERSet(map(pureldap.LDAPString, newlist)),

--- a/ldaptor/protocols/ldap/ldapclient.py
+++ b/ldaptor/protocols/ldap/ldapclient.py
@@ -51,7 +51,7 @@ class LDAPClient(protocol.Protocol):
 
     def __init__(self):
         self.onwire = {}
-        self.buffer = ''
+        self.buffer = b''
         self.connected = None
 
     berdecoder = pureldap.LDAPBERDecoderContext_TopLevel(
@@ -107,7 +107,7 @@ class LDAPClient(protocol.Protocol):
         assert op.needs_answer
         d = defer.Deferred()
         self.onwire[msg.id] = (d, False, None, None, None)
-        self.transport.write(str(msg))
+        self.transport.write(bytes(msg))
         return d
 
     def send_multiResponse(self, op, handler, *args, **kwargs):
@@ -137,7 +137,7 @@ class LDAPClient(protocol.Protocol):
         assert op.needs_answer
         d = defer.Deferred()
         self.onwire[msg.id] = (d, False, handler, args, kwargs)
-        self.transport.write(str(msg))
+        self.transport.write(bytes(msg))
         return d
 
     def send_multiResponse_ex(self, op, controls=None, handler=None, *args, **kwargs):
@@ -170,7 +170,7 @@ class LDAPClient(protocol.Protocol):
         assert op.needs_answer
         d = defer.Deferred()
         self.onwire[msg.id] = (d, True, handler, args, kwargs)
-        self.transport.write(str(msg))
+        self.transport.write(bytes(msg))
         return d
 
     def send_noResponse(self, op, controls=None):
@@ -183,7 +183,7 @@ class LDAPClient(protocol.Protocol):
         """
         msg = self._send(op, controls=controls)
         assert not op.needs_answer
-        self.transport.write(str(msg))
+        self.transport.write(bytes(msg))
 
     def unsolicitedNotification(self, msg):
         log.msg("Got unsolicited notification: %s" % repr(msg))

--- a/ldaptor/protocols/ldap/ldapserver.py
+++ b/ldaptor/protocols/ldap/ldapserver.py
@@ -31,7 +31,7 @@ class BaseLDAPServer(protocol.Protocol):
     debug = False
 
     def __init__(self):
-        self.buffer = ''
+        self.buffer = b''
         self.connected = None
 
     berdecoder = pureldap.LDAPBERDecoderContext_TopLevel(
@@ -68,7 +68,7 @@ class BaseLDAPServer(protocol.Protocol):
         msg = pureldap.LDAPMessage(op, id=id)
         if self.debug:
             log.msg('S->C %s' % repr(msg), debug=True)
-        self.transport.write(str(msg))
+        self.transport.write(bytes(msg))
 
     def unsolicitedNotification(self, msg):
         log.msg("Got unsolicited notification: %s" % repr(msg))

--- a/ldaptor/protocols/ldap/ldapsyntax.py
+++ b/ldaptor/protocols/ldap/ldapsyntax.py
@@ -278,7 +278,7 @@ class LDAPEntryWithClient(entry.EditableLDAPEntry):
         return hash(str(self))
 
     def bind(self, password):
-        r = pureldap.LDAPBindRequest(dn=str(self.dn), auth=password)
+        r = pureldap.LDAPBindRequest(dn=bytes(self.dn), auth=password)
         d = self.client.send(r)
         d.addCallback(self._handle_bind_msg)
         return d
@@ -333,7 +333,7 @@ class LDAPEntryWithClient(entry.EditableLDAPEntry):
             return defer.succeed(self)
 
         op = pureldap.LDAPModifyRequest(
-            object=str(self.dn),
+            object=bytes(self.dn),
             modification=[x.asLDAP() for x in self._journal])
         d = defer.maybeDeferred(self.client.send, op)
         d.addCallback(self._commit_success)
@@ -356,10 +356,10 @@ class LDAPEntryWithClient(entry.EditableLDAPEntry):
         newrdn = newDN.split()[0]
         newSuperior = distinguishedname.DistinguishedName(listOfRDNs=newDN.split()[1:])
         newDN = distinguishedname.DistinguishedName((newrdn,) + newSuperior.split())
-        op = pureldap.LDAPModifyDNRequest(entry=str(self.dn),
-                                          newrdn=str(newrdn),
+        op = pureldap.LDAPModifyDNRequest(entry=bytes(self.dn),
+                                          newrdn=bytes(newrdn),
                                           deleteoldrdn=1,
-                                          newSuperior=str(newSuperior))
+                                          newSuperior=bytes(newSuperior))
         d = self.client.send(op)
         d.addCallback(self._cbMoveDone, newDN)
         return d
@@ -379,7 +379,7 @@ class LDAPEntryWithClient(entry.EditableLDAPEntry):
     def delete(self):
         self._checkState()
 
-        op = pureldap.LDAPDelRequest(entry=str(self.dn))
+        op = pureldap.LDAPDelRequest(entry=bytes(self.dn))
         d = self.client.send(op)
         d.addCallback(self._cbDeleteDone)
         self._state = 'deleted'
@@ -420,7 +420,7 @@ class LDAPEntryWithClient(entry.EditableLDAPEntry):
             ldapValues = pureber.BERSet(lst)
             ldapAttrs.append((ldapAttrType, ldapValues))
         op = pureldap.LDAPAddRequest(
-            entry=str(dn),
+            entry=bytes(dn),
             attributes=ldapAttrs)
         d = self.client.send(op)
         d.addCallback(self._cbAddDone, dn)
@@ -449,7 +449,7 @@ class LDAPEntryWithClient(entry.EditableLDAPEntry):
 
         self._checkState()
 
-        op = pureldap.LDAPPasswordModifyRequest(userIdentity=str(self.dn), newPasswd=newPasswd)
+        op = pureldap.LDAPPasswordModifyRequest(userIdentity=bytes(self.dn), newPasswd=newPasswd)
         d = self.client.send(op)
         d.addCallback(self._cbSetPassword_ExtendedOperation)
         return d
@@ -706,7 +706,7 @@ class LDAPEntryWithClient(entry.EditableLDAPEntry):
             cb = callback
         try:
             op = pureldap.LDAPSearchRequest(
-                baseObject=str(self.dn),
+                baseObject=bytes(self.dn),
                 scope=scope,
                 derefAliases=derefAliases,
                 sizeLimit=sizeLimit,
@@ -758,7 +758,7 @@ class LDAPEntryWithClient(entry.EditableLDAPEntry):
         attributes = ', '.join(a)
         return '%s(dn=%s, attributes={%s})' % (
             self.__class__.__name__,
-            repr(str(self.dn)),
+            repr(bytes(self.dn)),
             attributes)
 
 

--- a/ldaptor/protocols/pureber.py
+++ b/ldaptor/protocols/pureber.py
@@ -74,7 +74,7 @@ def berDecodeLength(m, offset=0):
     Return a tuple of (length, lengthLength).
     m must be atleast one byte long.
     """
-    l = ber2int(m[offset + 0])
+    l = ber2int(m[offset + 0:offset + 1])
     ll = 1
     if l & 0x80:
         ll = 1 + (l & 0x7F)
@@ -107,11 +107,11 @@ def int2ber(i, signed=True):
 
 def ber2int(e, signed=True):
     need(e, 1)
-    v = 0 + ord(e[0])
+    v = 0 + ord(e[0:1])
     if v & 0x80 and signed:
         v = v - 256
     for i in range(1, len(e)):
-        v = (v << 8) | ord(e[i])
+        v = (v << 8) | ord(e[i:i + 1])
     return v
 
 
@@ -370,7 +370,7 @@ def berDecodeObject(context, m):
     """
     while m:
         need(m, 2)
-        i = ber2int(m[0], signed=0) & (CLASS_MASK | TAG_MASK)
+        i = ber2int(m[0:1], signed=0) & (CLASS_MASK | TAG_MASK)
 
         length, lenlen = berDecodeLength(m, offset=1)
         need(m, 1 + lenlen + length)

--- a/ldaptor/test/test_distinguishedname.py
+++ b/ldaptor/test/test_distinguishedname.py
@@ -23,12 +23,12 @@ class TestCaseWithKnownValues(unittest.TestCase):
 
             self.assertEqual(fromString, fromList)
 
-            fromStringToString = str(fromString)
-            fromListToString = str(fromList)
+            fromStringToBytes = bytes(fromString)
+            fromListToBytes = bytes(fromList)
 
-            assert fromStringToString == fromListToString
+            assert fromStringToBytes == fromListToBytes
 
-            canon = fromStringToString
+            canon = fromStringToBytes
             # DNs equal their string representation. Note this does
             # not mean they equal all the possible string
             # representations -- just the canonical one.
@@ -120,11 +120,11 @@ class LDAPDistinguishedName_Escaping(TestCaseWithKnownValues):
             dn.RelativeDistinguishedName('dc=example'),
             dn.RelativeDistinguishedName('dc=com'),
             ])
-        got = str(got)
+        got = bytes(got)
         self.assertEqual(got,
-                          r'cn=test+owner=uid\=foo\,ou\=depar'
-                          +r'tment\,dc\=example\,dc\=com,dc=ex'
-                          +r'ample,dc=com')
+                          b'cn=test+owner=uid\=foo\,ou\=depar'
+                          +b'tment\,dc\=example\,dc\=com,dc=ex'
+                          +b'ample,dc=com')
 
 
 class LDAPDistinguishedName_RFC2253_ExamplesBytes(TestCaseWithKnownValues):
@@ -315,29 +315,29 @@ class LDAPDistinguishedName_Malformed(unittest.TestCase):
 
 class LDAPDistinguishedName_Prettify(unittest.TestCase):
     def testPrettifySpaces(self):
-        """str(DistinguishedName(...)) prettifies the DN by removing extra whitespace."""
+        """bytes(DistinguishedName(...)) prettifies the DN by removing extra whitespace."""
         d=dn.DistinguishedName('cn=foo, o=bar,  c=us')
-        assert str(d) == 'cn=foo,o=bar,c=us'
+        assert bytes(d) == b'cn=foo,o=bar,c=us'
 
 class DistinguishedName_Init(unittest.TestCase):
     def testString(self):
         d=dn.DistinguishedName('dc=example,dc=com')
-        self.assertEqual(str(d), 'dc=example,dc=com')
+        self.assertEqual(bytes(d), b'dc=example,dc=com')
 
     def testDN(self):
         proto=dn.DistinguishedName('dc=example,dc=com')
         d=dn.DistinguishedName(proto)
-        self.assertEqual(str(d), 'dc=example,dc=com')
+        self.assertEqual(bytes(d), b'dc=example,dc=com')
 
 class RelativeDistinguishedName_Init(unittest.TestCase):
     def testString(self):
         rdn=dn.RelativeDistinguishedName('dc=example')
-        self.assertEqual(str(rdn), 'dc=example')
+        self.assertEqual(bytes(rdn), b'dc=example')
 
     def testRDN(self):
         proto=dn.RelativeDistinguishedName('dc=example')
         rdn=dn.RelativeDistinguishedName(proto)
-        self.assertEqual(str(rdn), 'dc=example')
+        self.assertEqual(bytes(rdn), b'dc=example')
 
 class DistinguishedName_Comparison(unittest.TestCase):
     """

--- a/ldaptor/test/test_merger.py
+++ b/ldaptor/test/test_merger.py
@@ -48,10 +48,10 @@ class MergedLDAPServerTest(unittest.TestCase):
                                     [[LDAPBindResponse(resultCode=0)]])
 
         def test_f(server):
-            server.dataReceived(str(LDAPMessage(LDAPBindRequest(), id=4)))
+            server.dataReceived(bytes(LDAPMessage(LDAPBindRequest(), id=4)))
 
             self.assertEqual(server.transport.value(),
-                              str(LDAPMessage(LDAPBindResponse(resultCode=0), id=4)))
+                              bytes(LDAPMessage(LDAPBindResponse(resultCode=0), id=4)))
 
         d.addCallback(test_f)
 
@@ -62,9 +62,9 @@ class MergedLDAPServerTest(unittest.TestCase):
                                     [[LDAPBindResponse(resultCode=0)]])
 
         def test_f(server):
-            server.dataReceived(str(LDAPMessage(LDAPBindRequest(), id=4)))
+            server.dataReceived(bytes(LDAPMessage(LDAPBindRequest(), id=4)))
             self.assertEqual(server.transport.value(),
-                              str(LDAPMessage(LDAPBindResponse(resultCode=0), id=4))) 
+                              bytes(LDAPMessage(LDAPBindResponse(resultCode=0), id=4)))
         d.addCallback(test_f)
         return d
 
@@ -73,9 +73,9 @@ class MergedLDAPServerTest(unittest.TestCase):
                                     [[LDAPBindResponse(resultCode=ldaperrors.LDAPInvalidCredentials.resultCode)]])
 
         def test_f(server):
-            server.dataReceived(str(LDAPMessage(LDAPBindRequest(), id=4)))
+            server.dataReceived(bytes(LDAPMessage(LDAPBindRequest(), id=4)))
             self.assertEqual(server.transport.value(),
-                              str(LDAPMessage(LDAPBindResponse(resultCode=ldaperrors.LDAPInvalidCredentials.resultCode), id=4)))
+                              bytes(LDAPMessage(LDAPBindResponse(resultCode=ldaperrors.LDAPInvalidCredentials.resultCode), id=4)))
 
         d.addCallback(test_f)
         return d
@@ -89,13 +89,13 @@ class MergedLDAPServerTest(unittest.TestCase):
                                      LDAPSearchResultDone(ldaperrors.Success.resultCode)]])
 
         def test_f(server):
-            server.dataReceived(str(LDAPMessage(LDAPSearchRequest(), id=3)))
+            server.dataReceived(bytes(LDAPMessage(LDAPSearchRequest(), id=3)))
             self.assertEqual(server.transport.value(),
-                              str(LDAPMessage(LDAPSearchResultEntry('cn=foo,dc=example,dc=com', [('a', ['b'])]), id=3))
-                              +str(LDAPMessage(LDAPSearchResultEntry('cn=bar2,dc=example,dc=com', [('b', ['c'])]), id=3))
-                              +str(LDAPMessage(LDAPSearchResultEntry('cn=foo,dc=example,dc=com', [('a', ['b'])]), id=3))
-                              +str(LDAPMessage(LDAPSearchResultEntry('cn=bar,dc=example,dc=com', [('b', ['c'])]), id=3))
-                              +str(LDAPMessage(LDAPSearchResultDone(ldaperrors.Success.resultCode), id=3)))
+                              bytes(LDAPMessage(LDAPSearchResultEntry('cn=foo,dc=example,dc=com', [('a', ['b'])]), id=3))
+                              +bytes(LDAPMessage(LDAPSearchResultEntry('cn=bar2,dc=example,dc=com', [('b', ['c'])]), id=3))
+                              +bytes(LDAPMessage(LDAPSearchResultEntry('cn=foo,dc=example,dc=com', [('a', ['b'])]), id=3))
+                              +bytes(LDAPMessage(LDAPSearchResultEntry('cn=bar,dc=example,dc=com', [('b', ['c'])]), id=3))
+                              +bytes(LDAPMessage(LDAPSearchResultDone(ldaperrors.Success.resultCode), id=3)))
         d.addCallback(test_f)
 
         return d
@@ -109,11 +109,11 @@ class MergedLDAPServerTest(unittest.TestCase):
                                      ]])
 
         def test_f(server):
-            server.dataReceived(str(LDAPMessage(LDAPSearchRequest(), id=3)))
+            server.dataReceived(bytes(LDAPMessage(LDAPSearchRequest(), id=3)))
             self.assertEqual(server.transport.value(),
-                              str(LDAPMessage(LDAPSearchResultEntry('cn=foo,dc=example,dc=com', [('a', ['b'])]), id=3))
-                              +str(LDAPMessage(LDAPSearchResultEntry('cn=bar,dc=example,dc=com', [('b', ['c'])]), id=3))
-                              +str(LDAPMessage(LDAPSearchResultDone(ldaperrors.Success.resultCode), id=3)))
+                              bytes(LDAPMessage(LDAPSearchResultEntry('cn=foo,dc=example,dc=com', [('a', ['b'])]), id=3))
+                              +bytes(LDAPMessage(LDAPSearchResultEntry('cn=bar,dc=example,dc=com', [('b', ['c'])]), id=3))
+                              +bytes(LDAPMessage(LDAPSearchResultDone(ldaperrors.Success.resultCode), id=3)))
 
         d.addCallback(test_f)
 
@@ -123,11 +123,11 @@ class MergedLDAPServerTest(unittest.TestCase):
         d = self.createMergedServer([[]], [[]])
 
         def test_f(server):
-            server.dataReceived(str(LDAPMessage(LDAPUnbindRequest(), id=3)))
+            server.dataReceived(bytes(LDAPMessage(LDAPUnbindRequest(), id=3)))
             server.connectionLost(error.ConnectionDone)
             for c in self.clients:
                 c.assertSent(LDAPUnbindRequest())
-            self.assertEqual(server.transport.value(), "")
+            self.assertEqual(server.transport.value(), b"")
         d.addCallback(test_f)
 
         return d
@@ -143,7 +143,7 @@ class MergedLDAPServerTest(unittest.TestCase):
 
             self.assertEqual(
               [], server.clients, 'A connection should not be done.')
-            self.assertEqual(server.transport.value(), "")
+            self.assertEqual(server.transport.value(), b"")
 
         d.addCallback(test_f)
 
@@ -153,20 +153,20 @@ class MergedLDAPServerTest(unittest.TestCase):
         d = self.createMergedServer([[]], [[]])
 
         def test_f(server):
-            server.dataReceived(str(LDAPMessage(LDAPAddRequest(entry="", attributes=[]), id=3)))
-            server.dataReceived(str(LDAPMessage(LDAPDelRequest(entry=""), id=4)))
-            server.dataReceived(str(LDAPMessage(LDAPModifyRequest(object="", modification=[]), id=5)))
-            server.dataReceived(str(LDAPMessage(LDAPModifyDNRequest(entry="", newrdn="", deleteoldrdn=0), id=6)))
-            server.dataReceived(str(LDAPMessage(LDAPExtendedRequest(requestName=""), id=7)))
+            server.dataReceived(bytes(LDAPMessage(LDAPAddRequest(entry="", attributes=[]), id=3)))
+            server.dataReceived(bytes(LDAPMessage(LDAPDelRequest(entry=""), id=4)))
+            server.dataReceived(bytes(LDAPMessage(LDAPModifyRequest(object="", modification=[]), id=5)))
+            server.dataReceived(bytes(LDAPMessage(LDAPModifyDNRequest(entry="", newrdn="", deleteoldrdn=0), id=6)))
+            server.dataReceived(bytes(LDAPMessage(LDAPExtendedRequest(requestName=""), id=7)))
             for c in server.clients:
                 c.assertNothingSent()
 
             self.assertEqual(server.transport.value(),
-                              str(LDAPMessage(LDAPAddResponse(resultCode=ldaperrors.LDAPUnwillingToPerform.resultCode), id=3))
-                              +str(LDAPMessage(LDAPDelResponse(resultCode=ldaperrors.LDAPUnwillingToPerform.resultCode), id=4))
-                              +str(LDAPMessage(LDAPModifyResponse(resultCode=ldaperrors.LDAPUnwillingToPerform.resultCode), id=5))
-                              +str(LDAPMessage(LDAPModifyDNResponse(resultCode=ldaperrors.LDAPUnwillingToPerform.resultCode), id=6))
-                              +str(LDAPMessage(LDAPExtendedResponse(resultCode=ldaperrors.LDAPUnwillingToPerform.resultCode), id=7))
+                              bytes(LDAPMessage(LDAPAddResponse(resultCode=ldaperrors.LDAPUnwillingToPerform.resultCode), id=3))
+                              +bytes(LDAPMessage(LDAPDelResponse(resultCode=ldaperrors.LDAPUnwillingToPerform.resultCode), id=4))
+                              +bytes(LDAPMessage(LDAPModifyResponse(resultCode=ldaperrors.LDAPUnwillingToPerform.resultCode), id=5))
+                              +bytes(LDAPMessage(LDAPModifyDNResponse(resultCode=ldaperrors.LDAPUnwillingToPerform.resultCode), id=6))
+                              +bytes(LDAPMessage(LDAPExtendedResponse(resultCode=ldaperrors.LDAPUnwillingToPerform.resultCode), id=7))
                               )
         d.addCallback(test_f)
 

--- a/ldaptor/test/test_proxy.py
+++ b/ldaptor/test/test_proxy.py
@@ -15,10 +15,10 @@ class Proxy(unittest.TestCase):
     def test_bind(self):
         server = self.createServer([ pureldap.LDAPBindResponse(resultCode=0),
                                      ])
-        server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=4)))
+        server.dataReceived(bytes(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=4)))
         reactor.iterate() #TODO
         self.assertEqual(server.transport.value(),
-                          str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=4)))
+                          bytes(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=4)))
 
     def test_search(self):
         server = self.createServer([ pureldap.LDAPBindResponse(resultCode=0),
@@ -28,48 +28,48 @@ class Proxy(unittest.TestCase):
                                      pureldap.LDAPSearchResultDone(ldaperrors.Success.resultCode),
                                      ],
                                    )
-        server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=2)))
-        server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPSearchRequest(), id=3)))
+        server.dataReceived(bytes(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=2)))
+        server.dataReceived(bytes(pureldap.LDAPMessage(pureldap.LDAPSearchRequest(), id=3)))
         reactor.iterate() #TODO
         self.assertEqual(server.transport.value(),
-                          str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2))
-                          +str(pureldap.LDAPMessage(pureldap.LDAPSearchResultEntry('cn=foo,dc=example,dc=com', [('a', ['b'])]), id=3))
-                          +str(pureldap.LDAPMessage(pureldap.LDAPSearchResultEntry('cn=bar,dc=example,dc=com', [('b', ['c'])]), id=3))
-                          +str(pureldap.LDAPMessage(pureldap.LDAPSearchResultDone(ldaperrors.Success.resultCode), id=3)))
+                          bytes(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2))
+                          +bytes(pureldap.LDAPMessage(pureldap.LDAPSearchResultEntry('cn=foo,dc=example,dc=com', [('a', ['b'])]), id=3))
+                          +bytes(pureldap.LDAPMessage(pureldap.LDAPSearchResultEntry('cn=bar,dc=example,dc=com', [('b', ['c'])]), id=3))
+                          +bytes(pureldap.LDAPMessage(pureldap.LDAPSearchResultDone(ldaperrors.Success.resultCode), id=3)))
 
     def test_unbind_clientUnbinds(self):
         server = self.createServer([ pureldap.LDAPBindResponse(resultCode=0),
                                      ],
                                    [],
                                    )
-        server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=2)))
+        server.dataReceived(bytes(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=2)))
         reactor.iterate() #TODO
         client = server.client
         client.assertSent(pureldap.LDAPBindRequest())
         self.assertEqual(server.transport.value(),
-                          str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
-        server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPUnbindRequest(), id=3)))
+                          bytes(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
+        server.dataReceived(bytes(pureldap.LDAPMessage(pureldap.LDAPUnbindRequest(), id=3)))
         server.connectionLost(error.ConnectionDone)
         reactor.iterate() #TODO
         client.assertSent(pureldap.LDAPBindRequest(),
                           pureldap.LDAPUnbindRequest())
         self.assertEqual(server.transport.value(),
-                          str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
+                          bytes(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
 
     def test_unbind_clientEOF(self):
         server = self.createServer([ pureldap.LDAPBindResponse(resultCode=0),
                                      ],
                                    [],
                                    )
-        server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=2)))
+        server.dataReceived(bytes(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=2)))
         reactor.iterate() #TODO
         client = server.client
         client.assertSent(pureldap.LDAPBindRequest())
         self.assertEqual(server.transport.value(),
-                          str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
+                          bytes(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
         server.connectionLost(error.ConnectionDone)
         reactor.iterate() #TODO
         client.assertSent(pureldap.LDAPBindRequest(),
-                          'fake-unbind-by-LDAPClientTestDriver')
+                          b'fake-unbind-by-LDAPClientTestDriver')
         self.assertEqual(server.transport.value(),
-                          str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
+                          bytes(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))

--- a/ldaptor/test/test_proxybase.py
+++ b/ldaptor/test/test_proxybase.py
@@ -105,10 +105,10 @@ class ProxyBase(unittest.TestCase):
         result code.is written to the transport.
         """
         server = self.createServer([pureldap.LDAPBindResponse(resultCode=0)])
-        server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=4)))
+        server.dataReceived(bytes(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=4)))
         server.reactor.advance(1)
         self.assertEqual(server.transport.value(),
-                          str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=4)))
+                          bytes(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=4)))
 
     def test_search(self):
         """
@@ -120,14 +120,14 @@ class ProxyBase(unittest.TestCase):
                                     pureldap.LDAPSearchResultEntry('cn=bar,dc=example,dc=com', [('b', ['c'])]),
                                     pureldap.LDAPSearchResultDone(ldaperrors.Success.resultCode)],
                                    )
-        server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=2)))
-        server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPSearchRequest(), id=3)))
+        server.dataReceived(bytes(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=2)))
+        server.dataReceived(bytes(pureldap.LDAPMessage(pureldap.LDAPSearchRequest(), id=3)))
         server.reactor.advance(1)
         self.assertEqual(server.transport.value(),
-                          str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2))
-                          + str(pureldap.LDAPMessage(pureldap.LDAPSearchResultEntry('cn=foo,dc=example,dc=com', [('a', ['b'])]), id=3))
-                          + str(pureldap.LDAPMessage(pureldap.LDAPSearchResultEntry('cn=bar,dc=example,dc=com', [('b', ['c'])]), id=3))
-                          + str(pureldap.LDAPMessage(pureldap.LDAPSearchResultDone(ldaperrors.Success.resultCode), id=3)))
+                          bytes(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2))
+                          + bytes(pureldap.LDAPMessage(pureldap.LDAPSearchResultEntry('cn=foo,dc=example,dc=com', [('a', ['b'])]), id=3))
+                          + bytes(pureldap.LDAPMessage(pureldap.LDAPSearchResultEntry('cn=bar,dc=example,dc=com', [('b', ['c'])]), id=3))
+                          + bytes(pureldap.LDAPMessage(pureldap.LDAPSearchResultDone(ldaperrors.Success.resultCode), id=3)))
 
     def test_unbind_clientUnbinds(self):
         """
@@ -135,19 +135,19 @@ class ProxyBase(unittest.TestCase):
         client signals its intent to unbind.
         """
         server = self.createServer([pureldap.LDAPBindResponse(resultCode=0)], [],)
-        server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=2)))
+        server.dataReceived(bytes(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=2)))
         server.reactor.advance(1)
         client = server.client
         client.assertSent(pureldap.LDAPBindRequest())
         self.assertEqual(server.transport.value(),
-                          str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
-        server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPUnbindRequest(), id=3)))
+                          bytes(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
+        server.dataReceived(bytes(pureldap.LDAPMessage(pureldap.LDAPUnbindRequest(), id=3)))
         server.connectionLost(error.ConnectionDone)
         server.reactor.advance(1)
         client.assertSent(pureldap.LDAPBindRequest(),
                           pureldap.LDAPUnbindRequest())
         self.assertEqual(server.transport.value(),
-                          str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
+                          bytes(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
 
     def test_unbind_clientEOF(self):
         """
@@ -155,20 +155,20 @@ class ProxyBase(unittest.TestCase):
         connection without sending an unbind request.
         """
         server = self.createServer([pureldap.LDAPBindResponse(resultCode=0)])
-        server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=2)))
+        server.dataReceived(bytes(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=2)))
         server.reactor.advance(1)
         client = server.client
         client.assertSent(pureldap.LDAPBindRequest())
         self.assertEqual(
             server.transport.value(),
-            str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
+            bytes(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
         server.connectionLost(error.ConnectionDone)
         server.reactor.advance(1)
         client.assertSent(
             pureldap.LDAPBindRequest(),
-            'fake-unbind-by-LDAPClientTestDriver')
+            b'fake-unbind-by-LDAPClientTestDriver')
         self.assertEqual(server.transport.value(),
-                          str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
+                          bytes(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2)))
 
     def test_intercepted_search_request(self):
         """
@@ -186,12 +186,12 @@ class ProxyBase(unittest.TestCase):
         server.responses = [
             pureldap.LDAPSearchResultEntry('cn=xyzzy,dc=example,dc=com', [('frobnitz', ['zork'])]),
             pureldap.LDAPSearchResultDone(ldaperrors.Success.resultCode)]
-        server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPSearchRequest(), id=1)))
+        server.dataReceived(bytes(pureldap.LDAPMessage(pureldap.LDAPSearchRequest(), id=1)))
         server.reactor.advance(1)
         self.assertEqual(len(server.clientTestDriver.sent), 0)
         self.assertEqual(server.transport.value(),
-                          str(pureldap.LDAPMessage(pureldap.LDAPSearchResultEntry('cn=xyzzy,dc=example,dc=com', [('frobnitz', ['zork'])]), id=1))
-                          + str(pureldap.LDAPMessage(pureldap.LDAPSearchResultDone(ldaperrors.Success.resultCode), id=1)))
+                          bytes(pureldap.LDAPMessage(pureldap.LDAPSearchResultEntry('cn=xyzzy,dc=example,dc=com', [('frobnitz', ['zork'])]), id=1))
+                          + bytes(pureldap.LDAPMessage(pureldap.LDAPSearchResultDone(ldaperrors.Success.resultCode), id=1)))
 
     def test_intercepted_search_response(self):
         """
@@ -203,15 +203,15 @@ class ProxyBase(unittest.TestCase):
                                     pureldap.LDAPSearchResultEntry('cn=bar,dc=example,dc=com', [('b', ['c'])]),
                                     pureldap.LDAPSearchResultDone(ldaperrors.Success.resultCode)],
                                    protocol=ResponseInterceptingProxy)
-        server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=2)))
-        server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPSearchRequest(), id=3)))
+        server.dataReceived(bytes(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=2)))
+        server.dataReceived(bytes(pureldap.LDAPMessage(pureldap.LDAPSearchRequest(), id=3)))
         server.reactor.advance(1)
         server.reactor.advance(5)
         self.assertEqual(server.transport.value(),
-                          str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2))
-                          + str(pureldap.LDAPMessage(pureldap.LDAPSearchResultEntry('cn=foo,dc=example,dc=com', [('a', ['b']), ('frotz', ['xyzzy'])]), id=3))
-                          + str(pureldap.LDAPMessage(pureldap.LDAPSearchResultEntry('cn=bar,dc=example,dc=com', [('b', ['c']), ('frotz', ['xyzzy'])]), id=3))
-                          + str(pureldap.LDAPMessage(pureldap.LDAPSearchResultDone(ldaperrors.Success.resultCode), id=3)))
+                          bytes(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=2))
+                          + bytes(pureldap.LDAPMessage(pureldap.LDAPSearchResultEntry('cn=foo,dc=example,dc=com', [('a', ['b']), ('frotz', ['xyzzy'])]), id=3))
+                          + bytes(pureldap.LDAPMessage(pureldap.LDAPSearchResultEntry('cn=bar,dc=example,dc=com', [('b', ['c']), ('frotz', ['xyzzy'])]), id=3))
+                          + bytes(pureldap.LDAPMessage(pureldap.LDAPSearchResultDone(ldaperrors.Success.resultCode), id=3)))
 
     def test_cannot_connect_to_proxied_server_no_pending_requests(self):
         """
@@ -242,11 +242,11 @@ class ProxyBase(unittest.TestCase):
             clock=clock)
         self.assertEqual(connector, server.clientConnector)
         server.dataReceived(
-            str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=4)))
+            bytes(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=4)))
         server.reactor.advance(2)
         self.assertEqual(
             server.transport.value(),
-            str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=52), id=4)))
+            bytes(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=52), id=4)))
 
     def test_health_check_closes_connection_to_proxied_server(self):
         """
@@ -258,7 +258,7 @@ class ProxyBase(unittest.TestCase):
         message = pureldap.LDAPMessage(request, id=4)
         server = self.createServer()
         # Send a message, message is queued
-        server.dataReceived(str(message))
+        server.dataReceived(bytes(message))
         self.assertEqual(len(server.queuedRequests), 1)
         self.assertEqual(server.queuedRequests[0][0], request)
         # Lose connection, message is discarded

--- a/ldaptor/test/test_server.py
+++ b/ldaptor/test/test_server.py
@@ -108,19 +108,19 @@ class LDAPServerTest(unittest.TestCase):
         buffer = s
         value = []
         while 1:
-            o, bytes = pureber.berDecodeObject(berdecoder, buffer)
-            buffer = buffer[bytes:]
+            o, length = pureber.berDecodeObject(berdecoder, buffer)
+            buffer = buffer[length:]
             if not o:
                 break
-            value.append(str(o))
+            value.append(bytes(o))
         return value
 
     def test_bind(self):
         self.server.dataReceived(
-            str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=4)))
+            bytes(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=4)))
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindResponse(resultCode=0),
                     id=4)))
@@ -128,7 +128,7 @@ class LDAPServerTest(unittest.TestCase):
     def test_bind_success(self):
         self.thingie['userPassword'] = ['{SSHA}yVLLj62rFf3kDAbzwEU0zYAVvbWrze8=']  # "secret"
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindRequest(
                         dn='cn=thingie,ou=stuff,dc=example,dc=com',
@@ -136,7 +136,7 @@ class LDAPServerTest(unittest.TestCase):
                     id=4)))
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindResponse(
                         resultCode=0,
@@ -145,7 +145,7 @@ class LDAPServerTest(unittest.TestCase):
 
     def test_bind_invalidCredentials_badPassword(self):
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindRequest(
                         dn='cn=thingie,ou=stuff,dc=example,dc=com',
@@ -153,7 +153,7 @@ class LDAPServerTest(unittest.TestCase):
                     id=734)))
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindResponse(
                         resultCode=ldaperrors.LDAPInvalidCredentials.resultCode),
@@ -161,7 +161,7 @@ class LDAPServerTest(unittest.TestCase):
 
     def test_bind_invalidCredentials_nonExisting(self):
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindRequest(
                         dn='cn=non-existing,dc=example,dc=com',
@@ -169,7 +169,7 @@ class LDAPServerTest(unittest.TestCase):
                     id=78)))
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindResponse(
                         resultCode=ldaperrors.LDAPInvalidCredentials.resultCode),
@@ -177,13 +177,13 @@ class LDAPServerTest(unittest.TestCase):
 
     def test_bind_badVersion_1_anonymous(self):
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindRequest(version=1),
                     id=32)))
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindResponse(
                         resultCode=ldaperrors.LDAPProtocolError.resultCode,
@@ -192,13 +192,13 @@ class LDAPServerTest(unittest.TestCase):
 
     def test_bind_badVersion_2_anonymous(self):
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindRequest(version=2),
                     id=32)))
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindResponse(
                         resultCode=ldaperrors.LDAPProtocolError.resultCode,
@@ -207,13 +207,13 @@ class LDAPServerTest(unittest.TestCase):
 
     def test_bind_badVersion_4_anonymous(self):
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindRequest(version=4),
                     id=32)))
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindResponse(
                         resultCode=ldaperrors.LDAPProtocolError.resultCode,
@@ -224,7 +224,7 @@ class LDAPServerTest(unittest.TestCase):
         # TODO make a test just like this one that would pass authentication
         # if version was correct, to ensure we don't leak that info either.
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindRequest(
                         version=4,
@@ -233,7 +233,7 @@ class LDAPServerTest(unittest.TestCase):
                     id=11)))
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindResponse(
                         resultCode=ldaperrors.LDAPProtocolError.resultCode,
@@ -242,7 +242,7 @@ class LDAPServerTest(unittest.TestCase):
 
     def test_unbind(self):
         self.server.dataReceived(
-            str(pureldap.LDAPMessage(pureldap.LDAPUnbindRequest(), id=7)))
+            bytes(pureldap.LDAPMessage(pureldap.LDAPUnbindRequest(), id=7)))
         self.assertEqual(self.server.transport.value(), '')
 
     def test_compare_outOfTree(self):
@@ -252,14 +252,14 @@ class LDAPServerTest(unittest.TestCase):
         ava = pureldap.LDAPAttributeValueAssertion(attribute_desc, attribute_value)
 
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPCompareRequest(entry=dn, ava=ava),
                     id=2)))
 
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPCompareResponse(
                         resultCode=ldaperrors.LDAPNoSuchObject.resultCode),
@@ -272,14 +272,14 @@ class LDAPServerTest(unittest.TestCase):
         ava = pureldap.LDAPAttributeValueAssertion(attribute_desc, attribute_value)
 
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPCompareRequest(entry=dn, ava=ava),
                     id=2)))
 
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPCompareResponse(
                         resultCode=ldaperrors.LDAPCompareTrue.resultCode),
@@ -292,14 +292,14 @@ class LDAPServerTest(unittest.TestCase):
         ava = pureldap.LDAPAttributeValueAssertion(attribute_desc, attribute_value)
 
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPCompareRequest(entry=dn, ava=ava),
                     id=2)))
 
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPCompareResponse(
                         resultCode=ldaperrors.LDAPCompareFalse.resultCode),
@@ -307,14 +307,14 @@ class LDAPServerTest(unittest.TestCase):
 
     def test_search_outOfTree(self):
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchRequest(
                         baseObject='dc=invalid'),
                     id=2)))
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultDone(
                         resultCode=ldaperrors.LDAPNoSuchObject.resultCode),
@@ -322,14 +322,14 @@ class LDAPServerTest(unittest.TestCase):
 
     def test_search_matchAll_oneResult(self):
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchRequest(
                         baseObject='cn=thingie,ou=stuff,dc=example,dc=com'),
                     id=2)))
         six.assertCountEqual(self,
             self._makeResultList(self.server.transport.value()),
-            [str(
+            [bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='cn=thingie,ou=stuff,dc=example,dc=com',
@@ -337,14 +337,14 @@ class LDAPServerTest(unittest.TestCase):
                             ('objectClass', ['a', 'b']),
                             ('cn', ['thingie'])]),
                     id=2)
-            ), str(
+            ), bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultDone(resultCode=0),
                     id=2))])
 
     def test_search_matchAll_oneResult_filtered(self):
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchRequest(
                         baseObject='cn=thingie,ou=stuff,dc=example,dc=com',
@@ -352,21 +352,21 @@ class LDAPServerTest(unittest.TestCase):
                     id=2)))
         six.assertCountEqual(self,
             self._makeResultList(self.server.transport.value()),
-            [str(
+            [bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='cn=thingie,ou=stuff,dc=example,dc=com',
                         attributes=[
                             ('cn', ['thingie'])]),
                     id=2)
-            ), str(
+            ), bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultDone(resultCode=0),
                     id=2))])
 
     def test_search_matchAll_oneResult_filteredNoAttribsRemaining(self):
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchRequest(
                         baseObject='cn=thingie,ou=stuff,dc=example,dc=com',
@@ -374,20 +374,20 @@ class LDAPServerTest(unittest.TestCase):
                     id=2)))
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultDone(resultCode=0),
                     id=2)))
 
     def test_search_matchAll_manyResults(self):
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchRequest(
                         baseObject='ou=stuff,dc=example,dc=com'), id=2)))
 
         six.assertCountEqual(self,
-            [str(
+            [bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='ou=stuff,dc=example,dc=com',
@@ -395,7 +395,7 @@ class LDAPServerTest(unittest.TestCase):
                             ('objectClass', ['a', 'b']),
                             ('ou', ['stuff'])]),
                     id=2)
-            ), str(
+            ), bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='cn=another,ou=stuff,dc=example,dc=com',
@@ -403,7 +403,7 @@ class LDAPServerTest(unittest.TestCase):
                             ('objectClass', ['a', 'b']),
                             ('cn', ['another'])]),
                     id=2)
-            ), str(
+            ), bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='cn=thingie,ou=stuff,dc=example,dc=com',
@@ -411,7 +411,7 @@ class LDAPServerTest(unittest.TestCase):
                             ('objectClass', ['a', 'b']),
                             ('cn', ['thingie'])]),
                     id=2)
-            ), str(
+            ), bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultDone(resultCode=0),
                     id=2))],
@@ -419,7 +419,7 @@ class LDAPServerTest(unittest.TestCase):
 
     def test_search_scope_oneLevel(self):
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchRequest(
                         baseObject='ou=stuff,dc=example,dc=com',
@@ -427,7 +427,7 @@ class LDAPServerTest(unittest.TestCase):
                     id=2)))
         six.assertCountEqual(self,
             self._makeResultList(self.server.transport.value()),
-            [str(
+            [bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='cn=thingie,ou=stuff,dc=example,dc=com',
@@ -435,7 +435,7 @@ class LDAPServerTest(unittest.TestCase):
                             ('objectClass', ['a', 'b']),
                             ('cn', ['thingie'])]),
                     id=2)
-            ), str(
+            ), bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='cn=another,ou=stuff,dc=example,dc=com',
@@ -443,14 +443,14 @@ class LDAPServerTest(unittest.TestCase):
                             ('objectClass', ['a', 'b']),
                             ('cn', ['another'])]),
                     id=2)
-            ), str(
+            ), bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultDone(resultCode=0),
                     id=2))])
 
     def test_search_scope_wholeSubtree(self):
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchRequest(
                         baseObject='ou=stuff,dc=example,dc=com',
@@ -458,7 +458,7 @@ class LDAPServerTest(unittest.TestCase):
                     id=2)))
         six.assertCountEqual(self,
             self._makeResultList(self.server.transport.value()),
-            [str(
+            [bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='ou=stuff,dc=example,dc=com',
@@ -466,7 +466,7 @@ class LDAPServerTest(unittest.TestCase):
                             ('objectClass', ['a', 'b']),
                             ('ou', ['stuff'])]),
                     id=2)
-            ), str(
+            ), bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='cn=another,ou=stuff,dc=example,dc=com',
@@ -474,7 +474,7 @@ class LDAPServerTest(unittest.TestCase):
                             ('objectClass', ['a', 'b']),
                             ('cn', ['another'])]),
                     id=2)
-            ), str(
+            ), bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='cn=thingie,ou=stuff,dc=example,dc=com',
@@ -482,14 +482,14 @@ class LDAPServerTest(unittest.TestCase):
                             ('objectClass', ['a', 'b']),
                             ('cn', ['thingie'])]),
                     id=2)
-            ), str(
+            ), bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultDone(resultCode=0),
                     id=2))])
 
     def test_search_scope_baseObject(self):
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchRequest(
                         baseObject='ou=stuff,dc=example,dc=com',
@@ -497,7 +497,7 @@ class LDAPServerTest(unittest.TestCase):
                     id=2)))
         six.assertCountEqual(self,
             self._makeResultList(self.server.transport.value()),
-            [str(
+            [bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='ou=stuff,dc=example,dc=com',
@@ -505,14 +505,14 @@ class LDAPServerTest(unittest.TestCase):
                             ('objectClass', ['a', 'b']),
                             ('ou', ['stuff'])]),
                     id=2)
-            ), str(
+            ), bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultDone(resultCode=0),
                     id=2))])
 
     def test_rootDSE(self):
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchRequest(
                         baseObject='',
@@ -521,7 +521,7 @@ class LDAPServerTest(unittest.TestCase):
                     id=2)))
         six.assertCountEqual(self,
             self._makeResultList(self.server.transport.value()),
-            [str(
+            [bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='',
@@ -531,7 +531,7 @@ class LDAPServerTest(unittest.TestCase):
                             ('supportedExtension',
                                 [pureldap.LDAPPasswordModifyRequest.oid])]),
                     id=2)
-            ), str(
+            ), bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultDone(
                         resultCode=ldaperrors.Success.resultCode),
@@ -539,13 +539,13 @@ class LDAPServerTest(unittest.TestCase):
 
     def test_delete(self):
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPDelRequest(str(self.thingie.dn)),
                     id=2)))
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPDelResponse(resultCode=0),
                     id=2)))
@@ -557,7 +557,7 @@ class LDAPServerTest(unittest.TestCase):
     def test_add_success(self):
         dn = 'cn=new,ou=stuff,dc=example,dc=com'
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPAddRequest(
                         entry=dn,
@@ -573,7 +573,7 @@ class LDAPServerTest(unittest.TestCase):
                     id=2)))
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPAddResponse(
                         resultCode=ldaperrors.Success.resultCode),
@@ -594,7 +594,7 @@ class LDAPServerTest(unittest.TestCase):
 
     def test_add_fail_existsAlready(self):
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPAddRequest(
                         entry=str(self.thingie.dn),
@@ -610,7 +610,7 @@ class LDAPServerTest(unittest.TestCase):
                     id=2)))
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPAddResponse(
                         resultCode=ldaperrors.LDAPEntryAlreadyExists.resultCode,
@@ -625,7 +625,7 @@ class LDAPServerTest(unittest.TestCase):
     def test_modifyDN_rdnOnly_deleteOldRDN_success(self):
         newrdn = 'cn=thingamagic'
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPModifyDNRequest(
                         entry=self.thingie.dn,
@@ -634,7 +634,7 @@ class LDAPServerTest(unittest.TestCase):
                     id=2)))
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPModifyDNResponse(
                         resultCode=ldaperrors.Success.resultCode),
@@ -657,7 +657,7 @@ class LDAPServerTest(unittest.TestCase):
 
     def test_modify(self):
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPModifyRequest(
                         self.stuff.dn,
@@ -667,7 +667,7 @@ class LDAPServerTest(unittest.TestCase):
                     id=2)))
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPModifyResponse(
                         resultCode=ldaperrors.Success.resultCode),
@@ -685,7 +685,7 @@ class LDAPServerTest(unittest.TestCase):
 
     def test_extendedRequest_unknown(self):
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPExtendedRequest(
                         requestName='42.42.42',
@@ -693,7 +693,7 @@ class LDAPServerTest(unittest.TestCase):
                     id=2)))
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPExtendedResponse(
                         resultCode=ldaperrors.LDAPProtocolError.resultCode,
@@ -702,7 +702,7 @@ class LDAPServerTest(unittest.TestCase):
 
     def test_passwordModify_notBound(self):
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPPasswordModifyRequest(
                         userIdentity='cn=thingie,ou=stuff,dc=example,dc=com',
@@ -710,7 +710,7 @@ class LDAPServerTest(unittest.TestCase):
                     id=2)))
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPExtendedResponse(
                         resultCode=ldaperrors.LDAPStrongAuthRequired.resultCode,
@@ -728,14 +728,14 @@ class LDAPServerTest(unittest.TestCase):
         # first bind to some entry
         self.thingie['userPassword'] = ['{SSHA}yVLLj62rFf3kDAbzwEU0zYAVvbWrze8=']  # "secret"
         self.server.dataReceived(
-            str(pureldap.LDAPMessage(
+            bytes(pureldap.LDAPMessage(
                 pureldap.LDAPBindRequest(
                     dn='cn=thingie,ou=stuff,dc=example,dc=com',
                     auth=b'secret'),
                 id=4)))
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindResponse(
                         resultCode=0,
@@ -743,7 +743,7 @@ class LDAPServerTest(unittest.TestCase):
                     id=4)))
         self.server.transport.clear()
         self.server.dataReceived(
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPPasswordModifyRequest(
                         userIdentity='cn=thingie,ou=stuff,dc=example,dc=com',
@@ -752,7 +752,7 @@ class LDAPServerTest(unittest.TestCase):
         self.assertEqual(data['committed'], True, "Server never committed data.")
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPExtendedResponse(
                         resultCode=ldaperrors.Success.resultCode,
@@ -774,11 +774,11 @@ class LDAPServerTest(unittest.TestCase):
             handle_LDAPBindRequest = property()
 
         self.server.__class__ = MockServer
-        self.server.dataReceived(str(pureldap.LDAPMessage(
+        self.server.dataReceived(bytes(pureldap.LDAPMessage(
             pureldap.LDAPBindRequest(), id=2)))
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPExtendedResponse(
                         resultCode=ldaperrors.LDAPProtocolError.resultCode,
@@ -787,13 +787,13 @@ class LDAPServerTest(unittest.TestCase):
                     id=2)))
 
     def test_control_unknown_critical(self):
-        self.server.dataReceived(str(pureldap.LDAPMessage(
+        self.server.dataReceived(bytes(pureldap.LDAPMessage(
             pureldap.LDAPBindRequest(), id=2,
             controls=[('42.42.42.42', True, None),
                       ])))
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindResponse(
                         resultCode=ldaperrors.LDAPUnavailableCriticalExtension.resultCode,
@@ -802,14 +802,14 @@ class LDAPServerTest(unittest.TestCase):
 
     def test_control_unknown_nonCritical(self):
         self.thingie['userPassword'] = ['{SSHA}yVLLj62rFf3kDAbzwEU0zYAVvbWrze8=']  # "secret"
-        self.server.dataReceived(str(pureldap.LDAPMessage(
+        self.server.dataReceived(bytes(pureldap.LDAPMessage(
             pureldap.LDAPBindRequest(dn='cn=thingie,ou=stuff,dc=example,dc=com',
                                      auth=b'secret'),
             controls=[('42.42.42.42', False, None)],
             id=4)))
         self.assertEqual(
             self.server.transport.value(),
-            str(
+            bytes(
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindResponse(
                         resultCode=0,
@@ -858,13 +858,13 @@ class TestSchema(unittest.TestCase):
         (attributeTypes, objectClasses) = util.pumpingDeferredResult(d)
 
         self.failUnlessEqual(
-            [str(x) for x in attributeTypes],
-            [str(schema.AttributeTypeDescription(x)) for x in [
+            [bytes(x) for x in attributeTypes],
+            [bytes(schema.AttributeTypeDescription(x)) for x in [
                 test_schema.AttributeType_KnownValues.knownValues[0][0]]])
 
         self.failUnlessEqual(
-            [str(x) for x in objectClasses],
-            [str(schema.ObjectClassDescription(x)) for x in [
+            [bytes(x) for x in objectClasses],
+            [bytes(schema.ObjectClassDescription(x)) for x in [
                 test_schema.OBJECTCLASSES['organization'],
                 test_schema.OBJECTCLASSES['organizationalUnit']]])
 

--- a/ldaptor/test/test_svcbindproxy.py
+++ b/ldaptor/test/test_svcbindproxy.py
@@ -38,7 +38,7 @@ class ServiceBindingProxy(unittest.TestCase):
             [ pureldap.LDAPSearchResultDone(ldaperrors.Success.resultCode) ],
             [ pureldap.LDAPSearchResultDone(ldaperrors.Success.resultCode) ],
             ])
-        server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(dn='cn=jack,dc=example,dc=com', auth='s3krit'), id=4)))
+        server.dataReceived(bytes(pureldap.LDAPMessage(pureldap.LDAPBindRequest(dn='cn=jack,dc=example,dc=com', auth='s3krit'), id=4)))
         reactor.iterate() #TODO
         client = server.client
 
@@ -84,7 +84,7 @@ class ServiceBindingProxy(unittest.TestCase):
                                        attributes=('1.1',)),
             )
         self.assertEqual(server.transport.value(),
-                          str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=ldaperrors.LDAPInvalidCredentials.resultCode), id=4)))
+                          bytes(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=ldaperrors.LDAPInvalidCredentials.resultCode), id=4)))
 
     def test_bind_noMatchingServicesFound_fallback_success(self):
         server = self.createServer(
@@ -99,7 +99,7 @@ class ServiceBindingProxy(unittest.TestCase):
             [ pureldap.LDAPSearchResultDone(ldaperrors.Success.resultCode) ],
             [ pureldap.LDAPBindResponse(resultCode=ldaperrors.Success.resultCode) ],
             ])
-        server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(dn='cn=jack,dc=example,dc=com', auth='s3krit'), id=4)))
+        server.dataReceived(bytes(pureldap.LDAPMessage(pureldap.LDAPBindRequest(dn='cn=jack,dc=example,dc=com', auth='s3krit'), id=4)))
         reactor.iterate() #TODO
         client = server.client
 
@@ -145,7 +145,7 @@ class ServiceBindingProxy(unittest.TestCase):
                                        attributes=('1.1',)),
             pureldap.LDAPBindRequest(dn='cn=jack,dc=example,dc=com', auth='s3krit'))
         self.assertEqual(server.transport.value(),
-                          str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=ldaperrors.Success.resultCode), id=4)))
+                          bytes(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=ldaperrors.Success.resultCode), id=4)))
 
     def test_bind_noMatchingServicesFound_fallback_badAuth(self):
         server = self.createServer(
@@ -161,7 +161,7 @@ class ServiceBindingProxy(unittest.TestCase):
             [ pureldap.LDAPBindResponse(resultCode=ldaperrors.LDAPInvalidCredentials.resultCode),
               ],
             ])
-        server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(dn='cn=jack,dc=example,dc=com', auth='wrong-s3krit'), id=4)))
+        server.dataReceived(bytes(pureldap.LDAPMessage(pureldap.LDAPBindRequest(dn='cn=jack,dc=example,dc=com', auth='wrong-s3krit'), id=4)))
         reactor.iterate() #TODO
         client = server.client
 
@@ -207,7 +207,7 @@ class ServiceBindingProxy(unittest.TestCase):
                                        attributes=('1.1',)),
             pureldap.LDAPBindRequest(dn='cn=jack,dc=example,dc=com', auth='wrong-s3krit'))
         self.assertEqual(server.transport.value(),
-                          str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=ldaperrors.LDAPInvalidCredentials.resultCode), id=4)))
+                          bytes(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=ldaperrors.LDAPInvalidCredentials.resultCode), id=4)))
 
 
     def test_bind_match_success(self):
@@ -226,7 +226,7 @@ class ServiceBindingProxy(unittest.TestCase):
             [ pureldap.LDAPBindResponse(resultCode=ldaperrors.Success.resultCode) ],
             ])
 
-        server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(dn='cn=jack,dc=example,dc=com', auth='secret'), id=4)))
+        server.dataReceived(bytes(pureldap.LDAPMessage(pureldap.LDAPBindRequest(dn='cn=jack,dc=example,dc=com', auth='secret'), id=4)))
         reactor.iterate() #TODO
         client = server.client
 
@@ -247,7 +247,7 @@ class ServiceBindingProxy(unittest.TestCase):
             pureldap.LDAPBindRequest(dn=r'cn=svc1+owner=cn\=jack\,dc\=example\,dc\=com,dc=example,dc=com', auth='secret'),
             )
         self.assertEqual(server.transport.value(),
-                          str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=ldaperrors.Success.resultCode,
+                          bytes(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=ldaperrors.Success.resultCode,
                                                                              matchedDN='cn=jack,dc=example,dc=com'), id=4)))
 
     def test_bind_match_success_later(self):
@@ -275,7 +275,7 @@ class ServiceBindingProxy(unittest.TestCase):
             [ pureldap.LDAPBindResponse(resultCode=ldaperrors.Success.resultCode) ],
             ])
 
-        server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(dn='cn=jack,dc=example,dc=com', auth='secret'), id=4)))
+        server.dataReceived(bytes(pureldap.LDAPMessage(pureldap.LDAPBindRequest(dn='cn=jack,dc=example,dc=com', auth='secret'), id=4)))
         reactor.iterate() #TODO
         client = server.client
 
@@ -323,7 +323,7 @@ class ServiceBindingProxy(unittest.TestCase):
             pureldap.LDAPBindRequest(dn='cn=svc3+owner=cn\=jack\,dc\=example\,dc\=com,dc=example,dc=com', auth='secret'),
             )
         self.assertEqual(server.transport.value(),
-                          str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=ldaperrors.Success.resultCode,
+                          bytes(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=ldaperrors.Success.resultCode,
                                                                              matchedDN='cn=jack,dc=example,dc=com'), id=4)))
 
     def test_bind_match_badAuth(self):
@@ -352,7 +352,7 @@ class ServiceBindingProxy(unittest.TestCase):
             [ pureldap.LDAPBindResponse(resultCode=ldaperrors.LDAPInvalidCredentials.resultCode) ],
             ])
 
-        server.dataReceived(str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(dn='cn=jack,dc=example,dc=com', auth='wrong-s3krit'), id=4)))
+        server.dataReceived(bytes(pureldap.LDAPMessage(pureldap.LDAPBindRequest(dn='cn=jack,dc=example,dc=com', auth='wrong-s3krit'), id=4)))
         reactor.iterate() #TODO
         client = server.client
 
@@ -401,4 +401,4 @@ class ServiceBindingProxy(unittest.TestCase):
             pureldap.LDAPBindRequest(version=3, dn='cn=jack,dc=example,dc=com', auth='wrong-s3krit'),
             )
         self.assertEqual(server.transport.value(),
-                          str(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=ldaperrors.LDAPInvalidCredentials.resultCode), id=4)))
+                          bytes(pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=ldaperrors.LDAPInvalidCredentials.resultCode), id=4)))

--- a/ldaptor/testutil.py
+++ b/ldaptor/testutil.py
@@ -127,13 +127,13 @@ class LDAPClientTestDriver:
             shouldBeSent,
             self.sent)
         assert self.sent == shouldBeSent, msg
-        sentStr = ''.join([str(x) for x in self.sent])
-        shouldBeSentStr = ''.join([str(x) for x in shouldBeSent])
-        msg = '%s expected to send data %r but sent %r' % (
+        sentBytes = b''.join([bytes(x) for x in self.sent])
+        shouldBeSentBytes = b''.join([bytes(x) for x in shouldBeSent])
+        msg = '%s expected to send data %s but sent %s' % (
             self.__class__.__name__,
-            shouldBeSentStr,
-            sentStr)
-        assert sentStr == shouldBeSentStr, msg
+            shouldBeSentBytes,
+            sentBytes)
+        assert sentBytes == shouldBeSentBytes, msg
 
     def connectionMade(self):
         """TCP connection has opened"""


### PR DESCRIPTION
Greetings! I made an attempt in porting some of the library code to the Python 3. It may be helpful in finding the better approach in this str/unicode/bytes problem. The key concepts I use:

1. `__str__` methods in pureber and pureldap modules were renamed to `__bytes__`. `__str__` is now used as an alias for `__bytes__` method in the Python 2. This modules allowed implicit conversion to the Python 2 str if unicode was used for their classes initializing so I tried to preserve this feature though there are no unicode tests for these modules.
2. distinguishedname.py classes allow using of both str/bytes and unicode/str for initialization. Their values are stored in unicode/str but both `__bytes__` and `__str__` methods are used.
3. `str()` conversion was changed to `bytes()` in many modules and tests.

The main problem I have stumbled is encoding/decoding of LDAP attributes and values. If we add an attribute to an entry do we need to convert it to str/bytes or unicode/str? If we parse a received entry what type should we use for its attributes and values? This ambiguity prevented me from making proper fixes for LDIF modules and most importantly ldapserver.

No tests were broken for the Python 2.7. The current test picture for the Python 3.5 and 3.6 is:

```
ldaptor/test/test_attributeset.py............
ldaptor/test/test_autofill.py.
ldaptor/test/test_autofill_posix.py..
ldaptor/test/test_autofill_samba.py............
ldaptor/test/test_config.py............
ldaptor/test/test_connector.py...
ldaptor/test/test_delta.py.........................................
ldaptor/test/test_distinguishedname.py.......................
ldaptor/test/test_dns.py...............
ldaptor/test/test_entry.py................
ldaptor/test/test_examples.pyFFF
ldaptor/test/test_fetchschema.py.
ldaptor/test/test_inmemory.py.......................................
ldaptor/test/test_ldapclient.py...............
ldaptor/test/test_ldapfilter.py...........................................................
ldaptor/test/test_ldapsyntax.py................................................................
ldaptor/test/test_ldifdelta.pyF.....F.....FFFF.
ldaptor/test/test_ldifprotocol.py...FFF.FFFF..F..F
ldaptor/test/test_ldiftree.py.....FFFFF.F.....................F.......FFFF.FF.....
ldaptor/test/test_match.py...............................
ldaptor/test/test_merger.py........
ldaptor/test/test_proxy.py..F.
ldaptor/test/test_proxybase.py.......F.
ldaptor/test/test_pureber.py...............................
ldaptor/test/test_pureldap.py.....................
ldaptor/test/test_schema.py.......
ldaptor/test/test_server.py.FF.......F..F..FF.FFFFFF..FFFF.x
ldaptor/test/test_smbpassword.py...
ldaptor/test/test_svcbindproxy.py......
ldaptor/test/test_usage.py.....

49 failed, 513 passed, 1 xfailed in 21.86 seconds
```

Contributor Checklist:

* [ ] I have updated the release notes at `docs/source/NEWS.rst` 
* [x] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.

I have not updated the release notes as these changes look like already mentioned "preparation for py3 port" in NEWS.rst .