### PR TITLE
Switching to bytes for pureber and pureldap modules

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -19,6 +19,8 @@ Changes
 
 - Using modern classmethod decorator instead of old-style method call.
 - Usage of zope.interfaces was updated in preparation for python3 port.
+- ``toWire`` method is used to get bytes representation of ``ldaptor.protocols.pureber`` and
+  ``ldaptor.protocols.pureldap`` classes instead of ``__str__`` which is deprecated now.
 - Code was updated to pass `python3 -m compileall` in preparation for py3 port.
 - Continuous test are executed only against latest related Twisted and latest
   Twisted trunk branch.

--- a/ldaptor/delta.py
+++ b/ldaptor/delta.py
@@ -32,12 +32,12 @@ class Modification(attributeset.LDAPAttributeSet):
                 value = tmplist[x]
                 newlist.append(value) 
         
-        return str(pureber.BERSequence([
+        return pureber.BERSequence([
             pureber.BEREnumerated(self._LDAP_OP),
             pureber.BERSequence([ pureldap.LDAPAttributeDescription(self.key),
                                   pureber.BERSet(map(pureldap.LDAPString, newlist)),
                                   ]),
-            ]))
+            ]).toWire()
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/ldaptor/encoder.py
+++ b/ldaptor/encoder.py
@@ -1,0 +1,13 @@
+"""
+    Encoding / decoding utilities
+"""
+
+import six
+
+
+def to_bytes(value):
+    if hasattr(value, 'toWire'):
+        return value.toWire()
+    if isinstance(value, six.text_type):
+        return value.encode('utf-8')
+    return bytes(value)

--- a/ldaptor/protocols/pureber.py
+++ b/ldaptor/protocols/pureber.py
@@ -74,7 +74,7 @@ def berDecodeLength(m, offset=0):
     Return a tuple of (length, lengthLength).
     m must be atleast one byte long.
     """
-    l = ber2int(m[offset + 0])
+    l = ber2int(m[offset + 0:offset + 1])
     ll = 1
     if l & 0x80:
         ll = 1 + (l & 0x7F)
@@ -107,11 +107,11 @@ def int2ber(i, signed=True):
 
 def ber2int(e, signed=True):
     need(e, 1)
-    v = 0 + ord(e[0])
+    v = 0 + ord(e[0:1])
     if v & 0x80 and signed:
         v = v - 256
     for i in range(1, len(e)):
-        v = (v << 8) | ord(e[i])
+        v = (v << 8) | ord(e[i:i + 1])
     return v
 
 
@@ -370,7 +370,7 @@ def berDecodeObject(context, m):
     """
     while m:
         need(m, 2)
-        i = ber2int(m[0], signed=0) & (CLASS_MASK | TAG_MASK)
+        i = ber2int(m[0:1], signed=0) & (CLASS_MASK | TAG_MASK)
 
         length, lenlen = berDecodeLength(m, offset=1)
         need(m, 1 + lenlen + length)

--- a/ldaptor/protocols/pureber.py
+++ b/ldaptor/protocols/pureber.py
@@ -29,6 +29,8 @@
 # (4) If a value of a type is its default value, it MUST be absent.
 #     Only some BOOLEAN and INTEGER types have default values in
 #     this protocol definition.
+import warnings
+
 import six
 
 from ldaptor.encoder import to_bytes
@@ -146,6 +148,15 @@ class BERBase(object):
 
     def toWire(self):
         return b''
+
+    def __str__(self):
+        warnings.simplefilter('always', DeprecationWarning)
+        warnings.warn('{0}.__str__ method is deprecated and will not be used '
+                      'for getting bytes representation in the future '
+                      'releases, use {0}.toWire instead'.format(self.__class__.__name__),
+                      category=DeprecationWarning)
+        warnings.simplefilter('default', DeprecationWarning)
+        return self.toWire()
 
 
 class BERStructured(BERBase):

--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -121,10 +121,6 @@ class LDAPMessage(BERSequence):
             l.append(LDAPControls([LDAPControl(*a) for a in self.controls]))
         return BERSequence(l).toWire()
 
-    def __str__(self):
-        # TODO: Left for compatibility, need to be removed when all higher level classes will use toWire method
-        return self.toWire()
-
     def __repr__(self):
         l = []
         l.append('id=%r' % self.id)

--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -28,6 +28,7 @@ from ldaptor.protocols.pureber import (
 
     berDecodeMultiple, berDecodeObject, int2berlen,
     )
+from ldaptor.encoder import to_bytes
 
 next_ldap_message_id = 1
 
@@ -72,7 +73,7 @@ class LDAPAttributeValue(BEROctetString):
 
 class LDAPMessage(BERSequence):
     """
-    To encode this object in order to be sent over the network use the str()
+    To encode this object in order to be sent over the network use the toWire()
     method.
     """
     id = None
@@ -111,14 +112,18 @@ class LDAPMessage(BERSequence):
         self.value = value
         self.controls = controls
 
-    def __str__(self):
+    def toWire(self):
         """
         This is the wire/encoded representation.
         """
         l = [BERInteger(self.id), self.value]
         if self.controls is not None:
             l.append(LDAPControls([LDAPControl(*a) for a in self.controls]))
-        return str(BERSequence(l))
+        return BERSequence(l).toWire()
+
+    def __str__(self):
+        # TODO: Left for compatibility, need to be removed when all higher level classes will use toWire method
+        return self.toWire()
 
     def __repr__(self):
         l = []
@@ -134,9 +139,8 @@ class LDAPProtocolOp:
     def __init__(self):
         pass
 
-    def __str__(self):
+    def toWire(self):
         raise NotImplementedError()
-
 
 
 class LDAPProtocolRequest(LDAPProtocolOp):
@@ -199,17 +203,17 @@ class LDAPBindRequest(LDAPProtocolRequest, BERSequence):
             assert (not sasl)
         self.sasl = sasl
 
-    def __str__(self):
+    def toWire(self):
         if not self.sasl:
             auth_ber = BEROctetString(self.auth, tag=CLASS_CONTEXT | 0)
         else:
             auth_ber = BERSequence([BEROctetString(self.auth[0]), BEROctetString(self.auth[1])],
                                    tag=CLASS_CONTEXT | 3)
-        return str(BERSequence([
+        return BERSequence([
             BERInteger(self.version),
             BEROctetString(self.dn),
             auth_ber,
-            ], tag=self.tag))
+            ], tag=self.tag).toWire()
 
     def __repr__(self):
         l = []
@@ -237,9 +241,6 @@ class LDAPSearchResultReference(LDAPProtocolResponse):
     def fromBER(cls, tag, content, berdecoder=None):
         r = cls()
         return r
-
-    def __str__(self):
-        return object.__str__(self)
 
     def __repr__(self):
         return object.__repr__(self)
@@ -279,14 +280,14 @@ class LDAPResult(LDAPProtocolResponse, BERSequence):
         self.referral = referral
         self.serverSaslCreds = serverSaslCreds
 
-    def __str__(self):
+    def toWire(self):
         assert self.referral is None  # TODO
-        return str(BERSequence([
+        return BERSequence([
             BEREnumerated(self.resultCode),
             BEROctetString(self.matchedDN),
             BEROctetString(self.errorMessage),
             #TODO referral [3] Referral OPTIONAL
-            ], tag=self.tag))
+            ], tag=self.tag).toWire()
 
     def __repr__(self):
         l = []
@@ -355,9 +356,6 @@ class LDAPBindResponse(LDAPResult):
         LDAPResult.__init__(self, resultCode=resultCode, matchedDN=matchedDN, errorMessage=errorMessage,
                             referral=referral, serverSaslCreds=serverSaslCreds, tag=None)
 
-    def __str__(self):
-        return LDAPResult.__str__(self)
-
     def __repr__(self):
         return LDAPResult.__repr__(self)
 
@@ -370,8 +368,8 @@ class LDAPUnbindRequest(LDAPProtocolRequest, BERNull):
         LDAPProtocolRequest.__init__(self)
         BERNull.__init__(self, *args, **kwargs)
 
-    def __str__(self):
-        return BERNull.__str__(self)
+    def toWire(self):
+        return BERNull.toWire(self)
 
 
 class LDAPAttributeDescription(BEROctetString):
@@ -396,10 +394,10 @@ class LDAPAttributeValueAssertion(BERSequence):
         self.assertionValue = assertionValue
         self.escaper = escaper
 
-    def __str__(self):
-        return str(BERSequence([self.attributeDesc,
-                                self.assertionValue],
-                               tag=self.tag))
+    def toWire(self):
+        return BERSequence([self.attributeDesc,
+                            self.assertionValue],
+                           tag=self.tag).toWire()
 
     def __repr__(self):
         if self.tag == self.__class__.tag:
@@ -428,7 +426,7 @@ class LDAPFilterSet(BERSet):
         elif len(self) != len(rhs):
             return False
 
-        return sorted(self, key=str) == sorted(rhs, key=str)
+        return sorted(self, key=lambda x: x.toWire()) == sorted(rhs, key=lambda x: x.toWire())
 
 class LDAPFilter_and(LDAPFilterSet):
     tag = CLASS_CONTEXT | 0x00
@@ -471,9 +469,9 @@ class LDAPFilter_not(LDAPFilter):
                    + "(value=%s, tag=%d)" \
                      % (repr(self.value), self.tag)
 
-    def __str__(self):
-        r = str(self.value)
-        return chr(self.identification()) + int2berlen(len(r)) + r
+    def toWire(self):
+        value = to_bytes(self.value)
+        return six.int2byte(self.identification()) + int2berlen(len(value)) + value
 
     def asText(self):
         return '(!' + self.value.asText() + ')'
@@ -533,10 +531,10 @@ class LDAPFilter_substrings(BERSequence):
         self.type = type
         self.substrings = substrings
 
-    def __str__(self):
-        return str(BERSequence([
+    def toWire(self):
+        return BERSequence([
             LDAPString(self.type),
-            BERSequence(self.substrings)], tag=self.tag))
+            BERSequence(self.substrings)], tag=self.tag).toWire()
 
     def __repr__(self):
         if self.tag==self.__class__.tag:
@@ -705,10 +703,10 @@ class LDAPMatchingRuleAssertion(BERSequence):
         if not self.dnAttributes:
             self.dnAttributes = None
 
-    def __str__(self):
-        return str(BERSequence(
+    def toWire(self):
+        return BERSequence(
             filter(lambda x: x is not None,
-                   [self.matchingRule, self.type, self.matchValue, self.dnAttributes]), tag=self.tag))
+                   [self.matchingRule, self.type, self.matchValue, self.dnAttributes]), tag=self.tag).toWire()
 
     def __repr__(self):
         l=[]
@@ -812,8 +810,8 @@ class LDAPSearchRequest(LDAPProtocolRequest, BERSequence):
         if attributes is not None:
             self.attributes = attributes
 
-    def __str__(self):
-        return str(BERSequence([
+    def toWire(self):
+        return BERSequence([
             BEROctetString(self.baseObject),
             BEREnumerated(self.scope),
             BEREnumerated(self.derefAliases),
@@ -822,7 +820,7 @@ class LDAPSearchRequest(LDAPProtocolRequest, BERSequence):
             BERBoolean(self.typesOnly),
             self.filter,
             BERSequenceOf(map(BEROctetString, self.attributes)),
-            ], tag=self.tag))
+            ], tag=self.tag).toWire()
 
     def __repr__(self):
         if self.tag == self.__class__.tag:
@@ -870,8 +868,8 @@ class LDAPSearchResultEntry(LDAPProtocolResponse, BERSequence):
         self.objectName = objectName
         self.attributes = attributes
 
-    def __str__(self):
-        return str(BERSequence([
+    def toWire(self):
+        return BERSequence([
             BEROctetString(self.objectName),
             BERSequence([
                 BERSequence([
@@ -879,7 +877,7 @@ class LDAPSearchResultEntry(LDAPProtocolResponse, BERSequence):
                     BERSet(list(map(BEROctetString, attr_li[1])))])
                 for attr_li in self.attributes
                 ]),
-        ], tag=self.tag))
+        ], tag=self.tag).toWire()
 
     def __repr__(self):
         if self.tag==self.__class__.tag:
@@ -947,13 +945,13 @@ class LDAPControl(BERSequence):
         self.criticality = criticality
         self.controlValue = controlValue
 
-    def __str__(self):
+    def toWire(self):
         self.data = [LDAPOID(self.controlType)]
         if self.criticality is not None:
             self.data.append(BERBoolean(self.criticality))
         if self.controlValue is not None:
             self.data.append(BEROctetString(self.controlValue))
-        return BERSequence.__str__(self)
+        return BERSequence.toWire(self)
 
 
 class LDAPBERDecoderContext_LDAPControls(BERDecoderContext):
@@ -1031,11 +1029,11 @@ class LDAPModifyRequest(LDAPProtocolRequest, BERSequence):
         self.object = object
         self.modification = modification
 
-    def __str__(self):
+    def toWire(self):
         l = [LDAPString(self.object)]
         if self.modification is not None:
             l.append(BERSequence(self.modification))
-        return str(BERSequence(l, tag=self.tag))
+        return BERSequence(l, tag=self.tag).toWire()
 
     def __repr__(self):
         if self.tag==self.__class__.tag:
@@ -1087,11 +1085,11 @@ class LDAPAddRequest(LDAPProtocolRequest, BERSequence):
         self.entry = entry
         self.attributes = attributes
 
-    def __str__(self):
-        return str(BERSequence([
+    def toWire(self):
+        return BERSequence([
             LDAPString(self.entry),
             BERSequence(map(BERSequence, self.attributes)),
-            ], tag=self.tag))
+            ], tag=self.tag).toWire()
 
     def __repr__(self):
         if self.tag==self.__class__.tag:
@@ -1121,8 +1119,8 @@ class LDAPDelRequest(LDAPProtocolRequest, LDAPString):
         LDAPProtocolRequest.__init__(self)
         LDAPString.__init__(self, value=entry, tag=tag)
 
-    def __str__(self):
-        return LDAPString.__str__(self)
+    def toWire(self):
+        return LDAPString.toWire(self)
 
     def __repr__(self):
         if self.tag == self.__class__.tag:
@@ -1164,12 +1162,12 @@ class LDAPModifyDNRequest(LDAPProtocolRequest, BERSequence):
 
         kw = {}
         try:
-            kw['newSuperior'] = str(l[3].value)
+            kw['newSuperior'] = to_bytes(l[3].value)
         except IndexError:
             pass
 
-        r = klass(entry=str(l[0].value),
-                  newrdn=str(l[1].value),
+        r = klass(entry=to_bytes(l[0].value),
+                  newrdn=to_bytes(l[1].value),
                   deleteoldrdn=l[2].value,
                   tag=tag,
                   **kw)
@@ -1197,7 +1195,7 @@ class LDAPModifyDNRequest(LDAPProtocolRequest, BERSequence):
         self.deleteoldrdn = deleteoldrdn
         self.newSuperior = newSuperior
 
-    def __str__(self):
+    def toWire(self):
         l = [
             LDAPString(self.entry),
             LDAPString(self.newrdn),
@@ -1205,7 +1203,7 @@ class LDAPModifyDNRequest(LDAPProtocolRequest, BERSequence):
             ]
         if self.newSuperior is not None:
             l.append(LDAPString(self.newSuperior, tag=CLASS_CONTEXT | 0))
-        return str(BERSequence(l, tag=self.tag))
+        return BERSequence(l, tag=self.tag).toWire()
 
     def __repr__(self):
         l = [
@@ -1260,9 +1258,9 @@ class LDAPCompareRequest(LDAPProtocolRequest, BERSequence):
         self.entry = entry
         self.ava = ava
 
-    def __str__(self):
+    def toWire(self):
         l = [LDAPString(self.entry), self.ava]
-        return str(BERSequence(l, tag=self.tag))
+        return BERSequence(l, tag=self.tag).toWire()
 
     def __repr__(self):
         l = ["entry={}".format(self.entry), "ava={}".format(repr(self.ava))]
@@ -1288,8 +1286,8 @@ class LDAPAbandonRequest(LDAPProtocolRequest, LDAPInteger):
         LDAPProtocolRequest.__init__(self)
         LDAPInteger.__init__(self, value=id, tag=tag)
 
-    def __str__(self):
-        return LDAPInteger.__str__(self)
+    def toWire(self):
+        return LDAPInteger.toWire(self)
 
     def __repr__(self):
         if self.tag==self.__class__.tag:
@@ -1348,17 +1346,18 @@ class LDAPExtendedRequest(LDAPProtocolRequest, BERSequence):
         LDAPProtocolRequest.__init__(self)
         BERSequence.__init__(self, [], tag=tag)
         assert requestName is not None
-        assert isinstance(requestName, six.string_types)
+        assert isinstance(requestName, (six.binary_type, six.text_type))
         assert requestValue is None or isinstance(
-            requestValue, six.string_types)
+            requestValue, (six.binary_type, six.text_type))
         self.requestName = requestName
         self.requestValue = requestValue
 
-    def __str__(self):
+    def toWire(self):
         l = [LDAPOID(self.requestName, tag=CLASS_CONTEXT | 0)]
         if self.requestValue is not None:
-            l.append(BEROctetString(str(self.requestValue), tag=CLASS_CONTEXT | 1))
-        return str(BERSequence(l, tag=self.tag))
+            value = to_bytes(self.requestValue)
+            l.append(BEROctetString(value, tag=CLASS_CONTEXT | 1))
+        return BERSequence(l, tag=self.tag).toWire()
 
 
 class LDAPPasswordModifyRequest_userIdentity(BEROctetString):
@@ -1408,7 +1407,7 @@ class LDAPPasswordModifyRequest(LDAPExtendedRequest):
         LDAPExtendedRequest.__init__(
             self,
             requestName=self.oid,
-            requestValue=str(BERSequence(l)),
+            requestValue=BERSequence(l).toWire(),
             tag=tag)
 
     def __repr__(self):
@@ -1475,7 +1474,7 @@ class LDAPExtendedResponse(LDAPResult):
         self.responseName = responseName
         self.response = response
 
-    def __str__(self):
+    def toWire(self):
         assert self.referral is None  # TODO
         l = [BEREnumerated(self.resultCode),
              BEROctetString(self.matchedDN),
@@ -1486,7 +1485,7 @@ class LDAPExtendedResponse(LDAPResult):
             l.append(LDAPOID(self.responseName, tag=CLASS_CONTEXT | 0x0a))
         if self.response is not None:
             l.append(BEROctetString(self.response, tag=CLASS_CONTEXT | 0x0b))
-        return str(BERSequence(l, tag=self.tag))
+        return BERSequence(l, tag=self.tag).toWire()
 
 
 class LDAPStartTLSRequest(LDAPExtendedRequest):

--- a/ldaptor/test/test_encoder.py
+++ b/ldaptor/test/test_encoder.py
@@ -1,0 +1,29 @@
+"""
+    Test cases for ldaptor.encoder module
+"""
+
+from twisted.trial import unittest
+
+import six
+
+from ldaptor.encoder import to_bytes
+
+
+class WireableObject(object):
+    def toWire(self):
+        return b'wire'
+
+
+class EncoderTests(unittest.TestCase):
+
+    def test_wireable_object(self):
+        obj = WireableObject()
+        self.assertEqual(to_bytes(obj), b'wire')
+
+    def test_unicode_object(self):
+        obj = six.u('unicode')
+        self.assertEqual(to_bytes(obj), b'unicode')
+
+    def test_bytes_object(self):
+        obj = b'bytes'
+        self.assertEqual(to_bytes(obj), b'bytes')

--- a/ldaptor/test/test_pureber.py
+++ b/ldaptor/test/test_pureber.py
@@ -26,9 +26,8 @@ def s(*l):
     """Join all members of list to a byte string. Integer members are converted to bytes"""
     r = b''
     for e in l:
-        if isinstance(e, int):
-            e = six.int2byte(e)
-        r = r + bytes(e)
+        e = six.int2byte(e)
+        r = r + e
     return r
 
 

--- a/ldaptor/test/test_pureber.py
+++ b/ldaptor/test/test_pureber.py
@@ -23,16 +23,17 @@ from ldaptor.protocols import pureber
 
 
 def s(*l):
-    """Join all members of list to a string. Integer members are chr()ed"""
-    r=''
+    """Join all members of list to a byte string. Integer members are converted to bytes"""
+    r = b''
     for e in l:
-        e = chr(e)
-        r = r + str(e)
+        if isinstance(e, int):
+            e = six.int2byte(e)
+        r = r + bytes(e)
     return r
 
 
 def l(s):
-    """Split a string to ord's of chars."""
+    """Split a byte string to ord's of chars."""
     return [six.byte2int([x]) for x in s]
 
 
@@ -56,8 +57,8 @@ class BerLengths(unittest.TestCase):
     def testToBER(self):
         for integer, encoded in self.knownValues:
             got = pureber.int2berlen(integer)
-            got = str(got)
-            got = list(map(ord, got))
+            got = bytes(got)
+            got = l(got)
             self.assertEqual(got, encoded)
 
     def testFromBER(self):
@@ -68,12 +69,12 @@ class BerLengths(unittest.TestCase):
             self.assertEqual(got, integer)
 
     def testPartialBER(self):
-        m=str(pureber.int2berlen(3*256))
+        m = bytes(pureber.int2berlen(3*256))
         self.assertEqual(3, len(m))
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeLength, m[:2])
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeLength, m[:1])
 
-        m=str(pureber.int2berlen(256**100-1))
+        m = bytes(pureber.int2berlen(256**100-1))
         self.assertEqual(101, len(m))
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeLength, m[:100])
 
@@ -83,6 +84,7 @@ class BERBaseTests(unittest.TestCase):
     Unit tests for generic BERBase.
     """
     valuesToTest=(
+        (pureber.BERBase, []),
         (pureber.BERInteger, [0]),
         (pureber.BERInteger, [1]),
         (pureber.BERInteger, [4000]),
@@ -154,11 +156,11 @@ class BERIntegerKnownValues(unittest.TestCase):
         )
 
     def testToBERIntegerKnownValues(self):
-        """str(BERInteger(n)) should give known result with known input"""
+        """BERInteger(n).toWire() should give known result with known input"""
         for integer, encoded in self.knownValues:
             result = pureber.BERInteger(integer)
-            result = str(result)
-            result = list(map(ord, result))
+            result = result.toWire()
+            result = l(result)
             self.assertEqual(encoded, result)
 
     def testFromBERIntegerKnownValues(self):
@@ -173,17 +175,18 @@ class BERIntegerKnownValues(unittest.TestCase):
 
     def testPartialBERIntegerEncodings(self):
         """BERInteger(encoded="...") with too short input should throw BERExceptionInsufficientData"""
-        m=str(pureber.BERInteger(42))
+        m = pureber.BERInteger(42).toWire()
         self.assertEqual(3, len(m))
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeObject, pureber.BERDecoderContext(), m[:2])
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeObject, pureber.BERDecoderContext(), m[:1])
         self.assertEqual((None, 0), pureber.berDecodeObject(pureber.BERDecoderContext(), ''))
 
+
 class BERIntegerSanityCheck(unittest.TestCase):
     def testSanity(self):
         """BERInteger(encoded=BERInteger(n)).value==n for -1000..1000"""
         for n in range(-1000, 1001, 10):
-            encoded = str(pureber.BERInteger(n))
+            encoded = pureber.BERInteger(n).toWire()
             result, bytes = pureber.berDecodeObject(pureber.BERDecoderContext(), encoded)
             self.assertEqual(bytes, len(encoded))
             self.assertIsInstance(result, pureber.BERInteger)
@@ -191,10 +194,9 @@ class BERIntegerSanityCheck(unittest.TestCase):
             self.assertEqual(n, result)
 
 
-
-class ObjectThatCanStringify(object):
-    def __str__(self):
-        return "bar"
+class ObjectWithToWireMethod(object):
+    def toWire(self):
+        return b"bar"
 
 
 class TestBEROctetString(unittest.TestCase):
@@ -205,15 +207,15 @@ class TestBEROctetString(unittest.TestCase):
         ("", [0x04, 0]),
         ("foo", [0x04, 3]+l(b"foo")),
         (100 * "x", [0x04, 100]+l(100 * b"x")),
-        (ObjectThatCanStringify(), [0x04, 3]+l(b"bar")),
+        (ObjectWithToWireMethod(), [0x04, 3]+l(b"bar")),
         )
 
     def testToBEROctetStringKnownValues(self):
-        """str(BEROctetString(n)) should give known result with known input"""
+        """BEROctetString(n).toWire() should give known result with known input"""
         for st, encoded in self.knownValues:
             result = pureber.BEROctetString(st)
-            result = str(result)
-            result = list(map(ord, result))
+            result = result.toWire()
+            result = l(result)
             self.assertEqual(encoded, result)
 
     def testFromBEROctetStringKnownValues(self):
@@ -223,13 +225,13 @@ class TestBEROctetString(unittest.TestCase):
             result, bytes = pureber.berDecodeObject(pureber.BERDecoderContext(), m)
             self.assertEqual(bytes, len(m))
             self.assertIsInstance(result, pureber.BEROctetString)
-            result = str(result)
-            result = list(map(ord, result))
+            result = result.toWire()
+            result = l(result)
             self.assertEqual(encoded, result)
 
     def testPartialBEROctetStringEncodings(self):
         """BEROctetString(encoded="...") with too short input should throw BERExceptionInsufficientData"""
-        m=str(pureber.BEROctetString("x"))
+        m = pureber.BEROctetString("x").toWire()
         self.assertEqual(3, len(m))
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeObject, pureber.BERDecoderContext(), m[:2])
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeObject, pureber.BERDecoderContext(), m[:1])
@@ -238,20 +240,20 @@ class TestBEROctetString(unittest.TestCase):
     def testSanity(self):
         """BEROctetString(encoded=BEROctetString(n*'x')).value==n*'x' for some values of n"""
         for n in 0,1,2,3,4,5,6,100,126,127,128,129,1000,2000:
-            encoded = str(pureber.BEROctetString(n*'x'))
+            encoded = pureber.BEROctetString(n * b'x').toWire()
             result, bytes = pureber.berDecodeObject(pureber.BERDecoderContext(), encoded)
             self.assertEqual(bytes, len(encoded))
             self.assertIsInstance(result, pureber.BEROctetString)
             result = result.value
-            self.assertEqual(n * 'x', result)
+            self.assertEqual(n * b'x', result)
 
 
 class BERNullKnownValues(unittest.TestCase):
     def testToBERNullKnownValues(self):
-        """str(BERNull()) should give known result"""
+        """BERNull().toWire() should give known result"""
         result = pureber.BERNull()
-        result = str(result)
-        result = list(map(ord, result))
+        result = result.toWire()
+        result = l(result)
         self.assertEqual([0x05, 0x00], result)
 
     def testFromBERNullKnownValues(self):
@@ -265,7 +267,7 @@ class BERNullKnownValues(unittest.TestCase):
 
     def testPartialBERNullEncodings(self):
         """BERNull(encoded="...") with too short input should throw BERExceptionInsufficientData"""
-        m=str(pureber.BERNull())
+        m = pureber.BERNull().toWire()
         self.assertEqual(2, len(m))
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeObject, pureber.BERDecoderContext(), m[:1])
         self.assertEqual((None, 0), pureber.berDecodeObject(pureber.BERDecoderContext(), ''))
@@ -294,11 +296,11 @@ class BERBooleanKnownValues(unittest.TestCase):
         )
 
     def testToBERBooleanKnownValues(self):
-        """str(BERBoolean(n)) should give known result with known input"""
+        """BERBoolean(n).toWire() should give known result with known input"""
         for integer, encoded, dummy in self.knownValues:
             result = pureber.BERBoolean(integer)
-            result = str(result)
-            result = list(map(ord, result))
+            result = result.toWire()
+            result = l(result)
             self.assertEqual(encoded, result)
 
     def testFromBERBooleanKnownValues(self):
@@ -313,7 +315,7 @@ class BERBooleanKnownValues(unittest.TestCase):
 
     def testPartialBERBooleanEncodings(self):
         """BERBoolean(encoded="...") with too short input should throw BERExceptionInsufficientData"""
-        m=str(pureber.BERBoolean(42))
+        m = pureber.BERBoolean(42).toWire()
         self.assertEqual(3, len(m))
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeObject, pureber.BERDecoderContext(), m[:2])
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeObject, pureber.BERDecoderContext(), m[:1])
@@ -340,11 +342,11 @@ class BEREnumeratedKnownValues(unittest.TestCase):
         )
 
     def testToBEREnumeratedKnownValues(self):
-        """str(BEREnumerated(n)) should give known result with known input"""
+        """BEREnumerated(n).toWire() should give known result with known input"""
         for integer, encoded in self.knownValues:
             result = pureber.BEREnumerated(integer)
-            result = str(result)
-            result = list(map(ord, result))
+            result = result.toWire()
+            result = l(result)
             self.assertEqual(encoded, result)
 
     def testFromBEREnumeratedKnownValues(self):
@@ -359,7 +361,7 @@ class BEREnumeratedKnownValues(unittest.TestCase):
 
     def testPartialBEREnumeratedEncodings(self):
         """BEREnumerated(encoded="...") with too short input should throw BERExceptionInsufficientData"""
-        m=str(pureber.BEREnumerated(42))
+        m = pureber.BEREnumerated(42).toWire()
         self.assertEqual(3, len(m))
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeObject, pureber.BERDecoderContext(), m[:2])
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeObject, pureber.BERDecoderContext(), m[:1])
@@ -370,7 +372,7 @@ class BEREnumeratedSanityCheck(unittest.TestCase):
     def testSanity(self):
         """BEREnumerated(encoded=BEREnumerated(n)).value==n for -1000..1000"""
         for n in range(-1000, 1001, 10):
-            encoded = str(pureber.BEREnumerated(n))
+            encoded = pureber.BEREnumerated(n).toWire()
             result, bytes = pureber.berDecodeObject(pureber.BERDecoderContext(), encoded)
             self.assertEqual(bytes, len(encoded))
             self.assertIsInstance(result, pureber.BEREnumerated)
@@ -385,14 +387,14 @@ class TestBERSequence(unittest.TestCase):
 
     def testStringRepresentationEmpty(self):
         """
-        It can return the string representation for empty sequence which
+        It can return the byte string representation for empty sequence which
         is just the zero/null byte.
         """
         sut = pureber.BERSequence([])
 
-        result = str(sut)
+        result = sut.toWire()
 
-        self.assertEqual('0\x00', result)
+        self.assertEqual(b'0\x00', result)
 
     def testStringRepresentatinSmallInteger(self):
         """
@@ -401,9 +403,9 @@ class TestBERSequence(unittest.TestCase):
         """
         sut = pureber.BERSequence([pureber.BERInteger(2)])
 
-        result = str(sut)
+        result = sut.toWire()
 
-        self.assertEqual('0\x03\x02\x01\x02', result)
+        self.assertEqual(b'0\x03\x02\x01\x02', result)
 
     def testStringRepresentatinLargerInteger(self):
         """
@@ -412,9 +414,9 @@ class TestBERSequence(unittest.TestCase):
         """
         sut = pureber.BERSequence([pureber.BERInteger(128)])
 
-        result = str(sut)
+        result = sut.toWire()
 
-        self.assertEqual('0\x04\x02\x02\x00\x80', result)
+        self.assertEqual(b'0\x04\x02\x02\x00\x80', result)
 
     def testStringRepresentatinMultipleIntegers(self):
         """
@@ -423,9 +425,9 @@ class TestBERSequence(unittest.TestCase):
         sut = pureber.BERSequence([
             pureber.BERInteger(3), pureber.BERInteger(128)])
 
-        result = str(sut)
+        result = sut.toWire()
 
-        self.assertEqual('0\x07\x02\x01\x03\x02\x02\x00\x80', result)
+        self.assertEqual(b'0\x07\x02\x01\x03\x02\x02\x00\x80', result)
 
     def testDecodeValidInput(self):
         """
@@ -460,7 +462,7 @@ class TestBERSequence(unittest.TestCase):
         It raises BERExceptionInsufficientData when trying to decode from
         data which is not valid.
         """
-        m=str(pureber.BERSequence([pureber.BERInteger(2)]))
+        m = pureber.BERSequence([pureber.BERInteger(2)]).toWire()
         self.assertEqual(5, len(m))
 
         self.assertRaises(pureber.BERExceptionInsufficientData, pureber.berDecodeObject, pureber.BERDecoderContext(), m[:4])

--- a/ldaptor/test/test_pureldap.py
+++ b/ldaptor/test/test_pureldap.py
@@ -23,17 +23,17 @@ from ldaptor.protocols import pureldap, pureber
 
 
 def s(*l):
-    """Join all members of list to a string. Integer members are chr()ed"""
-    r=''
+    """Join all members of list to a byte string. Integer members are chr()ed"""
+    r = b''
     for e in l:
         if isinstance(e, int):
-            e = chr(e)
-        r = r + str(e)
+            e = six.int2byte(e)
+        r = r + e
     return r
 
 
 def l(s):
-    """Split a string to ord's of chars."""
+    """Split a byte string to ord's of chars."""
     return [six.byte2int([x]) for x in s]
 
 
@@ -58,15 +58,15 @@ class KnownValues(unittest.TestCase):
            },
          None,
          [0x66, 50]
-         + ([0x04, 0x1a] + l("cn=foo, dc=example, dc=com")
+         + ([0x04, 0x1a] + l(b"cn=foo, dc=example, dc=com")
             + [0x30, 20]
             + ([0x30, 18]
                + ([0x0a, 0x01, 0x00]
                   + [0x30, 13]
-                  + ([0x04, len("bar")] + l("bar")
+                  + ([0x04, len(b"bar")] + l(b"bar")
                      + [0x31, 0x06]
-                     + ([0x04, len("a")] + l("a")
-                        + [0x04, len("b")] + l("b"))))))
+                     + ([0x04, len(b"a")] + l(b"a")
+                        + [0x04, len(b"b")] + l(b"b"))))))
             ),
 
         (pureldap.LDAPModifyRequest,
@@ -84,12 +84,12 @@ class KnownValues(unittest.TestCase):
            },
          None,
          [0x66, 0x2c]
-         + ([0x04, 0x1a] + l("cn=foo, dc=example, dc=com")
+         + ([0x04, 0x1a] + l(b"cn=foo, dc=example, dc=com")
             + [0x30, 0x0e]
             + ([0x30, 0x0c]
                + ([0x0a, 0x01, 0x01]
                   + [0x30, 0x07]
-                  + ([0x04, 0x03] + l("bar")
+                  + ([0x04, 0x03] + l(b"bar")
                      + [0x31, 0x00]))))
         ),
 
@@ -100,8 +100,8 @@ class KnownValues(unittest.TestCase):
          pureldap.LDAPBERDecoderContext_Filter(fallback=pureber.BERDecoderContext()),
          [0xa2, 0x05]
          + [0x87]
-         + [len("foo")]
-         + l("foo")),
+         + [len(b"foo")]
+         + l(b"foo")),
 
         (pureldap.LDAPFilter_or,
          [],
@@ -116,11 +116,11 @@ class KnownValues(unittest.TestCase):
          pureldap.LDAPBERDecoderContext_Filter(fallback=pureber.BERDecoderContext()),
          [0xa1, 23]
          + [0xa3, 9]
-         + [0x04] + [len("cn")] + l("cn")
-         + [0x04] + [len("foo")] + l("foo")
+         + [0x04] + [len(b"cn")] + l(b"cn")
+         + [0x04] + [len(b"foo")] + l(b"foo")
          + [0xa3, 10]
-         + [0x04] + [len("uid")] + l("uid")
-         + [0x04] + [len("foo")] + l("foo"),
+         + [0x04] + [len(b"uid")] + l(b"uid")
+         + [0x04] + [len(b"foo")] + l(b"foo"),
          ),
 
         (pureldap.LDAPFilter_and,
@@ -136,11 +136,11 @@ class KnownValues(unittest.TestCase):
          pureldap.LDAPBERDecoderContext_Filter(fallback=pureber.BERDecoderContext()),
          [0xa0, 23]
          + [0xa3, 9]
-         + [0x04] + [len("cn")] + l("cn")
-         + [0x04] + [len("foo")] + l("foo")
+         + [0x04] + [len(b"cn")] + l(b"cn")
+         + [0x04] + [len(b"foo")] + l(b"foo")
          + [0xa3, 10]
-         + [0x04] + [len("uid")] + l("uid")
-         + [0x04] + [len("foo")] + l("foo"),
+         + [0x04] + [len(b"uid")] + l(b"uid")
+         + [0x04] + [len(b"foo")] + l(b"foo"),
          ),
 
         (pureldap.LDAPModifyDNRequest,
@@ -152,11 +152,11 @@ class KnownValues(unittest.TestCase):
          None,
          [0x6c, 0x26]
          + [0x04]
-         + [len("cn=foo,dc=example,dc=com")]
-         + l("cn=foo,dc=example,dc=com")
+         + [len(b"cn=foo,dc=example,dc=com")]
+         + l(b"cn=foo,dc=example,dc=com")
          + [0x04]
-         + [len("uid=bar")]
-         + l("uid=bar")
+         + [len(b"uid=bar")]
+         + l(b"uid=bar")
          + [0x01, 0x01, 0x00]),
 
         (pureldap.LDAPModifyDNRequest,
@@ -169,15 +169,15 @@ class KnownValues(unittest.TestCase):
          None,
          [0x6c, 69]
          + [0x04]
-         + [len("cn=aoue,dc=example,dc=com")]
-         + l("cn=aoue,dc=example,dc=com")
+         + [len(b"cn=aoue,dc=example,dc=com")]
+         + l(b"cn=aoue,dc=example,dc=com")
          + [0x04]
-         + [len("uid=aoue")]
-         + l("uid=aoue")
+         + [len(b"uid=aoue")]
+         + l(b"uid=aoue")
          + [0x01, 0x01, 0x00]
          + [0x80]
-         + [len("ou=People,dc=example,dc=com")]
-         + l("ou=People,dc=example,dc=com")),
+         + [len(b"ou=People,dc=example,dc=com")]
+         + l(b"ou=People,dc=example,dc=com")),
 
         (pureldap.LDAPSearchRequest,
          [],
@@ -186,8 +186,8 @@ class KnownValues(unittest.TestCase):
          None,
          [0x63, 57]
          + [0x04]
-         + [len('dc=yoja,dc=example,dc=com')]
-         + l('dc=yoja,dc=example,dc=com')
+         + [len(b'dc=yoja,dc=example,dc=com')]
+         + l(b'dc=yoja,dc=example,dc=com')
          # scope
          + [0x0a, 1, 2]
          # derefAliases
@@ -199,7 +199,7 @@ class KnownValues(unittest.TestCase):
          # typesOnly
          + [0x01, 1, 0]
          # filter
-         + [135, 11] + l('objectClass')
+         + [135, 11] + l(b'objectClass')
          # attributes
          + [48, 0]
          ),
@@ -221,12 +221,12 @@ class KnownValues(unittest.TestCase):
          + [0x0a, 0x01, 0x00]
          # matchedDN
          + [0x04]
-         + [len('')]
-         + l('')
+         + [len(b'')]
+         + l(b'')
          # errorMessage
          + [0x04]
-         + [len('')]
-         + l('')
+         + [len(b'')]
+         + l(b'')
          # referral, TODO
          + []
         ),
@@ -242,12 +242,12 @@ class KnownValues(unittest.TestCase):
          + [0x0a, 0x01, 0x00]
          # matchedDN
          + [0x04]
-         + [len('dc=foo,dc=example,dc=com')]
-         + l('dc=foo,dc=example,dc=com')
+         + [len(b'dc=foo,dc=example,dc=com')]
+         + l(b'dc=foo,dc=example,dc=com')
          # errorMessage
          + [0x04]
-         + [len('')]
-         + l('')
+         + [len(b'')]
+         + l(b'')
          # referral, TODO
          + []
         ),
@@ -264,12 +264,12 @@ class KnownValues(unittest.TestCase):
          + [0x0a, 0x01, 0x00]
          # matchedDN
          + [0x04]
-         + [len('dc=foo,dc=example,dc=com')]
-         + l('dc=foo,dc=example,dc=com')
+         + [len(b'dc=foo,dc=example,dc=com')]
+         + l(b'dc=foo,dc=example,dc=com')
          # errorMessage
          + [0x04]
-         + [len('the foobar was fubar')]
-         + l('the foobar was fubar',)
+         + [len(b'the foobar was fubar')]
+         + l(b'the foobar was fubar',)
          # referral, TODO
          + []
         ),
@@ -285,12 +285,12 @@ class KnownValues(unittest.TestCase):
          + [0x0a, 0x01, 0x00]
          # matchedDN
          + [0x04]
-         + [len('')]
-         + l('')
+         + [len(b'')]
+         + l(b'')
          # errorMessage
          + [0x04]
-         + [len('the foobar was fubar')]
-         + l('the foobar was fubar',)
+         + [len(b'the foobar was fubar')]
+         + l(b'the foobar was fubar',)
          # referral, TODO
          + []
         ),
@@ -308,7 +308,7 @@ class KnownValues(unittest.TestCase):
          # id
          + [0x02, 0x01, 42]
          # value
-         + l(str(pureldap.LDAPBindRequest()))
+         + l(pureldap.LDAPBindRequest().toWire())
          ),
 
         (pureldap.LDAPControl,
@@ -319,7 +319,7 @@ class KnownValues(unittest.TestCase):
          [0x30, 9]
          # controlType
          + [0x04, 7]
-         + l("1.2.3.4")
+         + l(b"1.2.3.4")
          ),
 
         (pureldap.LDAPControl,
@@ -331,7 +331,7 @@ class KnownValues(unittest.TestCase):
          [0x30, 12]
          # controlType
          + [0x04, 7]
-         + l("1.2.3.4")
+         + l(b"1.2.3.4")
          # criticality
          + [0x01, 1, 0xFF]
          ),
@@ -346,12 +346,12 @@ class KnownValues(unittest.TestCase):
          [0x30, 19]
          # controlType
          + [0x04, 7]
-         + l("1.2.3.4")
+         + l(b"1.2.3.4")
          # criticality
          + [0x01, 1, 0xFF]
          # controlValue
-         + [0x04, len("silly")]
-         + l("silly")
+         + [0x04, len(b"silly")]
+         + l(b"silly")
          ),
 
         (pureldap.LDAPMessage,
@@ -360,8 +360,8 @@ class KnownValues(unittest.TestCase):
           'value': pureldap.LDAPBindRequest(),
           'controls': [ ('1.2.3.4', None, None),
                         ('2.3.4.5', False),
-                        ('3.4.5.6', True, '\x00\x01\x02\xFF'),
-                        ('4.5.6.7', None, '\x00\x01\x02\xFF'),
+                        ('3.4.5.6', True, b'\x00\x01\x02\xFF'),
+                        ('4.5.6.7', None, b'\x00\x01\x02\xFF'),
                         ],
           },
          pureldap.LDAPBERDecoderContext_TopLevel(
@@ -372,19 +372,19 @@ class KnownValues(unittest.TestCase):
          # id
          + [0x02, 0x01, 42]
          # value
-         + l(str(pureldap.LDAPBindRequest()))
+         + l(pureldap.LDAPBindRequest().toWire())
          # controls
-         + l(str(pureldap.LDAPControls(value=[
+         + l(pureldap.LDAPControls(value=[
         pureldap.LDAPControl(controlType='1.2.3.4'),
         pureldap.LDAPControl(controlType='2.3.4.5',
                              criticality=False),
         pureldap.LDAPControl(controlType='3.4.5.6',
                              criticality=True,
-                             controlValue='\x00\x01\x02\xFF'),
+                             controlValue=b'\x00\x01\x02\xFF'),
         pureldap.LDAPControl(controlType='4.5.6.7',
                              criticality=None,
-                             controlValue='\x00\x01\x02\xFF'),
-        ]))),
+                             controlValue=b'\x00\x01\x02\xFF'),
+        ]).toWire()),
          ),
 
         (pureldap.LDAPFilter_equalityMatch,
@@ -397,8 +397,8 @@ class KnownValues(unittest.TestCase):
         inherit=pureldap.LDAPBERDecoderContext(fallback=pureber.BERDecoderContext())),
 
          [0xa3, 9]
-         + ([0x04, 2] + l('cn')
-            + [0x04, 3] + l('foo'))
+         + ([0x04, 2] + l(b'cn')
+            + [0x04, 3] + l(b'foo'))
          ),
 
         (pureldap.LDAPFilter_or,
@@ -417,18 +417,18 @@ class KnownValues(unittest.TestCase):
 
          [0xA1, 52]
          + ([0xa3, 9]
-            + ([0x04, 2] + l('cn')
-               + [0x04, 3] + l('foo'))
+            + ([0x04, 2] + l(b'cn')
+               + [0x04, 3] + l(b'foo'))
             + [0xa3, 10]
-            + ([0x04, 3] + l('uid')
-               + [0x04, 3] + l('foo'))
+            + ([0x04, 3] + l(b'uid')
+               + [0x04, 3] + l(b'foo'))
             + [0xa3, 11]
-               + ([0x04, 4] + l('mail')
-                  + [0x04, 3] + l('foo'))
+               + ([0x04, 4] + l(b'mail')
+                  + [0x04, 3] + l(b'foo'))
             + [0xa4, 14]
-            + ([0x04, 4] + l('mail')
+            + ([0x04, 4] + l(b'mail')
                + [0x30, 6]
-               + ([0x80, 4] + l('foo@'))))
+               + ([0x80, 4] + l(b'foo@'))))
          ),
 
         (pureldap.LDAPSearchRequest,
@@ -455,7 +455,7 @@ class KnownValues(unittest.TestCase):
         inherit=pureldap.LDAPBERDecoderContext(fallback=pureber.BERDecoderContext())),
 
          [0x63, 92]
-         + ([0x04, 17] + l('dc=example,dc=com')
+         + ([0x04, 17] + l(b'dc=example,dc=com')
             + [0x0a, 1, 0x02]
             + [0x0a, 1, 0x00]
             + [0x02, 1, 0x01]
@@ -463,18 +463,18 @@ class KnownValues(unittest.TestCase):
             + [0x01, 1, 0x00]
             + [0xA1, 52]
             + ([0xa3, 9]
-               + ([0x04, 2] + l('cn')
-                  + [0x04, 3] + l('foo'))
+               + ([0x04, 2] + l(b'cn')
+                  + [0x04, 3] + l(b'foo'))
                + [0xa3, 10]
-               + ([0x04, 3] + l('uid')
-                  + [0x04, 3] + l('foo'))
+               + ([0x04, 3] + l(b'uid')
+                  + [0x04, 3] + l(b'foo'))
                + [0xa3, 11]
-               + ([0x04, 4] + l('mail')
-                  + [0x04, 3] + l('foo'))
+               + ([0x04, 4] + l(b'mail')
+                  + [0x04, 3] + l(b'foo'))
                + [0xa4, 14]
-               + ([0x04, 4] + l('mail')
+               + ([0x04, 4] + l(b'mail')
                   + [0x30, 6]
-                  + ([0x80, 4] + l('foo@'))))
+                  + ([0x80, 4] + l(b'foo@'))))
             + [0x30, 2]
             + ([0x04, 0])
             )
@@ -512,7 +512,7 @@ class KnownValues(unittest.TestCase):
          + [0x02, 1, 1]
          # value
          + [0x63, 92]
-         + ([0x04, 17] + l('dc=example,dc=com')
+         + ([0x04, 17] + l(b'dc=example,dc=com')
             + [0x0a, 1, 0x02]
             + [0x0a, 1, 0x00]
             + [0x02, 1, 0x01]
@@ -520,18 +520,18 @@ class KnownValues(unittest.TestCase):
             + [0x01, 1, 0x00]
             + [0xA1, 52]
             + ([0xa3, 9]
-               + ([0x04, 2] + l('cn')
-                  + [0x04, 3] + l('foo'))
+               + ([0x04, 2] + l(b'cn')
+                  + [0x04, 3] + l(b'foo'))
                + [0xa3, 10]
-               + ([0x04, 3] + l('uid')
-                  + [0x04, 3] + l('foo'))
+               + ([0x04, 3] + l(b'uid')
+                  + [0x04, 3] + l(b'foo'))
                + [0xa3, 11]
-               + ([0x04, 4] + l('mail')
-                  + [0x04, 3] + l('foo'))
+               + ([0x04, 4] + l(b'mail')
+                  + [0x04, 3] + l(b'foo'))
                + [0xa4, 14]
-               + ([0x04, 4] + l('mail')
+               + ([0x04, 4] + l(b'mail')
                   + [0x30, 6]
-                  + ([0x80, 4] + l('foo@'))))
+                  + ([0x80, 4] + l(b'foo@'))))
             + [0x30, 2]
             + ([0x04, 0])
             )
@@ -545,11 +545,11 @@ class KnownValues(unittest.TestCase):
          None,
          [0x40|0x20|23, 1+1+8+1+1+3]
          + ([0x80|0]
-            + [len('42.42.42')]
-            + l('42.42.42'))
+            + [len(b'42.42.42')]
+            + l(b'42.42.42'))
          + ([0x80|1]
-            + [len('foo')]
-            + l('foo'))
+            + [len(b'foo')]
+            + l(b'foo'))
          ),
 
         (pureldap.LDAPExtendedRequest,
@@ -560,8 +560,8 @@ class KnownValues(unittest.TestCase):
          None,
          [0x40|0x20|23, 1+1+8]
          + ([0x80|0]
-            + [len('42.42.42')]
-            + l('42.42.42'))
+            + [len(b'42.42.42')]
+            + l(b'42.42.42'))
          ),
 
         (pureldap.LDAPExtendedResponse,
@@ -575,8 +575,8 @@ class KnownValues(unittest.TestCase):
          None,
          [0x40|0x20|24, 3+2+3+2+3,
           0x0a, 1, 49,
-          0x04, len('foo')] + l('foo') + [
-          0x04, len('bar')] + l('bar'),
+          0x04, len(b'foo')] + l(b'foo') + [
+          0x04, len(b'bar')] + l(b'bar'),
          ),
 
         (pureldap.LDAPExtendedResponse,
@@ -590,10 +590,10 @@ class KnownValues(unittest.TestCase):
          None,
          [0x40|0x20|24, 3+2+3+2+3+2+len('1.2.3.4.5.6.7.8.9')+2+3,
           0x0a, 1, 49,
-          0x04, len('foo')] + l('foo') + [
-          0x04, len('bar')] + l('bar') + [
-          0x8a, len('1.2.3.4.5.6.7.8.9')] + l('1.2.3.4.5.6.7.8.9') + [
-          0x8b, len('baz')] + l('baz'),
+          0x04, len(b'foo')] + l(b'foo') + [
+          0x04, len(b'bar')] + l(b'bar') + [
+          0x8a, len(b'1.2.3.4.5.6.7.8.9')] + l(b'1.2.3.4.5.6.7.8.9') + [
+          0x8b, len(b'baz')] + l(b'baz'),
          ),
 
         (pureldap.LDAPAbandonRequest,
@@ -610,16 +610,16 @@ class KnownValues(unittest.TestCase):
          pureldap.LDAPBERDecoderContext(
                 fallback=pureldap.LDAPBERDecoderContext(fallback=pureber.BERDecoderContext()),
                 inherit=pureldap.LDAPBERDecoderContext(fallback=pureber.BERDecoderContext())),
-         [ord(x) for x in str(pureldap.LDAPBindRequest(auth=('PLAIN', 'test'), sasl=True))]
+         l(pureldap.LDAPBindRequest(auth=('PLAIN', 'test'), sasl=True).toWire())
          )
         )
 
     def testToLDAP(self):
-        """str(LDAPClass(...)) should give known result with known input"""
+        """LDAPClass(...).toWire() should give known result with known input"""
         for klass, args, kwargs, decoder, encoded in self.knownValues:
             result = klass(*args, **kwargs)
-            result = str(result)
-            result = [ord(x) for x in result]
+            result = result.toWire()
+            result = l(result)
 
             message = (
                 "Class %s(*%r, **%r) doesn't encode properly: "
@@ -638,8 +638,7 @@ class KnownValues(unittest.TestCase):
             self.assertEqual(bytes, len(m))
 
             shouldBe = klass(*args, **kwargs)
-            #TODO shouldn't use str below
-            assert str(result)==str(shouldBe), \
+            assert result.toWire() == shouldBe.toWire(), \
                    "Class %s(*%s, **%s) doesn't decode properly: " \
                    "%s != %s" % (klass.__name__,
                                  repr(args), repr(kwargs),
@@ -697,9 +696,9 @@ class Substrings(unittest.TestCase):
             fallback=pureber.BERDecoderContext())
         filt = pureldap.LDAPFilter_substrings.fromBER(
             tag=pureldap.LDAPFilter_substrings.tag,
-            content=s(0x04, 4, 'mail',
+            content=s(0x04, 4, b'mail',
                       0x30, 6,
-                      0x80, 4, 'foo@'),
+                      0x80, 4, b'foo@'),
             berdecoder=decoder)
         # The confusion that used to occur here was because
         # filt.substrings was left as a BERSequence, which under the

--- a/ldaptor/testutil.py
+++ b/ldaptor/testutil.py
@@ -5,6 +5,7 @@ from twisted.python import failure
 from twisted.trial import unittest
 from twisted.test import proto_helpers
 from ldaptor import config
+from ldaptor.encoder import to_bytes
 
 
 def mustRaise(dummy):
@@ -127,8 +128,8 @@ class LDAPClientTestDriver:
             shouldBeSent,
             self.sent)
         assert self.sent == shouldBeSent, msg
-        sentStr = ''.join([str(x) for x in self.sent])
-        shouldBeSentStr = ''.join([str(x) for x in shouldBeSent])
+        sentStr = b''.join([to_bytes(x) for x in self.sent])
+        shouldBeSentStr = b''.join([to_bytes(x) for x in shouldBeSent])
         msg = '%s expected to send data %r but sent %r' % (
             self.__class__.__name__,
             shouldBeSentStr,

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ commands =
 
     test: coverage run --rcfile={toxinidir}/.coveragerc -m twisted.trial {posargs:ldaptor}
 
-    ported: trial ldaptor.test.test_attributeset ldaptor.test.test_autofill ldaptor.test.test_autofill_posix ldaptor.test.test_autofill_samba ldaptor.test.test_config ldaptor.test.test_connector ldaptor.test.test_delta ldaptor.test.test_dns ldaptor.test.test_entry ldaptor.test.test_fetchschema ldaptor.test.test_match ldaptor.test.test_schema ldaptor.test.test_usage ldaptor.test.test_ldapfilter ldaptor.test.test_smbpassword ldaptor.test.test_ldapsyntax ldaptor.test.test_pureber
+    ported: trial ldaptor.test.test_attributeset ldaptor.test.test_autofill ldaptor.test.test_autofill_posix ldaptor.test.test_autofill_samba ldaptor.test.test_config ldaptor.test.test_connector ldaptor.test.test_delta ldaptor.test.test_dns ldaptor.test.test_entry ldaptor.test.test_fetchschema ldaptor.test.test_match ldaptor.test.test_schema ldaptor.test.test_usage ldaptor.test.test_ldapfilter ldaptor.test.test_smbpassword ldaptor.test.test_ldapsyntax ldaptor.test.test_pureber ldaptor.test.test_pureldap
 
     ; Only run on local dev env.
     dev: coverage report --show-missing


### PR DESCRIPTION
Greetings!

This is a Python 3 compatibility fix for `ldaptor.protocols.pureber` and `ldaptor.protocols.pureldap` modules. As was advised `__str__` methods were switched to `toWire` ones and now they are returning bytes in both interpreter versions. I had to leave `LDAPMessage.__str__` method as an alias of `toWire` as it is used in higher-level classes, it should be removed when the transition to using `toWire` will be finished.

`test_pureber` and `test_pureldap` were accordingly updated. The latest one is passing in the Python 3 environment — updated tox.ini file to include it in py35-ported.

### Contributor Checklist:

* [x] I have updated the release notes at `docs/source/NEWS.rst` 
* [X] I have updated the automated tests.
* [X] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
