### PR TITLE
Python 3 compatability fix for inmemory and ldaperrors modules

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -20,7 +20,8 @@ Changes
 - Using modern classmethod decorator instead of old-style method call.
 - Usage of zope.interfaces was updated in preparation for python3 port.
 - ``toWire`` method is used to get bytes representation of ``ldaptor.protocols.pureber``,
-  ``ldaptor.protocols.pureldap``, ``ldaptor.protocols.distinguishedname`` and ``ldaptor.entry`` classes
+  ``ldaptor.protocols.pureldap``, ``ldaptor.protocols.ldap.distinguishedname``,
+  ``ldaptor.protocols.ldap.ldaperrors`` and ``ldaptor.entry`` classes
   instead of ``__str__`` which is deprecated now.
 - Code was updated to pass `python3 -m compileall` in preparation for py3 port.
 - Continuous test are executed only against latest related Twisted and latest

--- a/ldaptor/inmemory.py
+++ b/ldaptor/inmemory.py
@@ -78,7 +78,7 @@ class ReadOnlyInMemoryLDAPEntry(entry.EditableLDAPEntry,
     def _deleteChild(self, rdn):
         if not isinstance(rdn, distinguishedname.RelativeDistinguishedName):
             rdn = distinguishedname.RelativeDistinguishedName(stringValue=rdn)
-        rdn_str = str(rdn)
+        rdn_str = rdn.toWire()
         try:
             return self._children.pop(rdn_str)
         except KeyError:
@@ -103,8 +103,8 @@ class ReadOnlyInMemoryLDAPEntry(entry.EditableLDAPEntry,
 
     def _move2(self, newParent, newDN):
         if newParent is not None:
-            newParent._children[str(newDN.split()[0])] = self
-            del self._parent._children[str(self.dn.split()[0])]
+            newParent._children[newDN.split()[0].toWire()] = self
+            del self._parent._children[self.dn.split()[0].toWire()]
         # remove old RDN attributes
         for attr in self.dn.split()[0].split():
             self[attr.attributeType].remove(attr.value)

--- a/ldaptor/protocols/ldap/ldaperrors.py
+++ b/ldaptor/protocols/ldap/ldaperrors.py
@@ -14,6 +14,9 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 # make pyflakes not complain about undefined names
+
+from ldaptor._encoder import WireStrAlias, to_bytes
+
 reverse = None
 LDAPOther = None
 
@@ -35,13 +38,13 @@ class LDAPResult:
 
 class Success(LDAPResult):
     resultCode = 0
-    name = 'success'
+    name = b'success'
 
     def __init__(self, msg):
         pass
 
 
-class LDAPException(Exception, LDAPResult):
+class LDAPException(WireStrAlias, Exception, LDAPResult):
 
     def _get_message(self):
         return self.__message
@@ -55,14 +58,14 @@ class LDAPException(Exception, LDAPResult):
         Exception.__init__(self)
         self.message = message
 
-    def __str__(self):
+    def toWire(self):
         message = self.message
         if message:
-            return '%s: %s' % (self.name, message)
+            return b'%s: %s' % (self.name, to_bytes(message))
         elif self.name:
             return self.name
         else:
-            return 'Unknown LDAP error %r' % self
+            return b'Unknown LDAP error %r' % self
 
 
 class LDAPUnknownError(LDAPException):
@@ -74,10 +77,10 @@ class LDAPUnknownError(LDAPException):
         self.code = resultCode
         LDAPException.__init__(self, message)
 
-    def __str__(self):
-        codeName = 'unknownError(%d)' % self.code
+    def toWire(self):
+        codeName = b'unknownError(%d)' % self.code
         if self.message:
-            return '%s: %s' % (codeName, self.message)
+            return b'%s: %s' % (codeName, to_bytes(self.message))
         else:
             return codeName
 
@@ -95,7 +98,7 @@ def init(**errors):
                 (LDAPException,),
                 {
                     'resultCode': value,
-                    'name': name,
+                    'name': to_bytes(name),
                     },
                 )
             globals()[classname] = klass

--- a/ldaptor/test/test_inmemory.py
+++ b/ldaptor/test/test_inmemory.py
@@ -473,8 +473,8 @@ cn: foo
         def eb(fail):
             fail.trap(ldaperrors.LDAPNoSuchObject)
             self.failUnlessEqual(
-                str(fail.value),
-                'noSuchObject: ou=nonexisting,dc=example,dc=com')
+                fail.value.toWire(),
+                b'noSuchObject: ou=nonexisting,dc=example,dc=com')
         d.addCallbacks(testutil.mustRaise, eb)
         return d
 

--- a/ldaptor/test/test_ldaperrors.py
+++ b/ldaptor/test/test_ldaperrors.py
@@ -1,0 +1,73 @@
+"""
+    Test cases for ldaptor.protocols.ldap.ldaperrors module.
+"""
+
+from twisted.trial import unittest
+
+from ldaptor.protocols.ldap import distinguishedname
+from ldaptor.protocols.ldap import ldaperrors
+
+
+class UnnamedException(ldaperrors.LDAPException):
+    """LDAP exception with undefined name"""
+
+
+class GetTests(unittest.TestCase):
+    """Getting LDAP exception implementation by error code"""
+
+    def test_get_success(self):
+        """Getting OK message"""
+        success = ldaperrors.get(0, 'Some message')
+        self.assertEqual(success.__class__, ldaperrors.Success)
+        self.assertEqual(success.resultCode, 0)
+        self.assertEqual(success.name, b'success')
+
+    def test_get_existing_exception(self):
+        """Getting existing LDAPException subclass"""
+        exception = ldaperrors.get(49, 'Error message')
+        self.assertEqual(exception.__class__, ldaperrors.LDAPInvalidCredentials)
+        self.assertEqual(exception.resultCode, 49)
+        self.assertEqual(exception.name, b'invalidCredentials')
+        self.assertEqual(exception.message, 'Error message')
+
+    def test_get_nonexisting_exception(self):
+        """Getting non-existing LDAP error"""
+        exception = ldaperrors.get(55, 'Error message')
+        self.assertEqual(exception.__class__, ldaperrors.LDAPUnknownError)
+        self.assertEqual(exception.code, 55)
+        self.assertEqual(exception.message, 'Error message')
+
+
+class LDAPExceptionTests(unittest.TestCase):
+    """Getting bytes representations of LDAP exceptions"""
+
+    def test_exception_with_dn(self):
+        """Exception with a distinguished name"""
+        dn = distinguishedname.DistinguishedName(stringValue='dc=example,dc=org')
+        exception = ldaperrors.LDAPNoSuchObject(dn)
+        self.assertEqual(exception.toWire(), b'noSuchObject: dc=example,dc=org')
+
+    def test_exception_with_message(self):
+        """Exception with a text message"""
+        exception = ldaperrors.LDAPProtocolError('Error message')
+        self.assertEqual(exception.toWire(), b'protocolError: Error message')
+
+    def test_empty_exception(self):
+        """Exception with no message"""
+        exception = ldaperrors.LDAPCompareFalse()
+        self.assertEqual(exception.toWire(), b'compareFalse')
+
+    def test_unnamed_exception(self):
+        """Exception with no name"""
+        exception = UnnamedException()
+        self.assertEqual(exception.toWire(), b'Unknown LDAP error UnnamedException()')
+
+    def test_unknown_exception_with_message(self):
+        """Unknown exception with a text message"""
+        exception = ldaperrors.LDAPUnknownError(56, 'Error message')
+        self.assertEqual(exception.toWire(), b'unknownError(56): Error message')
+
+    def test_unknown_empty_exception(self):
+        """Unknown exception with no message"""
+        exception = ldaperrors.LDAPUnknownError(57)
+        self.assertEqual(exception.toWire(), b'unknownError(57)')

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ commands =
 
     test: coverage run --rcfile={toxinidir}/.coveragerc -m twisted.trial {posargs:ldaptor}
 
-    ported: trial ldaptor.test.test_attributeset ldaptor.test.test_autofill ldaptor.test.test_autofill_posix ldaptor.test.test_autofill_samba ldaptor.test.test_config ldaptor.test.test_connector ldaptor.test.test_delta ldaptor.test.test_distinguishedname ldaptor.test.test_dns ldaptor.test.test_entry ldaptor.test.test_fetchschema ldaptor.test.test_match ldaptor.test.test_schema ldaptor.test.test_usage ldaptor.test.test_ldapfilter ldaptor.test.test_smbpassword ldaptor.test.test_ldapsyntax ldaptor.test.test_pureber ldaptor.test.test_pureldap ldaptor.test.test_encoder ldaptor.test.test_ldif
+    ported: trial ldaptor.test.test_attributeset ldaptor.test.test_autofill ldaptor.test.test_autofill_posix ldaptor.test.test_autofill_samba ldaptor.test.test_config ldaptor.test.test_connector ldaptor.test.test_delta ldaptor.test.test_distinguishedname ldaptor.test.test_dns ldaptor.test.test_entry ldaptor.test.test_fetchschema ldaptor.test.test_match ldaptor.test.test_schema ldaptor.test.test_usage ldaptor.test.test_ldapfilter ldaptor.test.test_smbpassword ldaptor.test.test_ldapsyntax ldaptor.test.test_pureber ldaptor.test.test_pureldap ldaptor.test.test_encoder ldaptor.test.test_ldif ldaptor.test.test_ldaperrors
 
     ; Only run on local dev env.
     dev: coverage report --show-missing

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ commands =
 
     test: coverage run --rcfile={toxinidir}/.coveragerc -m twisted.trial {posargs:ldaptor}
 
-    ported: trial ldaptor.test.test_attributeset ldaptor.test.test_autofill ldaptor.test.test_autofill_posix ldaptor.test.test_autofill_samba ldaptor.test.test_config ldaptor.test.test_connector ldaptor.test.test_delta ldaptor.test.test_distinguishedname ldaptor.test.test_dns ldaptor.test.test_entry ldaptor.test.test_fetchschema ldaptor.test.test_match ldaptor.test.test_schema ldaptor.test.test_usage ldaptor.test.test_ldapfilter ldaptor.test.test_smbpassword ldaptor.test.test_ldapsyntax ldaptor.test.test_pureber ldaptor.test.test_pureldap ldaptor.test.test_encoder ldaptor.test.test_ldif ldaptor.test.test_ldaperrors
+    ported: trial ldaptor.test.test_attributeset ldaptor.test.test_autofill ldaptor.test.test_autofill_posix ldaptor.test.test_autofill_samba ldaptor.test.test_config ldaptor.test.test_connector ldaptor.test.test_delta ldaptor.test.test_distinguishedname ldaptor.test.test_dns ldaptor.test.test_entry ldaptor.test.test_fetchschema ldaptor.test.test_match ldaptor.test.test_schema ldaptor.test.test_usage ldaptor.test.test_ldapfilter ldaptor.test.test_smbpassword ldaptor.test.test_ldapsyntax ldaptor.test.test_pureber ldaptor.test.test_pureldap ldaptor.test.test_encoder ldaptor.test.test_ldif ldaptor.test.test_ldaperrors ldaptor.test.test_inmemory
 
     ; Only run on local dev env.
     dev: coverage report --show-missing


### PR DESCRIPTION
Greetings!

Here are minor improvements for `inmemory` module and its tests: they pass now for the both Python versions. In order to achieve this I had to switch `ldaperrors` module to using `toWire` method instead of `__str__` for getting errors' bytes representations and implement tests for it.

### Contributor Checklist:

* [x] I have updated the release notes at `docs/source/NEWS.rst` 
* [x] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
