### PR TITLE
Porting LDAPClient to Python 3

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -21,7 +21,7 @@ Changes
 - Usage of zope.interfaces was updated in preparation for python3 port.
 - ``toWire`` method is used to get bytes representation of ``ldaptor.protocols.pureber``,
   ``ldaptor.protocols.pureldap``, ``ldaptor.protocols.ldap.distinguishedname``,
-  ``ldaptor.protocols.ldap.ldaperrors`` and ``ldaptor.entry`` classes
+  ``ldaptor.protocols.ldap.ldaperrors``, ``ldaptor.protocols.ldap.ldapclient`` and ``ldaptor.entry`` classes
   instead of ``__str__`` which is deprecated now.
 - Code was updated to pass `python3 -m compileall` in preparation for py3 port.
 - Continuous test are executed only against latest related Twisted and latest

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ commands =
 
     test: coverage run --rcfile={toxinidir}/.coveragerc -m twisted.trial {posargs:ldaptor}
 
-    ported: trial ldaptor.test.test_attributeset ldaptor.test.test_autofill ldaptor.test.test_autofill_posix ldaptor.test.test_autofill_samba ldaptor.test.test_config ldaptor.test.test_connector ldaptor.test.test_delta ldaptor.test.test_distinguishedname ldaptor.test.test_dns ldaptor.test.test_entry ldaptor.test.test_fetchschema ldaptor.test.test_match ldaptor.test.test_schema ldaptor.test.test_usage ldaptor.test.test_ldapfilter ldaptor.test.test_smbpassword ldaptor.test.test_ldapsyntax ldaptor.test.test_pureber ldaptor.test.test_pureldap ldaptor.test.test_encoder ldaptor.test.test_ldif ldaptor.test.test_ldaperrors ldaptor.test.test_inmemory
+    ported: trial ldaptor.test.test_attributeset ldaptor.test.test_autofill ldaptor.test.test_autofill_posix ldaptor.test.test_autofill_samba ldaptor.test.test_config ldaptor.test.test_connector ldaptor.test.test_delta ldaptor.test.test_distinguishedname ldaptor.test.test_dns ldaptor.test.test_entry ldaptor.test.test_fetchschema ldaptor.test.test_match ldaptor.test.test_schema ldaptor.test.test_usage ldaptor.test.test_ldapfilter ldaptor.test.test_smbpassword ldaptor.test.test_ldapsyntax ldaptor.test.test_pureber ldaptor.test.test_pureldap ldaptor.test.test_encoder ldaptor.test.test_ldif ldaptor.test.test_ldaperrors ldaptor.test.test_inmemory ldaptor.test.test_ldapclient
 
     ; Only run on local dev env.
     dev: coverage report --show-missing


### PR DESCRIPTION
Hi!

LDAPClient was modified to work with the both Python version. The tests are passed in the Python 2.7 and Python 3.5 environment.

### Contributor Checklist:

* [x] I have updated the release notes at `docs/source/NEWS.rst` 
* [x] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
