### PR TITLE
Python 3 support for LDAPServer

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -21,7 +21,8 @@ Changes
 - Usage of zope.interfaces was updated in preparation for python3 port.
 - ``toWire`` method is used to get bytes representation of ``ldaptor.protocols.pureber``,
   ``ldaptor.protocols.pureldap``, ``ldaptor.protocols.ldap.distinguishedname``,
-  ``ldaptor.protocols.ldap.ldaperrors``, ``ldaptor.protocols.ldap.ldapclient`` and ``ldaptor.entry`` classes
+  ``ldaptor.protocols.ldap.ldaperrors``, ``ldaptor.protocols.ldap.ldapclient``,
+  ``ldaptor.protocols.ldap.ldapserver`` and ``ldaptor.entry`` classes
   instead of ``__str__`` which is deprecated now.
 - Code was updated to pass `python3 -m compileall` in preparation for py3 port.
 - Continuous test are executed only against latest related Twisted and latest

--- a/ldaptor/_encoder.py
+++ b/ldaptor/_encoder.py
@@ -34,6 +34,19 @@ def to_unicode(value):
     return value
 
 
+def get_strings(value):
+    """
+    Getting tuple of available string values
+    (byte string and unicode string) for
+    given value
+    """
+    if isinstance(value, six.text_type):
+        return value, value.encode('utf-8')
+    if isinstance(value, six.binary_type):
+        return value, value.decode('utf-8')
+    return value,
+
+
 class WireStrAlias(object):
     """
     A helper base or mixin class which adds __str__ method

--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -1390,7 +1390,7 @@ class LDAPBERDecoderContext_LDAPPasswordModifyRequest(BERDecoderContext):
 
 
 class LDAPPasswordModifyRequest(LDAPExtendedRequest):
-    oid = '1.3.6.1.4.1.4203.1.11.1'
+    oid = b'1.3.6.1.4.1.4203.1.11.1'
 
     def __init__(self, requestName=None,
                  userIdentity=None, oldPasswd=None, newPasswd=None,

--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -858,7 +858,7 @@ class LDAPSearchResultEntry(LDAPProtocolResponse, BERSequence):
         objectName = l[0].value
         attributes = []
         for attr, li in l[1].data:
-            attributes.append((attr.value, map(lambda x: x.value, li)))
+            attributes.append((attr.value, [x.value for x in li]))
         r = klass(objectName=objectName,
                   attributes=attributes,
                   tag=tag)
@@ -878,7 +878,7 @@ class LDAPSearchResultEntry(LDAPProtocolResponse, BERSequence):
             BERSequence([
                 BERSequence([
                     BEROctetString(attr_li[0]),
-                    BERSet(list(map(BEROctetString, attr_li[1])))])
+                    BERSet([BEROctetString(x) for x in attr_li[1]])])
                 for attr_li in self.attributes
                 ]),
         ], tag=self.tag).toWire()

--- a/ldaptor/test/test_entry.py
+++ b/ldaptor/test/test_entry.py
@@ -106,6 +106,19 @@ class TestBaseLDAPEntry(unittest.TestCase):
 
         self.assertTrue(failure.check(LDAPInvalidCredentials))
 
+    def testRepr(self):
+        """
+        Getting string representation of an entry
+        """
+        sut = entry.BaseLDAPEntry(
+            dn='dc=foo',
+            attributes={
+                'foo': ['bar'],
+                'bar': ['foo'],
+            }
+        )
+        self.assertEqual(repr(sut), "BaseLDAPEntry('dc=foo', {'bar': ['foo'], 'foo': ['bar']})")
+
 
 
 class TestDiffEntry(unittest.TestCase):

--- a/ldaptor/test/test_server.py
+++ b/ldaptor/test/test_server.py
@@ -40,8 +40,8 @@ class LDAPServerTest(unittest.TestCase):
         self.stuff = self.root.addChild(
             rdn='ou=stuff',
             attributes={
-                'objectClass': ['a', 'b'],
-                'ou': ['stuff'],
+                b'objectClass': [b'a', b'b'],
+                b'ou': [b'stuff'],
             })
         self.thingie = self.stuff.addChild(
             rdn='cn=thingie',
@@ -112,138 +112,123 @@ class LDAPServerTest(unittest.TestCase):
             buffer = buffer[bytes:]
             if not o:
                 break
-            value.append(str(o))
+            value.append(o.toWire())
         return value
 
     def test_bind(self):
         self.server.dataReceived(
-            str(pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=4)))
+            pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=4).toWire())
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPBindResponse(resultCode=0),
-                    id=4)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPBindResponse(resultCode=0),
+                id=4).toWire())
 
     def test_bind_success(self):
         self.thingie['userPassword'] = ['{SSHA}yVLLj62rFf3kDAbzwEU0zYAVvbWrze8=']  # "secret"
         self.server.dataReceived(
-            str(
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindRequest(
                         dn='cn=thingie,ou=stuff,dc=example,dc=com',
                         auth=b'secret'),
-                    id=4)))
+                    id=4).toWire())
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPBindResponse(
-                        resultCode=0,
-                        matchedDN='cn=thingie,ou=stuff,dc=example,dc=com'),
-                    id=4)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPBindResponse(
+                    resultCode=0,
+                    matchedDN='cn=thingie,ou=stuff,dc=example,dc=com'),
+                id=4).toWire())
 
     def test_bind_invalidCredentials_badPassword(self):
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPBindRequest(
-                        dn='cn=thingie,ou=stuff,dc=example,dc=com',
-                        auth=b'invalid'),
-                    id=734)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPBindRequest(
+                    dn='cn=thingie,ou=stuff,dc=example,dc=com',
+                    auth=b'invalid'),
+                id=734).toWire())
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPBindResponse(
-                        resultCode=ldaperrors.LDAPInvalidCredentials.resultCode),
-                    id=734)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPBindResponse(
+                    resultCode=ldaperrors.LDAPInvalidCredentials.resultCode),
+                id=734).toWire())
 
     def test_bind_invalidCredentials_nonExisting(self):
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPBindRequest(
-                        dn='cn=non-existing,dc=example,dc=com',
-                        auth=b'invalid'),
-                    id=78)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPBindRequest(
+                    dn='cn=non-existing,dc=example,dc=com',
+                    auth=b'invalid'),
+                id=78).toWire())
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPBindResponse(
-                        resultCode=ldaperrors.LDAPInvalidCredentials.resultCode),
-                    id=78)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPBindResponse(
+                    resultCode=ldaperrors.LDAPInvalidCredentials.resultCode),
+                id=78).toWire())
 
     def test_bind_badVersion_1_anonymous(self):
         self.server.dataReceived(
-            str(
                 pureldap.LDAPMessage(
                     pureldap.LDAPBindRequest(version=1),
-                    id=32)))
+                    id=32).toWire())
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPBindResponse(
-                        resultCode=ldaperrors.LDAPProtocolError.resultCode,
-                        errorMessage='Version 1 not supported'),
-                    id=32)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPBindResponse(
+                    resultCode=ldaperrors.LDAPProtocolError.resultCode,
+                    errorMessage='Version 1 not supported'),
+                id=32).toWire())
 
     def test_bind_badVersion_2_anonymous(self):
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPBindRequest(version=2),
-                    id=32)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPBindRequest(version=2),
+                id=32).toWire())
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPBindResponse(
-                        resultCode=ldaperrors.LDAPProtocolError.resultCode,
-                        errorMessage='Version 2 not supported'),
-                    id=32)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPBindResponse(
+                    resultCode=ldaperrors.LDAPProtocolError.resultCode,
+                    errorMessage='Version 2 not supported'),
+                id=32).toWire())
 
     def test_bind_badVersion_4_anonymous(self):
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPBindRequest(version=4),
-                    id=32)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPBindRequest(version=4),
+                id=32).toWire())
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPBindResponse(
-                        resultCode=ldaperrors.LDAPProtocolError.resultCode,
-                        errorMessage='Version 4 not supported'),
-                    id=32)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPBindResponse(
+                    resultCode=ldaperrors.LDAPProtocolError.resultCode,
+                    errorMessage='Version 4 not supported'),
+                id=32).toWire())
 
     def test_bind_badVersion_4_nonExisting(self):
         # TODO make a test just like this one that would pass authentication
         # if version was correct, to ensure we don't leak that info either.
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPBindRequest(
-                        version=4,
-                        dn='cn=non-existing,dc=example,dc=com',
-                        auth=b'invalid'),
-                    id=11)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPBindRequest(
+                    version=4,
+                    dn='cn=non-existing,dc=example,dc=com',
+                    auth=b'invalid'),
+                id=11).toWire())
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPBindResponse(
-                        resultCode=ldaperrors.LDAPProtocolError.resultCode,
-                        errorMessage='Version 4 not supported'),
-                    id=11)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPBindResponse(
+                    resultCode=ldaperrors.LDAPProtocolError.resultCode,
+                    errorMessage='Version 4 not supported'),
+                id=11).toWire())
 
     def test_unbind(self):
         self.server.dataReceived(
-            str(pureldap.LDAPMessage(pureldap.LDAPUnbindRequest(), id=7)))
-        self.assertEqual(self.server.transport.value(), '')
+            pureldap.LDAPMessage(pureldap.LDAPUnbindRequest(), id=7).toWire())
+        self.assertEqual(self.server.transport.value(), b'')
 
     def test_compare_outOfTree(self):
         dn = 'dc=invalid'
@@ -252,18 +237,16 @@ class LDAPServerTest(unittest.TestCase):
         ava = pureldap.LDAPAttributeValueAssertion(attribute_desc, attribute_value)
 
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPCompareRequest(entry=dn, ava=ava),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPCompareRequest(entry=dn, ava=ava),
+                id=2).toWire())
 
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPCompareResponse(
-                        resultCode=ldaperrors.LDAPNoSuchObject.resultCode),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPCompareResponse(
+                    resultCode=ldaperrors.LDAPNoSuchObject.resultCode),
+                id=2).toWire())
 
     def test_compare_inGroup(self):
         dn = 'cn=unix,ou=Groups,dc=example,dc=com'
@@ -272,18 +255,16 @@ class LDAPServerTest(unittest.TestCase):
         ava = pureldap.LDAPAttributeValueAssertion(attribute_desc, attribute_value)
 
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPCompareRequest(entry=dn, ava=ava),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPCompareRequest(entry=dn, ava=ava),
+                id=2).toWire())
 
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPCompareResponse(
-                        resultCode=ldaperrors.LDAPCompareTrue.resultCode),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPCompareResponse(
+                    resultCode=ldaperrors.LDAPCompareTrue.resultCode),
+                id=2).toWire())
 
     def test_compare_notInGroup(self):
         dn = 'cn=unix,ou=Groups,dc=example,dc=com'
@@ -292,236 +273,212 @@ class LDAPServerTest(unittest.TestCase):
         ava = pureldap.LDAPAttributeValueAssertion(attribute_desc, attribute_value)
 
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPCompareRequest(entry=dn, ava=ava),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPCompareRequest(entry=dn, ava=ava),
+                id=2).toWire())
 
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPCompareResponse(
-                        resultCode=ldaperrors.LDAPCompareFalse.resultCode),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPCompareResponse(
+                    resultCode=ldaperrors.LDAPCompareFalse.resultCode),
+                id=2).toWire())
 
     def test_search_outOfTree(self):
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchRequest(
-                        baseObject='dc=invalid'),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPSearchRequest(
+                    baseObject='dc=invalid'),
+                id=2).toWire())
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchResultDone(
-                        resultCode=ldaperrors.LDAPNoSuchObject.resultCode),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPSearchResultDone(
+                    resultCode=ldaperrors.LDAPNoSuchObject.resultCode),
+                id=2).toWire())
 
     def test_search_matchAll_oneResult(self):
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchRequest(
-                        baseObject='cn=thingie,ou=stuff,dc=example,dc=com'),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPSearchRequest(
+                    baseObject='cn=thingie,ou=stuff,dc=example,dc=com'),
+                id=2).toWire())
         six.assertCountEqual(self,
             self._makeResultList(self.server.transport.value()),
-            [str(
+            [
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='cn=thingie,ou=stuff,dc=example,dc=com',
                         attributes=[
                             ('objectClass', ['a', 'b']),
                             ('cn', ['thingie'])]),
-                    id=2)
-            ), str(
+                    id=2).toWire(),
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultDone(resultCode=0),
-                    id=2))])
+                    id=2).toWire()])
 
     def test_search_matchAll_oneResult_filtered(self):
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchRequest(
-                        baseObject='cn=thingie,ou=stuff,dc=example,dc=com',
-                        attributes=['cn']),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPSearchRequest(
+                    baseObject='cn=thingie,ou=stuff,dc=example,dc=com',
+                    attributes=['cn']),
+                id=2).toWire())
         six.assertCountEqual(self,
             self._makeResultList(self.server.transport.value()),
-            [str(
+            [
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='cn=thingie,ou=stuff,dc=example,dc=com',
                         attributes=[
                             ('cn', ['thingie'])]),
-                    id=2)
-            ), str(
+                    id=2).toWire(),
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultDone(resultCode=0),
-                    id=2))])
+                    id=2).toWire()])
 
     def test_search_matchAll_oneResult_filteredNoAttribsRemaining(self):
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchRequest(
-                        baseObject='cn=thingie,ou=stuff,dc=example,dc=com',
-                        attributes=['xyzzy']),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPSearchRequest(
+                    baseObject='cn=thingie,ou=stuff,dc=example,dc=com',
+                    attributes=['xyzzy']),
+                id=2).toWire())
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchResultDone(resultCode=0),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPSearchResultDone(resultCode=0),
+                id=2).toWire())
 
     def test_search_matchAll_manyResults(self):
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchRequest(
-                        baseObject='ou=stuff,dc=example,dc=com'), id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPSearchRequest(
+                    baseObject='ou=stuff,dc=example,dc=com'), id=2).toWire())
 
         six.assertCountEqual(self,
-            [str(
+            [
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='ou=stuff,dc=example,dc=com',
                         attributes=[
                             ('objectClass', ['a', 'b']),
                             ('ou', ['stuff'])]),
-                    id=2)
-            ), str(
+                    id=2).toWire(),
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='cn=another,ou=stuff,dc=example,dc=com',
                         attributes=[
                             ('objectClass', ['a', 'b']),
                             ('cn', ['another'])]),
-                    id=2)
-            ), str(
+                    id=2).toWire(),
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='cn=thingie,ou=stuff,dc=example,dc=com',
                         attributes=[
                             ('objectClass', ['a', 'b']),
                             ('cn', ['thingie'])]),
-                    id=2)
-            ), str(
+                    id=2).toWire(),
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultDone(resultCode=0),
-                    id=2))],
+                    id=2).toWire()],
             self._makeResultList(self.server.transport.value()))
 
     def test_search_scope_oneLevel(self):
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchRequest(
-                        baseObject='ou=stuff,dc=example,dc=com',
-                        scope=pureldap.LDAP_SCOPE_singleLevel),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPSearchRequest(
+                    baseObject='ou=stuff,dc=example,dc=com',
+                    scope=pureldap.LDAP_SCOPE_singleLevel),
+                id=2).toWire())
         six.assertCountEqual(self,
             self._makeResultList(self.server.transport.value()),
-            [str(
+            [
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='cn=thingie,ou=stuff,dc=example,dc=com',
                         attributes=[
                             ('objectClass', ['a', 'b']),
                             ('cn', ['thingie'])]),
-                    id=2)
-            ), str(
+                    id=2).toWire(),
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='cn=another,ou=stuff,dc=example,dc=com',
                         attributes=[
                             ('objectClass', ['a', 'b']),
                             ('cn', ['another'])]),
-                    id=2)
-            ), str(
+                    id=2).toWire(),
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultDone(resultCode=0),
-                    id=2))])
+                    id=2).toWire()])
 
     def test_search_scope_wholeSubtree(self):
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchRequest(
-                        baseObject='ou=stuff,dc=example,dc=com',
-                        scope=pureldap.LDAP_SCOPE_wholeSubtree),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPSearchRequest(
+                    baseObject='ou=stuff,dc=example,dc=com',
+                    scope=pureldap.LDAP_SCOPE_wholeSubtree),
+                id=2).toWire())
         six.assertCountEqual(self,
             self._makeResultList(self.server.transport.value()),
-            [str(
+            [
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='ou=stuff,dc=example,dc=com',
                         attributes=[
                             ('objectClass', ['a', 'b']),
                             ('ou', ['stuff'])]),
-                    id=2)
-            ), str(
+                    id=2).toWire(),
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='cn=another,ou=stuff,dc=example,dc=com',
                         attributes=[
                             ('objectClass', ['a', 'b']),
                             ('cn', ['another'])]),
-                    id=2)
-            ), str(
+                    id=2).toWire(),
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='cn=thingie,ou=stuff,dc=example,dc=com',
                         attributes=[
                             ('objectClass', ['a', 'b']),
                             ('cn', ['thingie'])]),
-                    id=2)
-            ), str(
+                    id=2).toWire(),
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultDone(resultCode=0),
-                    id=2))])
+                    id=2).toWire()])
 
     def test_search_scope_baseObject(self):
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchRequest(
-                        baseObject='ou=stuff,dc=example,dc=com',
-                        scope=pureldap.LDAP_SCOPE_baseObject),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPSearchRequest(
+                    baseObject='ou=stuff,dc=example,dc=com',
+                    scope=pureldap.LDAP_SCOPE_baseObject),
+                id=2).toWire())
         six.assertCountEqual(self,
             self._makeResultList(self.server.transport.value()),
-            [str(
+            [
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='ou=stuff,dc=example,dc=com',
                         attributes=[
                             ('objectClass', ['a', 'b']),
                             ('ou', ['stuff'])]),
-                    id=2)
-            ), str(
+                    id=2).toWire(),
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultDone(resultCode=0),
-                    id=2))])
+                    id=2).toWire()])
 
     def test_rootDSE(self):
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchRequest(
-                        baseObject='',
-                        scope=pureldap.LDAP_SCOPE_baseObject,
-                        filter=pureldap.LDAPFilter_present('objectClass')),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPSearchRequest(
+                    baseObject='',
+                    scope=pureldap.LDAP_SCOPE_baseObject,
+                    filter=pureldap.LDAPFilter_present('objectClass')),
+                id=2).toWire())
         six.assertCountEqual(self,
             self._makeResultList(self.server.transport.value()),
-            [str(
+            [
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultEntry(
                         objectName='',
@@ -530,25 +487,22 @@ class LDAPServerTest(unittest.TestCase):
                             ('namingContexts', ['dc=example,dc=com']),
                             ('supportedExtension',
                                 [pureldap.LDAPPasswordModifyRequest.oid])]),
-                    id=2)
-            ), str(
+                    id=2).toWire(),
                 pureldap.LDAPMessage(
                     pureldap.LDAPSearchResultDone(
                         resultCode=ldaperrors.Success.resultCode),
-                    id=2))])
+                    id=2).toWire()])
 
     def test_delete(self):
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPDelRequest(str(self.thingie.dn)),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPDelRequest(self.thingie.dn),
+                id=2).toWire())
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPDelResponse(resultCode=0),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPDelResponse(resultCode=0),
+                id=2).toWire())
         d = self.stuff.children()
         d.addCallback(lambda actual: six.assertCountEqual(
             self, actual, [self.another]))
@@ -557,27 +511,25 @@ class LDAPServerTest(unittest.TestCase):
     def test_add_success(self):
         dn = 'cn=new,ou=stuff,dc=example,dc=com'
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPAddRequest(
-                        entry=dn,
-                        attributes=[
-                            (
-                                pureldap.LDAPAttributeDescription("objectClass"),
-                                pureber.BERSet(
-                                    value=[
-                                        pureldap.LDAPAttributeValue('something')
-                                    ])
-                            )
-                        ]),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPAddRequest(
+                    entry=dn,
+                    attributes=[
+                        (
+                            pureldap.LDAPAttributeDescription("objectClass"),
+                            pureber.BERSet(
+                                value=[
+                                    pureldap.LDAPAttributeValue('something')
+                                ])
+                        )
+                    ]),
+                id=2).toWire())
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPAddResponse(
-                        resultCode=ldaperrors.Success.resultCode),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPAddResponse(
+                    resultCode=ldaperrors.Success.resultCode),
+                id=2).toWire())
         # tree changed
         d = self.stuff.children()
         d.addCallback(lambda actual: six.assertCountEqual(
@@ -587,35 +539,33 @@ class LDAPServerTest(unittest.TestCase):
                 self.thingie,
                 self.another,
                 inmemory.ReadOnlyInMemoryLDAPEntry(
-                    'cn=new,ou=stuff,dc=example,dc=com',
-                    {'objectClass': ['something']})
+                    b'cn=new,ou=stuff,dc=example,dc=com',
+                    {b'objectClass': [b'something']})
             ]))
         return d
 
     def test_add_fail_existsAlready(self):
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPAddRequest(
-                        entry=str(self.thingie.dn),
-                        attributes=[
-                            (
-                                pureldap.LDAPAttributeDescription("objectClass"),
-                                pureber.BERSet(
-                                    value=[
-                                        pureldap.LDAPAttributeValue('something'),
-                                    ])
-                            )
-                        ]),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPAddRequest(
+                    entry=self.thingie.dn,
+                    attributes=[
+                        (
+                            pureldap.LDAPAttributeDescription("objectClass"),
+                            pureber.BERSet(
+                                value=[
+                                    pureldap.LDAPAttributeValue('something'),
+                                ])
+                        )
+                    ]),
+                id=2).toWire())
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPAddResponse(
-                        resultCode=ldaperrors.LDAPEntryAlreadyExists.resultCode,
-                        errorMessage=str(self.thingie.dn)),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPAddResponse(
+                    resultCode=ldaperrors.LDAPEntryAlreadyExists.resultCode,
+                    errorMessage=self.thingie.dn),
+                id=2).toWire())
         # tree did not change
         d = self.stuff.children()
         d.addCallback(lambda actual: six.assertCountEqual(
@@ -625,20 +575,18 @@ class LDAPServerTest(unittest.TestCase):
     def test_modifyDN_rdnOnly_deleteOldRDN_success(self):
         newrdn = 'cn=thingamagic'
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPModifyDNRequest(
-                        entry=self.thingie.dn,
-                        newrdn=newrdn,
-                        deleteoldrdn=True),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPModifyDNRequest(
+                    entry=self.thingie.dn,
+                    newrdn=newrdn,
+                    deleteoldrdn=True),
+                id=2).toWire())
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPModifyDNResponse(
-                        resultCode=ldaperrors.Success.resultCode),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPModifyDNResponse(
+                    resultCode=ldaperrors.Success.resultCode),
+                id=2).toWire())
         # tree changed
         d = self.stuff.children()
         d.addCallback(lambda actual: six.assertCountEqual(
@@ -657,65 +605,59 @@ class LDAPServerTest(unittest.TestCase):
 
     def test_modify(self):
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPModifyRequest(
-                        self.stuff.dn,
-                        modification=[
-                            delta.Add('foo', ['bar']).asLDAP(),
-                        ]),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPModifyRequest(
+                    self.stuff.dn,
+                    modification=[
+                        delta.Add('foo', ['bar']).asLDAP(),
+                    ]),
+                id=2).toWire())
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPModifyResponse(
-                        resultCode=ldaperrors.Success.resultCode),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPModifyResponse(
+                    resultCode=ldaperrors.Success.resultCode),
+                id=2).toWire())
         # tree changed
         self.assertEqual(
             self.stuff,
             inmemory.ReadOnlyInMemoryLDAPEntry(
                 'ou=stuff,dc=example,dc=com',
                 {
-                    'objectClass': ['a', 'b'],
-                    'ou': ['stuff'],
-                    'foo': ['bar']
+                    b'objectClass': [b'a', b'b'],
+                    b'ou': [b'stuff'],
+                    b'foo': [b'bar']
                 }))
 
     def test_extendedRequest_unknown(self):
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPExtendedRequest(
-                        requestName='42.42.42',
-                        requestValue='foo'),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPExtendedRequest(
+                    requestName='42.42.42',
+                    requestValue='foo'),
+                id=2).toWire())
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPExtendedResponse(
-                        resultCode=ldaperrors.LDAPProtocolError.resultCode,
-                        errorMessage='Unknown extended request: 42.42.42'),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPExtendedResponse(
+                    resultCode=ldaperrors.LDAPProtocolError.resultCode,
+                    errorMessage='Unknown extended request: 42.42.42'),
+                id=2).toWire())
 
     def test_passwordModify_notBound(self):
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPPasswordModifyRequest(
-                        userIdentity='cn=thingie,ou=stuff,dc=example,dc=com',
-                        newPasswd='hushhush'),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPPasswordModifyRequest(
+                    userIdentity='cn=thingie,ou=stuff,dc=example,dc=com',
+                    newPasswd='hushhush'),
+                id=2).toWire())
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPExtendedResponse(
-                        resultCode=ldaperrors.LDAPStrongAuthRequired.resultCode,
-                        responseName=pureldap.LDAPPasswordModifyRequest.oid),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPExtendedResponse(
+                    resultCode=ldaperrors.LDAPStrongAuthRequired.resultCode,
+                    responseName=pureldap.LDAPPasswordModifyRequest.oid),
+                id=2).toWire())
 
     def test_passwordModify_simple(self):
         data = {'committed': False}
@@ -728,44 +670,41 @@ class LDAPServerTest(unittest.TestCase):
         # first bind to some entry
         self.thingie['userPassword'] = ['{SSHA}yVLLj62rFf3kDAbzwEU0zYAVvbWrze8=']  # "secret"
         self.server.dataReceived(
-            str(pureldap.LDAPMessage(
+            pureldap.LDAPMessage(
                 pureldap.LDAPBindRequest(
                     dn='cn=thingie,ou=stuff,dc=example,dc=com',
                     auth=b'secret'),
-                id=4)))
+                id=4).toWire())
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPBindResponse(
-                        resultCode=0,
-                        matchedDN='cn=thingie,ou=stuff,dc=example,dc=com'),
-                    id=4)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPBindResponse(
+                    resultCode=0,
+                    matchedDN='cn=thingie,ou=stuff,dc=example,dc=com'),
+                id=4).toWire())
         self.server.transport.clear()
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPPasswordModifyRequest(
-                        userIdentity='cn=thingie,ou=stuff,dc=example,dc=com',
-                        newPasswd='hushhush'),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPPasswordModifyRequest(
+                    userIdentity='cn=thingie,ou=stuff,dc=example,dc=com',
+                    newPasswd='hushhush'),
+                id=2).toWire())
         self.assertEqual(data['committed'], True, "Server never committed data.")
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPExtendedResponse(
-                        resultCode=ldaperrors.Success.resultCode,
-                        responseName=pureldap.LDAPPasswordModifyRequest.oid),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPExtendedResponse(
+                    resultCode=ldaperrors.Success.resultCode,
+                    responseName=pureldap.LDAPPasswordModifyRequest.oid),
+                id=2).toWire())
         # tree changed
         secrets = self.thingie.get('userPassword', [])
         self.assertEqual(len(secrets), 1)
         for secret in secrets:
-            self.assertEqual(secret[:len('{SSHA}')], '{SSHA}')
-            raw = base64.decodestring(secret[len('{SSHA}'):])
+            self.assertEqual(secret[:len(b'{SSHA}')], b'{SSHA}')
+            raw = base64.decodestring(secret[len(b'{SSHA}'):])
             salt = raw[20:]
-            self.assertEqual(entry.sshaDigest('hushhush', salt), secret)
+            self.assertEqual(entry.sshaDigest(b'hushhush', salt), secret)
 
     def test_unknownRequest(self):
         # make server miss one of the handle_* attributes
@@ -774,47 +713,44 @@ class LDAPServerTest(unittest.TestCase):
             handle_LDAPBindRequest = property()
 
         self.server.__class__ = MockServer
-        self.server.dataReceived(str(pureldap.LDAPMessage(
-            pureldap.LDAPBindRequest(), id=2)))
+        self.server.dataReceived(pureldap.LDAPMessage(
+            pureldap.LDAPBindRequest(), id=2).toWire())
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPExtendedResponse(
-                        resultCode=ldaperrors.LDAPProtocolError.resultCode,
-                        responseName='1.3.6.1.4.1.1466.20036',
-                        errorMessage='Unknown request'),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPExtendedResponse(
+                    resultCode=ldaperrors.LDAPProtocolError.resultCode,
+                    responseName='1.3.6.1.4.1.1466.20036',
+                    errorMessage='Unknown request'),
+                id=2).toWire())
 
     def test_control_unknown_critical(self):
-        self.server.dataReceived(str(pureldap.LDAPMessage(
+        self.server.dataReceived(pureldap.LDAPMessage(
             pureldap.LDAPBindRequest(), id=2,
             controls=[('42.42.42.42', True, None),
-                      ])))
+                      ]).toWire())
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPBindResponse(
-                        resultCode=ldaperrors.LDAPUnavailableCriticalExtension.resultCode,
-                        errorMessage='Unknown control 42.42.42.42'),
-                    id=2)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPBindResponse(
+                    resultCode=ldaperrors.LDAPUnavailableCriticalExtension.resultCode,
+                    errorMessage='Unknown control 42.42.42.42'),
+                id=2).toWire())
 
     def test_control_unknown_nonCritical(self):
         self.thingie['userPassword'] = ['{SSHA}yVLLj62rFf3kDAbzwEU0zYAVvbWrze8=']  # "secret"
-        self.server.dataReceived(str(pureldap.LDAPMessage(
+        self.server.dataReceived(pureldap.LDAPMessage(
             pureldap.LDAPBindRequest(dn='cn=thingie,ou=stuff,dc=example,dc=com',
                                      auth=b'secret'),
             controls=[('42.42.42.42', False, None)],
-            id=4)))
+            id=4).toWire())
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPBindResponse(
-                        resultCode=0,
-                        matchedDN='cn=thingie,ou=stuff,dc=example,dc=com'),
-                    id=4)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPBindResponse(
+                    resultCode=0,
+                    matchedDN='cn=thingie,ou=stuff,dc=example,dc=com'),
+                id=4).toWire())
 
 
 class TestSchema(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ commands =
 
     test: coverage run --rcfile={toxinidir}/.coveragerc -m twisted.trial {posargs:ldaptor}
 
-    ported: trial ldaptor.test.test_attributeset ldaptor.test.test_autofill ldaptor.test.test_autofill_posix ldaptor.test.test_autofill_samba ldaptor.test.test_config ldaptor.test.test_connector ldaptor.test.test_delta ldaptor.test.test_distinguishedname ldaptor.test.test_dns ldaptor.test.test_entry ldaptor.test.test_fetchschema ldaptor.test.test_match ldaptor.test.test_schema ldaptor.test.test_usage ldaptor.test.test_ldapfilter ldaptor.test.test_smbpassword ldaptor.test.test_ldapsyntax ldaptor.test.test_pureber ldaptor.test.test_pureldap ldaptor.test.test_encoder ldaptor.test.test_ldif ldaptor.test.test_ldaperrors ldaptor.test.test_inmemory ldaptor.test.test_ldapclient
+    ported: trial ldaptor.test.test_attributeset ldaptor.test.test_autofill ldaptor.test.test_autofill_posix ldaptor.test.test_autofill_samba ldaptor.test.test_config ldaptor.test.test_connector ldaptor.test.test_delta ldaptor.test.test_distinguishedname ldaptor.test.test_dns ldaptor.test.test_entry ldaptor.test.test_fetchschema ldaptor.test.test_match ldaptor.test.test_schema ldaptor.test.test_usage ldaptor.test.test_ldapfilter ldaptor.test.test_smbpassword ldaptor.test.test_ldapsyntax ldaptor.test.test_pureber ldaptor.test.test_pureldap ldaptor.test.test_encoder ldaptor.test.test_ldif ldaptor.test.test_ldaperrors ldaptor.test.test_inmemory ldaptor.test.test_ldapclient ldaptor.test.test_server
 
     ; Only run on local dev env.
     dev: coverage report --show-missing


### PR DESCRIPTION
Greetings!

This is an another step to Python 3 support. It mostly consists of switching from ``__str__`` to ``toWire`` method. I also had to implement here a feature which may be considered somewhat ugly: attributes can be got from entry by their bytes or unicode representation regardless of how they are stored in it. It helped to implement Python 3 support for LDAP search.

### Contributor Checklist:

* [x] I have updated the release notes at `docs/source/NEWS.rst` 
* [x] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
