### PR TITLE
Python 3 support for ldiftree module

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -22,7 +22,7 @@ Changes
 - ``toWire`` method is used to get bytes representation of ``ldaptor.protocols.pureber``,
   ``ldaptor.protocols.pureldap``, ``ldaptor.protocols.ldap.distinguishedname``,
   ``ldaptor.protocols.ldap.ldaperrors``, ``ldaptor.protocols.ldap.ldapclient``,
-  ``ldaptor.protocols.ldap.ldapserver`` and ``ldaptor.entry`` classes
+  ``ldaptor.protocols.ldap.ldapserver``, ``ldaptor.ldiftree`` and ``ldaptor.entry`` classes
   instead of ``__str__`` which is deprecated now.
 - Code was updated to pass `python3 -m compileall` in preparation for py3 port.
 - Continuous test are executed only against latest related Twisted and latest

--- a/ldaptor/attributeset.py
+++ b/ldaptor/attributeset.py
@@ -1,5 +1,7 @@
 from copy import deepcopy
 
+from ldaptor._encoder import get_strings
+
 
 class LDAPAttributeSet(set):
     def __init__(self, key, *a, **kw):
@@ -47,6 +49,29 @@ class LDAPAttributeSet(set):
 
     def __ne__(self, other):
         return not self == other
+
+    def add(self, key):
+        """
+        Adding key to the attributes with checking
+        if it exists as byte or unicode string
+        """
+        for k in get_strings(key):
+            if k in self:
+                return
+
+        set.add(self, key)
+
+    def remove(self, key):
+        """
+        Removing key from the attributes with checking
+        if it exists as byte or unicode string
+        """
+        for k in get_strings(key):
+            if k in self:
+                set.remove(self, k)
+                return
+
+        raise KeyError(key)
 
     def copy(self):
         result = self.__class__(self.key)

--- a/ldaptor/test/test_attributeset.py
+++ b/ldaptor/test/test_attributeset.py
@@ -74,6 +74,45 @@ class TestLDAPAttributeSet(unittest.TestCase):
 
         self.assertEqual({'d'}, result)
 
+    def testAddNewValue(self):
+        """
+        Adding new value
+        """
+        a = attributeset.LDAPAttributeSet('k', ['b', 'c', 'd'])
+        a.add('e')
+
+        self.assertEqual(a, {'b', 'c', 'd', 'e'})
+
+    def testAddExistingValue(self):
+        """
+        Adding existing value as a byte or unicode string
+        """
+        a = attributeset.LDAPAttributeSet('k', ['b', 'c', 'd'])
+
+        a.add(b'b')
+        self.assertEqual(a, {'b', 'c', 'd'})
+
+        a.add(u'b')
+        self.assertEqual(a, {'b', 'c', 'd'})
+
+    def testRemoveExistingValue(self):
+        """
+        Removing existing value as a byte or unicode string
+        """
+        a = attributeset.LDAPAttributeSet('k', ['b', 'c', 'd'])
+        a.remove(b'b')
+        a.remove(u'c')
+
+        self.assertEqual(a, {'d'})
+
+    def testRemoveNonexistingValue(self):
+        """
+        Removing non-existing value
+        """
+        a = attributeset.LDAPAttributeSet('k', ['b', 'c', 'd'])
+
+        self.assertRaises(KeyError, a.remove, 'e')
+
     def testUnion(self):
         a = attributeset.LDAPAttributeSet('k', ['b', 'c', 'd'])
         b = attributeset.LDAPAttributeSet('k', ['b', 'c', 'e'])

--- a/ldaptor/test/test_ldifdelta.py
+++ b/ldaptor/test/test_ldifdelta.py
@@ -86,8 +86,8 @@ foo: bar
         proto.connectionLost()
         self.assertEqual(
             proto.listOfCompleted,
-            [delta.ModifyOp(dn='cn=foo,dc=example,dc=com',
-                            modifications=[delta.Add('foo', ['bar']),
+            [delta.ModifyOp(dn=b'cn=foo,dc=example,dc=com',
+                            modifications=[delta.Add(b'foo', [b'bar']),
                                            ]),
              ])
 
@@ -109,9 +109,9 @@ thud: baz
         proto.connectionLost()
         self.assertEqual(
             proto.listOfCompleted,
-            [delta.ModifyOp(dn='cn=foo,dc=example,dc=com',
-                            modifications=[delta.Add('foo', ['bar']),
-                                           delta.Add('thud', ['quux', 'baz']),
+            [delta.ModifyOp(dn=b'cn=foo,dc=example,dc=com',
+                            modifications=[delta.Add(b'foo', [b'bar']),
+                                           delta.Add(b'thud', [b'quux', b'baz']),
                                            ]),
              ])
 
@@ -145,14 +145,14 @@ add: silly
         proto.connectionLost()
         self.assertEqual(
             proto.listOfCompleted,
-            [delta.ModifyOp(dn='cn=foo,dc=example,dc=com',
-                            modifications=[delta.Delete('foo', ['bar']),
-                                           delta.Delete('garply'),
-                                           delta.Add('thud', ['quux', 'baz']),
-                                           delta.Replace('waldo'),
-                                           delta.Add('foo', ['baz']),
-                                           delta.Replace('thud', ['xyzzy']),
-                                           delta.Add('silly'),
+            [delta.ModifyOp(dn=b'cn=foo,dc=example,dc=com',
+                            modifications=[delta.Delete(b'foo', [b'bar']),
+                                           delta.Delete(b'garply'),
+                                           delta.Add(b'thud', [b'quux', b'baz']),
+                                           delta.Replace(b'waldo'),
+                                           delta.Add(b'foo', [b'baz']),
+                                           delta.Replace(b'thud', [b'xyzzy']),
+                                           delta.Add(b'silly'),
                                            ]),
              ])
 
@@ -225,7 +225,7 @@ foo: bar
 
 """)
         self.assertEqual(
-            ('cn=foo,dc=example,dc=com', 'add', 'foo'), error.args)
+            (b'cn=foo,dc=example,dc=com', b'add', b'foo'), error.args)
 
 
     def testNoChangetTypeEmpty(self):
@@ -243,7 +243,7 @@ dn: cn=foo,dc=example,dc=com
 
 """)
 
-        self.assertEqual(('cn=foo,dc=example,dc=com',), error.args)
+        self.assertEqual((b'cn=foo,dc=example,dc=com',), error.args)
 
 
     def testAdd(self):
@@ -260,10 +260,10 @@ thud: baz
         proto.connectionLost()
         self.assertEqual(proto.listOfCompleted,
                          [delta.AddOp(entry.BaseLDAPEntry(
-            dn='cn=foo,dc=example,dc=com',
+            dn=b'cn=foo,dc=example,dc=com',
             attributes={
-            'foo': ['bar'],
-            'thud': ['quux', 'baz'],
+            b'foo': [b'bar'],
+            b'thud': [b'quux', b'baz'],
             }))])
 
     def testAdd_fail_noAttrvals(self):

--- a/ldaptor/test/test_ldifprotocol.py
+++ b/ldaptor/test/test_ldifprotocol.py
@@ -77,16 +77,16 @@ class TestLDIFParsing(unittest.TestCase):
         self.failUnlessEqual(len(proto.listOfCompleted), 2)
 
         o = proto.listOfCompleted.pop(0)
-        self.failUnlessEqual(str(o.dn), 'cn=foo,dc=example,dc=com')
-        self.failUnlessEqual(o['objectClass'], ['a', 'b'])
-        self.failUnlessEqual(o['aValue'], ['a', 'b'])
-        self.failUnlessEqual(o['bValue'], ['c'])
+        self.failUnlessEqual(o.dn.toWire(), b'cn=foo,dc=example,dc=com')
+        self.failUnlessEqual(o[b'objectClass'], [b'a', b'b'])
+        self.failUnlessEqual(o[b'aValue'], [b'a', b'b'])
+        self.failUnlessEqual(o[b'bValue'], [b'c'])
 
         o = proto.listOfCompleted.pop(0)
-        self.failUnlessEqual(str(o.dn), 'cn=bar,dc=example,dc=com')
-        self.failUnlessEqual(o['objectClass'], ['c'])
-        self.failUnlessEqual(o['aValue'], [' FOO!', 'b'])
-        self.failUnlessEqual(o['bValue'], ['C'])
+        self.failUnlessEqual(o.dn.toWire(), b'cn=bar,dc=example,dc=com')
+        self.failUnlessEqual(o[b'objectClass'], [b'c'])
+        self.failUnlessEqual(o[b'aValue'], [b' FOO!', b'b'])
+        self.failUnlessEqual(o[b'bValue'], [b'C'])
 
         self.failUnlessEqual(proto.listOfCompleted, [])
 
@@ -109,8 +109,8 @@ class TestLDIFParsing(unittest.TestCase):
         self.failUnlessEqual(len(proto.listOfCompleted), 1)
 
         o = proto.listOfCompleted.pop(0)
-        self.failUnlessEqual(str(o.dn), 'cn=foo,dc=example,dc=com')
-        self.failUnlessEqual(o['objectClass'], ['a', 'b'])
+        self.failUnlessEqual(o.dn.toWire(), b'cn=foo,dc=example,dc=com')
+        self.failUnlessEqual(o[b'objectClass'], [b'a', b'b'])
 
         self.failUnlessEqual(proto.listOfCompleted, [])
 
@@ -132,12 +132,12 @@ cn: bar
         self.failUnlessEqual(len(proto.listOfCompleted), 2)
 
         o = proto.listOfCompleted.pop(0)
-        self.failUnlessEqual(str(o.dn), 'cn=foo,dc=example,dc=com')
-        self.failUnlessEqual(o['CN'], ['foo'])
+        self.failUnlessEqual(o.dn.toWire(), b'cn=foo,dc=example,dc=com')
+        self.failUnlessEqual(o[b'CN'], [b'foo'])
 
         o = proto.listOfCompleted.pop(0)
-        self.failUnlessEqual(str(o.dn), 'cn=bar,dc=example,dc=com')
-        self.failUnlessEqual(o['CN'], ['bar'])
+        self.failUnlessEqual(o.dn.toWire(), b'cn=bar,dc=example,dc=com')
+        self.failUnlessEqual(o[b'CN'], [b'bar'])
 
         self.failUnlessEqual(proto.listOfCompleted, [])
 
@@ -161,10 +161,10 @@ aValUe: B
         self.failUnlessEqual(len(proto.listOfCompleted), 1)
 
         o = proto.listOfCompleted.pop(0)
-        self.failUnlessEqual(str(o.dn), 'cn=foo,dc=example,dc=com')
-        self.failUnlessEqual(o['objectClass'], ['a', 'b'])
-        self.failUnlessEqual(o['CN'], ['foo'])
-        self.failUnlessEqual(o['aValue'], ['a', 'B'])
+        self.failUnlessEqual(o.dn.toWire(), b'cn=foo,dc=example,dc=com')
+        self.failUnlessEqual(o[b'objectClass'], [b'a', b'b'])
+        self.failUnlessEqual(o[b'CN'], [b'foo'])
+        self.failUnlessEqual(o[b'aValue'], [b'a', b'B'])
 
         self.failUnlessEqual(proto.listOfCompleted, [])
 
@@ -184,10 +184,10 @@ bValue: c
         self.failUnlessEqual(len(proto.listOfCompleted), 1)
 
         o = proto.listOfCompleted.pop(0)
-        self.failUnlessEqual(str(o.dn), 'cn=foo,dc=example,dc=com')
-        self.failUnlessEqual(o['objectClass'], ['a', 'b'])
-        self.failUnlessEqual(o['aValue'], ['a', 'b'])
-        self.failUnlessEqual(o['bValue'], ['c'])
+        self.failUnlessEqual(o.dn.toWire(), b'cn=foo,dc=example,dc=com')
+        self.failUnlessEqual(o[b'objectClass'], [b'a', b'b'])
+        self.failUnlessEqual(o[b'aValue'], [b'a', b'b'])
+        self.failUnlessEqual(o[b'bValue'], [b'c'])
 
     def testVersionInvalid(self):
         proto = LDIFDriver()
@@ -234,10 +234,10 @@ aValUe:b
         self.failUnlessEqual(len(proto.listOfCompleted), 1)
 
         o = proto.listOfCompleted.pop(0)
-        self.failUnlessEqual(str(o.dn), 'cn=foo,dc=example,dc=com')
-        self.failUnlessEqual(o['objectClass'], ['a', 'b'])
-        self.failUnlessEqual(o['CN'], ['foo'])
-        self.failUnlessEqual(o['aValue'], ['a', 'b'])
+        self.failUnlessEqual(o.dn.toWire(), b'cn=foo,dc=example,dc=com')
+        self.failUnlessEqual(o[b'objectClass'], [b'a', b'b'])
+        self.failUnlessEqual(o[b'CN'], [b'foo'])
+        self.failUnlessEqual(o[b'aValue'], [b'a', b'b'])
 
         self.failUnlessEqual(proto.listOfCompleted, [])
 
@@ -280,12 +280,12 @@ cn: bar
         self.failUnlessEqual(len(proto.listOfCompleted), 2)
 
         o = proto.listOfCompleted.pop(0)
-        self.failUnlessEqual(str(o.dn), 'cn=foo,dc=example,dc=com')
-        self.failUnlessEqual(o['CN'], ['foo'])
+        self.failUnlessEqual(o.dn.toWire(), b'cn=foo,dc=example,dc=com')
+        self.failUnlessEqual(o[b'CN'], [b'foo'])
 
         o = proto.listOfCompleted.pop(0)
-        self.failUnlessEqual(str(o.dn), 'cn=bar,dc=example,dc=com')
-        self.failUnlessEqual(o['CN'], ['bar'])
+        self.failUnlessEqual(o.dn.toWire(), b'cn=bar,dc=example,dc=com')
+        self.failUnlessEqual(o[b'CN'], [b'bar'])
 
         self.failUnlessEqual(proto.listOfCompleted, [])
 
@@ -310,12 +310,12 @@ cn: bar
         self.failUnlessEqual(len(proto.listOfCompleted), 2)
 
         o = proto.listOfCompleted.pop(0)
-        self.failUnlessEqual(str(o.dn), 'cn=foo,dc=example,dc=com')
-        self.failUnlessEqual(o['CN'], ['foo'])
+        self.failUnlessEqual(o.dn.toWire(), b'cn=foo,dc=example,dc=com')
+        self.failUnlessEqual(o[b'CN'], [b'foo'])
 
         o = proto.listOfCompleted.pop(0)
-        self.failUnlessEqual(str(o.dn), 'cn=bar,dc=example,dc=com')
-        self.failUnlessEqual(o['CN'], ['bar'])
+        self.failUnlessEqual(o.dn.toWire(), b'cn=bar,dc=example,dc=com')
+        self.failUnlessEqual(o[b'CN'], [b'bar'])
 
         self.failUnlessEqual(proto.listOfCompleted, [])
 
@@ -393,22 +393,22 @@ sn: Jensen
 telephonenumber: +1 408 555 1212
 
 """,
-          [ ( 'cn=Barbara Jensen,ou=Product Development,dc=airius,dc=com',
-              { 'objectClass': ['top', 'person', 'organizationalPerson'],
-                'cn': ['Barbara Jensen',
-                       'Barbara J Jensen',
-                       'Babs Jensen'],
-                'sn': ['Jensen'],
-                'uid': ['bjensen'],
-                'telephonenumber': ['+1 408 555 1212'],
-                'description': ['A big sailing fan.'],
+          [ ( b'cn=Barbara Jensen,ou=Product Development,dc=airius,dc=com',
+              { b'objectClass': [b'top', b'person', b'organizationalPerson'],
+                b'cn': [b'Barbara Jensen',
+                       b'Barbara J Jensen',
+                       b'Babs Jensen'],
+                b'sn': [b'Jensen'],
+                b'uid': [b'bjensen'],
+                b'telephonenumber': [b'+1 408 555 1212'],
+                b'description': [b'A big sailing fan.'],
                 }),
 
-            ( 'cn=Bjorn Jensen,ou=Accounting,dc=airius,dc=com',
-              {  'objectClass': ['top', 'person', 'organizationalPerson'],
-                 'cn': ['Bjorn Jensen'],
-                 'sn': ['Jensen'],
-                 'telephonenumber': ['+1 408 555 1212'],
+            ( b'cn=Bjorn Jensen,ou=Accounting,dc=airius,dc=com',
+              {  b'objectClass': [b'top', b'person', b'organizationalPerson'],
+                 b'cn': [b'Bjorn Jensen'],
+                 b'sn': [b'Jensen'],
+                 b'telephonenumber': [b'+1 408 555 1212'],
                  }),
             ]),
 
@@ -430,14 +430,14 @@ description:Babs is a big sailing fan, and travels extensively in sea
 title:Product Manager, Rod and Reel Division
 
 """,
-          [ ( 'cn=Barbara Jensen, ou=Product Development, dc=airius, dc=com',
-              { 'objectclass': ['top', 'person', 'organizationalPerson'],
-                'cn': ['Barbara Jensen', 'Barbara J Jensen', 'Babs Jensen'],
-                'sn': ['Jensen'],
-                'uid': ['bjensen'],
-                'telephonenumber': ['+1 408 555 1212'],
-                'description': ['Babs is a big sailing fan, and travels extensively in search of perfect sailing conditions.'],
-                'title': ['Product Manager, Rod and Reel Division'],
+          [ ( b'cn=Barbara Jensen, ou=Product Development, dc=airius, dc=com',
+              { b'objectclass': [b'top', b'person', b'organizationalPerson'],
+                b'cn': [b'Barbara Jensen', b'Barbara J Jensen', b'Babs Jensen'],
+                b'sn': [b'Jensen'],
+                b'uid': [b'bjensen'],
+                b'telephonenumber': [b'+1 408 555 1212'],
+                b'description': [b'Babs is a big sailing fan, and travels extensively in search of perfect sailing conditions.'],
+                b'title': [b'Product Manager, Rod and Reel Division'],
                 }),
             ]),
 
@@ -456,13 +456,13 @@ telephonenumber: +1 408 555 1212
 description:: V2hhdCBhIGNhcmVmdWwgcmVhZGVyIHlvdSBhcmUhICBUaGlzIHZhbHVlIGlzIGJhc2UtNjQtZW5jb2RlZCBiZWNhdXNlIGl0IGhhcyBhIGNvbnRyb2wgY2hhcmFjdGVyIGluIGl0IChhIENSKS4NICBCeSB0aGUgd2F5LCB5b3Ugc2hvdWxkIHJlYWxseSBnZXQgb3V0IG1vcmUu
 
 """,
-          [ ( 'cn=Gern Jensen, ou=Product Testing, dc=airius, dc=com',
-              { 'objectclass': ['top', 'person', 'organizationalPerson'],
-                'cn': ['Gern Jensen', 'Gern O Jensen'],
-                'sn': ['Jensen'],
-                'uid': ['gernj'],
-                'telephonenumber': ['+1 408 555 1212'],
-                'description': ['What a careful reader you are!  This value is base-64-encoded because it has a control character in it (a CR).\r  By the way, you should really get out more.'],
+          [ ( b'cn=Gern Jensen, ou=Product Testing, dc=airius, dc=com',
+              { b'objectclass': [b'top', b'person', b'organizationalPerson'],
+                b'cn': [b'Gern Jensen', b'Gern O Jensen'],
+                b'sn': [b'Jensen'],
+                b'uid': [b'gernj'],
+                b'telephonenumber': [b'+1 408 555 1212'],
+                b'description': [b'What a careful reader you are!  This value is base-64-encoded because it has a control character in it (a CR).\r  By the way, you should really get out more.'],
                 }),
             ]),
 

--- a/ldaptor/test/test_ldiftree.py
+++ b/ldaptor/test/test_ldiftree.py
@@ -90,10 +90,10 @@ objectClass: top
 """)
 
     def testSimpleRead(self):
-        want = BaseLDAPEntry(dn='cn=foo,dc=example,dc=com',
+        want = BaseLDAPEntry(dn=b'cn=foo,dc=example,dc=com',
                              attributes={
-            'objectClass': ['top'],
-            'cn': ['foo'],
+            b'objectClass': [b'top'],
+            b'cn': [b'foo'],
             })
         d = ldiftree.get(self.tree, want.dn)
         d.addCallback(self.failUnlessEqual, want)
@@ -143,10 +143,10 @@ objectClass: top
             ldifprotocol.LDIFLineWithoutSemicolonError)
 
     def testTreeBranches(self):
-        want = BaseLDAPEntry(dn='cn=sales-thingie,ou=Sales,dc=example,dc=com',
+        want = BaseLDAPEntry(dn=b'cn=sales-thingie,ou=Sales,dc=example,dc=com',
                              attributes={
-            'objectClass': ['top'],
-            'cn': ['sales-thingie'],
+            b'objectClass': [b'top'],
+            b'cn': [b'sales-thingie'],
             })
         d = ldiftree.get(self.tree, want.dn)
         d.addCallback(self.failUnlessEqual, want)
@@ -190,7 +190,7 @@ objectClass: organizationalUnit
         path = os.path.join(self.tree, 'dc=com.dir', 'dc=example.dir', 'cn=foo.ldif')
         self.failUnless(os.path.isfile(path))
         self.failUnlessEqual(open(path, 'rb').read(),
-                             """\
+                             b"""\
 dn: cn=foo,dc=example,dc=com
 objectClass: top
 cn: foo
@@ -212,7 +212,7 @@ cn: foo
                             'ou=OrgUnit.dir', 'cn=create-me.ldif')
         self.failUnless(os.path.isfile(path))
         self.failUnlessEqual(open(path, 'rb').read(),
-                             """\
+                             b"""\
 dn: cn=create-me,ou=OrgUnit,dc=example,dc=com
 objectClass: top
 cn: create-me
@@ -236,7 +236,7 @@ cn: create-me
         path = os.path.join(dirpath, 'cn=create-me.ldif')
         self.failUnless(os.path.isfile(path))
         self.failUnlessEqual(open(path, 'rb').read(),
-                             """\
+                             b"""\
 dn: cn=create-me,ou=OrgUnit,dc=example,dc=com
 objectClass: top
 cn: create-me
@@ -269,7 +269,7 @@ cn: create-me
         path = os.path.join(self.tree, 'dc=org.ldif')
         self.failUnless(os.path.isfile(path))
         self.failUnlessEqual(open(path, 'rb').read(),
-                             """\
+                             b"""\
 dn: dc=org
 objectClass: dcObject
 dc: org
@@ -455,7 +455,7 @@ cn: theChild
         test_children_noAccess_dir_noExec.skip = "Can't test as root"
 
     def test_children_noAccess_file(self):
-        os.chmod(os.path.join(self.meta.path, 'cn=foo.ldif'), 0)
+        os.chmod(os.path.join(self.meta.path, b'cn=foo.ldif'), 0)
         d = self.meta.children()
         def eb(fail):
             fail.trap(IOError)
@@ -600,7 +600,7 @@ cn: theChild
 
     def test_lookup_fail_multipleError(self):
         writeFile(os.path.join(self.example.path,
-                               'cn=bad-two-entries.ldif'),
+                               b'cn=bad-two-entries.ldif'),
                   b"""\
 dn: cn=bad-two-entries,dc=example,dc=com
 cn: bad-two-entries
@@ -618,7 +618,7 @@ objectClass: top
 
     def test_lookup_fail_emptyError(self):
         writeFile(os.path.join(self.example.path,
-                               'cn=bad-empty.ldif'),
+                               b'cn=bad-empty.ldif'),
                   b"")
         self.assertRaises(
             ldiftree.LDIFTreeEntryContainsNoEntries,
@@ -684,13 +684,13 @@ objectClass: top
         return d
 
     def test_setPassword(self):
-        self.foo.setPassword('s3krit', salt=b'\xf2\x4a')
+        self.foo.setPassword(b's3krit', salt=b'\xf2\x4a')
         self.failUnless('userPassword' in self.foo)
         self.assertEqual(self.foo['userPassword'],
-                          ['{SSHA}0n/Iw1NhUOKyaI9gm9v5YsO3ZInySg=='])
+                          [b'{SSHA}0n/Iw1NhUOKyaI9gm9v5YsO3ZInySg=='])
 
     def test_setPassword_noSalt(self):
-        self.foo.setPassword('s3krit')
+        self.foo.setPassword(b's3krit')
         self.failUnless('userPassword' in self.foo)
         d = self.foo.bind('s3krit')
         d.addCallback(self.assertIdentical, self.foo)
@@ -767,7 +767,7 @@ objectClass: top
         def cb3(got):
             self.assertEqual(got, [
                 delta.ModifyOp(self.empty.dn,
-                               [delta.Add('foo', ['bar'])],
+                               [delta.Add(b'foo', [b'bar'])],
                                ),
                 ])
         d.addCallback(cb3)
@@ -784,8 +784,8 @@ objectClass: top
             self.meta,
             BaseLDAPEntry(
             dn='ou=moved,dc=example,dc=com',
-            attributes={ 'objectClass': ['a', 'b'],
-                         'ou': ['moved'],
+            attributes={ b'objectClass': [b'a', b'b'],
+                         b'ou': [b'moved'],
             }),
             self.oneChild,
             ]))
@@ -799,8 +799,8 @@ objectClass: top
         d.addCallback(set)
         d.addCallback(self.assertEqual, set([
             BaseLDAPEntry(dn='ou=moved,dc=example,dc=com',
-                          attributes={ 'objectClass': ['a', 'b'],
-                                       'ou': ['moved'],
+                          attributes={ b'objectClass': [b'a', b'b'],
+                                       b'ou': [b'moved'],
                                        }),
             self.empty,
             self.oneChild,
@@ -826,8 +826,8 @@ objectClass: top
             self.theChild,
             BaseLDAPEntry(
             dn='ou=moved,ou=oneChild,dc=example,dc=com',
-            attributes={ 'objectClass': ['a', 'b'],
-                         'ou': ['moved'],
+            attributes={ b'objectClass': [b'a', b'b'],
+                         b'ou': [b'moved'],
             }),
             ]))
         return d
@@ -849,8 +849,8 @@ objectClass: top
         d.addCallback(self.assertEqual, set([
             self.theChild,
             BaseLDAPEntry(dn='ou=moved,ou=oneChild,dc=example,dc=com',
-                          attributes={ 'objectClass': ['a', 'b'],
-                                       'ou': ['moved'],
+                          attributes={ b'objectClass': [b'a', b'b'],
+                                       b'ou': [b'moved'],
                                        }),
             ]))
         return d

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ commands =
 
     test: coverage run --rcfile={toxinidir}/.coveragerc -m twisted.trial {posargs:ldaptor}
 
-    ported: trial ldaptor.test.test_attributeset ldaptor.test.test_autofill ldaptor.test.test_autofill_posix ldaptor.test.test_autofill_samba ldaptor.test.test_config ldaptor.test.test_connector ldaptor.test.test_delta ldaptor.test.test_distinguishedname ldaptor.test.test_dns ldaptor.test.test_entry ldaptor.test.test_fetchschema ldaptor.test.test_match ldaptor.test.test_schema ldaptor.test.test_usage ldaptor.test.test_ldapfilter ldaptor.test.test_smbpassword ldaptor.test.test_ldapsyntax ldaptor.test.test_pureber ldaptor.test.test_pureldap ldaptor.test.test_encoder ldaptor.test.test_ldif ldaptor.test.test_ldaperrors ldaptor.test.test_inmemory ldaptor.test.test_ldapclient ldaptor.test.test_server
+    ported: trial ldaptor.test.test_attributeset ldaptor.test.test_autofill ldaptor.test.test_autofill_posix ldaptor.test.test_autofill_samba ldaptor.test.test_config ldaptor.test.test_connector ldaptor.test.test_delta ldaptor.test.test_distinguishedname ldaptor.test.test_dns ldaptor.test.test_entry ldaptor.test.test_fetchschema ldaptor.test.test_match ldaptor.test.test_schema ldaptor.test.test_usage ldaptor.test.test_ldapfilter ldaptor.test.test_smbpassword ldaptor.test.test_ldapsyntax ldaptor.test.test_pureber ldaptor.test.test_pureldap ldaptor.test.test_encoder ldaptor.test.test_ldif ldaptor.test.test_ldaperrors ldaptor.test.test_inmemory ldaptor.test.test_ldapclient ldaptor.test.test_server ldaptor.test.test_ldifdelta ldaptor.test.test_ldifprotocol ldaptor.test.test_ldiftree
 
     ; Only run on local dev env.
     dev: coverage report --show-missing


### PR DESCRIPTION
Greetings!

This is another Python 3 compatibility fix. I had to override `add` and `remove` methods of `LDAPAttributeSet` for it: they now check for existence of a key in a set as a byte or a unicode string. Other updates are mostly usual: explicit using of bytes and switching to `toWire` method from `__str__`.

### Contributor Checklist:

* [x] I have updated the release notes at `docs/source/NEWS.rst` 
* [x] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
