### PR TITLE
Python 3 support for test_examples

### DIFF
--- a/docs/source/examples/ldaptor_with_upn_bind.py
+++ b/docs/source/examples/ldaptor_with_upn_bind.py
@@ -38,7 +38,7 @@ class LDAPServerWithUPNBind(LDAPServer):
 
         self.checkControls(controls)
 
-        if request.dn == '':
+        if request.dn == b'':
             # anonymous bind
             self.boundUser = None
             return pureldap.LDAPBindResponse(resultCode=0)
@@ -53,7 +53,7 @@ class LDAPServerWithUPNBind(LDAPServer):
             # A single result, so the UPN might exist.
             return results[0].dn
 
-        if '@' in request.dn and ',' not in request.dn:
+        if b'@' in request.dn and b',' not in request.dn:
             # This might be an UPN request.
             filterText = b'(' + self._loginAttribute + b'=' + request.dn + b')'
             d = root.search(filterText=filterText)
@@ -88,7 +88,7 @@ class LDAPServerWithUPNBind(LDAPServer):
                 self.boundUser = entry
                 msg = pureldap.LDAPBindResponse(
                     resultCode=ldaperrors.Success.resultCode,
-                    matchedDN=str(entry.dn))
+                    matchedDN=entry.dn)
                 return msg
             d.addCallback(_cb)
             return d

--- a/ldaptor/ldapfilter.py
+++ b/ldaptor/ldapfilter.py
@@ -1,6 +1,10 @@
 #!/usr/bin/python
 
+import six
+
 from ldaptor.protocols import pureldap
+from ldaptor._encoder import to_unicode
+
 
 """
 
@@ -217,6 +221,14 @@ toplevel.setName('toplevel')
 
 
 def parseFilter(s):
+    """
+    Converting source string to pureldap.LDAPFilter
+
+    Source string is converted to unicode for Python 3
+    as pyparsing cannot parse Python 3 byte strings with
+    the rules declared in this module.
+    """
+    s = to_unicode(s) if not six.PY2 else s
     try:
         x = toplevel.parseString(s)
     except ParseException as e:

--- a/ldaptor/test/test_examples.py
+++ b/ldaptor/test/test_examples.py
@@ -47,20 +47,20 @@ class LDAPServerWithUPNBind(unittest.TestCase):
         Do a BIND request and check that is succeeds.
         """
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPBindRequest(
-                        dn=bind_dn,
-                        auth=password),
-                    id=4)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPBindRequest(
+                    dn=bind_dn,
+                    auth=password),
+                id=4).toWire()
+        )
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPBindResponse(
-                        resultCode=0,
-                        matchedDN='cn=bob,dc=example,dc=com'),
-                    id=4)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPBindResponse(
+                    resultCode=0,
+                    matchedDN='cn=bob,dc=example,dc=com'),
+                id=4).toWire()
+        )
 
     def test_bindSuccessUPN(self):
         """
@@ -81,16 +81,16 @@ class LDAPServerWithUPNBind(unittest.TestCase):
         When password don't match the BIND fails.
         """
         self.server.dataReceived(
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPBindRequest(
-                        dn='bob@ad.example.com',
-                        auth='invalid'),
-                    id=734)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPBindRequest(
+                    dn='bob@ad.example.com',
+                    auth='invalid'),
+                id=734).toWire()
+        )
         self.assertEqual(
             self.server.transport.value(),
-            str(
-                pureldap.LDAPMessage(
-                    pureldap.LDAPBindResponse(
-                        resultCode=ldaperrors.LDAPInvalidCredentials.resultCode),
-                    id=734)))
+            pureldap.LDAPMessage(
+                pureldap.LDAPBindResponse(
+                    resultCode=ldaperrors.LDAPInvalidCredentials.resultCode),
+                id=734).toWire()
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ commands =
 
     test: coverage run --rcfile={toxinidir}/.coveragerc -m twisted.trial {posargs:ldaptor}
 
-    ported: trial ldaptor.test.test_attributeset ldaptor.test.test_autofill ldaptor.test.test_autofill_posix ldaptor.test.test_autofill_samba ldaptor.test.test_config ldaptor.test.test_connector ldaptor.test.test_delta ldaptor.test.test_distinguishedname ldaptor.test.test_dns ldaptor.test.test_entry ldaptor.test.test_fetchschema ldaptor.test.test_match ldaptor.test.test_schema ldaptor.test.test_usage ldaptor.test.test_ldapfilter ldaptor.test.test_smbpassword ldaptor.test.test_ldapsyntax ldaptor.test.test_pureber ldaptor.test.test_pureldap ldaptor.test.test_encoder ldaptor.test.test_ldif ldaptor.test.test_ldaperrors ldaptor.test.test_inmemory ldaptor.test.test_ldapclient ldaptor.test.test_server ldaptor.test.test_ldifdelta ldaptor.test.test_ldifprotocol ldaptor.test.test_ldiftree ldaptor.test.test_proxy ldaptor.test.test_proxybase ldaptor.test.test_svcbindproxy ldaptor.test.test_merger
+    ported: trial ldaptor
 
     ; Only run on local dev env.
     dev: coverage report --show-missing


### PR DESCRIPTION
Greetings!

This is the compatibility fix for `test_examples` module which actually covers only one of the examples: `ldaptor_with_upn_bind`. Perhaps the other examples should be modernized and covered by tests.

It looks like all tests are passed on both Python 2.7 and Python 3.5 :)

### Contributor Checklist:

* [x] I have updated the release notes at `docs/source/NEWS.rst` 
* [x] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
