### PR TITLE
Bug fix for ReadOnlyInMemoryLDAPEntry subclass instances children creation

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -40,6 +40,7 @@ Bugfixes
 - DN matching is now case insensitive.
 - Proxies now terminate the connection to the proxied server in case a client immediately closes the connection.
 - asText() implemented for LDAPFilter_extensibleMatch
+- Children of ``ldaptor.inmemory.ReadOnlyInMemoryLDAPEntry`` subclass instances are added as the same class instances.
 
 Release 16.0 (2016-06-07)
 -------------------------

--- a/ldaptor/inmemory.py
+++ b/ldaptor/inmemory.py
@@ -60,7 +60,7 @@ class ReadOnlyInMemoryLDAPEntry(entry.EditableLDAPEntry,
             raise ldaperrors.LDAPEntryAlreadyExists(self._children[rdn_str].dn)
         dn = distinguishedname.DistinguishedName(
             listOfRDNs=(rdn,) + self.dn.split())
-        e = ReadOnlyInMemoryLDAPEntry(dn, attributes)
+        e = self.__class__(dn, attributes)
         e._parent = self
         self._children[rdn_str] = e
         return e

--- a/ldaptor/test/test_inmemory.py
+++ b/ldaptor/test/test_inmemory.py
@@ -9,6 +9,11 @@ import six
 from ldaptor import inmemory, delta, testutil
 from ldaptor.protocols.ldap import distinguishedname, ldaperrors
 
+
+class SubclassEntry(inmemory.ReadOnlyInMemoryLDAPEntry):
+    pass
+
+
 class TestInMemoryDatabase(unittest.TestCase):
     def setUp(self):
         self.root = inmemory.ReadOnlyInMemoryLDAPEntry(
@@ -127,6 +132,15 @@ class TestInMemoryDatabase(unittest.TestCase):
             'objectClass': ['a'],
             'cn': 'foo',
             })
+
+    def test_addChild_subclass(self):
+        """
+        Adding child to ReadOnlyInMemoryLDAPEntry subclass instance
+        creates entry of the same class
+        """
+        entry = SubclassEntry(dn='dc=example,dc=com')
+        child = entry.addChild(rdn='ou=empty', attributes={'objectClass': ['a']})
+        self.assertIsInstance(child, SubclassEntry)
 
     def test_parent(self):
         self.assertEqual(self.foo.parent(), self.meta)


### PR DESCRIPTION
Problem:
```
from ldaptor.inmemory import ReadOnlyInMemoryLDAPEntry

class MyEntry(ReadOnlyInMemoryLDAPEntry):
    pass

entry = MyEntry(dn='dc=example,dc=gs')
child = entry.addChild(rdn='ou=empty', attributes={'objectClass': ['a']})
assert isinstance(child, MyEntry)
```
This code fails as the type of the `child` entry is `ReadOnlyInMemoryLDAPEntry` though it was created as the child of `MyEntry` instance. Small bug fix for it is here.

### Contributor Checklist:

* [x] I have updated the release notes at `docs/source/NEWS.rst` 
* [x] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
