### PR TITLE
Redundant attributes keys sorting was removed from BaseLDAPEntry

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -41,6 +41,7 @@ Bugfixes
 - Proxies now terminate the connection to the proxied server in case a client immediately closes the connection.
 - asText() implemented for LDAPFilter_extensibleMatch
 - Children of ``ldaptor.inmemory.ReadOnlyInMemoryLDAPEntry`` subclass instances are added as the same class instances.
+- Redundant attributes keys sorting was removed from ``ldaptor.entry.BaseLDAPEntry`` methods.
 
 Release 16.0 (2016-06-07)
 -------------------------


### PR DESCRIPTION
Found this problem while working on Python 3 compatibility for `ldaptor.entry` module.

`toWire`, `__eq__`, `__repr__` and `diff` methods of `BaseLDAPEntry` class contained double or unnecessary attribute sorting as the `keys` and `items` methods were used in them which returned partially sorted lists of objects. `__iter__` method which yields unsorted entry attribute keys was implemented to fix this flaw.

Haven't updated unit tests as no new functionality is introduced and these methods are already heavily covered by tests.

### Contributor Checklist:

* [x] I have updated the release notes at `docs/source/NEWS.rst` 
* [ ] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
