### PR TITLE
Make sure extensibleMatch's asText() supports dnAttribute=None

### DIFF
--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -722,7 +722,7 @@ class LDAPFilter_extensibleMatch(LDAPMatchingRuleAssertion):
     def asText(self):
         return '(' + \
                (self.type.value if self.type else '') + \
-               (':dn' if self.dnAttributes.value else '') + \
+               (':dn' if self.dnAttributes and self.dnAttributes.value else '') + \
                ((':' + self.matchingRule.value) if self.matchingRule else '') + \
                ':=' + \
                self.escaper(self.matchValue.value) + \

--- a/ldaptor/test/test_ldapfilter.py
+++ b/ldaptor/test/test_ldapfilter.py
@@ -99,6 +99,16 @@ class RFC2254Examples(unittest.TestCase):
         self.assertEqual(ldapfilter.parseFilter(text), filt)
         self.assertEqual(filt.asText(), text)
 
+    def test_extensible_5(self):
+        text = '(cn:1.2.3.4.5:=Fred Flintstone)'
+        filt = pureldap.LDAPFilter_extensibleMatch(
+            type='cn',
+            dnAttributes=None,
+            matchingRule='1.2.3.4.5',
+            matchValue='Fred Flintstone',
+            )
+        self.assertEqual(filt.asText(), text)
+
     def test_escape_parens(self):
         text = r'(o=Parens R Us \28for all your parenthetical needs\29)'
         filt = pureldap.LDAPFilter_equalityMatch(


### PR DESCRIPTION
### Contributor Checklist:

* [ ] I have updated the release notes at `docs/source/NEWS.rst` 
(not updated because this is a bugfix for a feature that's already mentioned in NEWS.rst, but not yet released)
* [x] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.

(This is a bugfix for PR #112, slated for version 18.0.0.)

dnAttributes does not always have a value.