### PR TITLE
Python 3 compatibility fix for schema and fetchschema modules

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -22,7 +22,8 @@ Changes
 - ``toWire`` method is used to get bytes representation of ``ldaptor.protocols.pureber``,
   ``ldaptor.protocols.pureldap``, ``ldaptor.protocols.ldap.distinguishedname``,
   ``ldaptor.protocols.ldap.ldaperrors``, ``ldaptor.protocols.ldap.ldapclient``,
-  ``ldaptor.protocols.ldap.ldapserver``, ``ldaptor.ldiftree`` and ``ldaptor.entry`` classes
+  ``ldaptor.protocols.ldap.ldapserver``, ``ldaptor.protocols.ldap.fetchschema``,
+  ``ldaptor.schema``, ``ldaptor.ldiftree`` and ``ldaptor.entry`` classes
   instead of ``__str__`` which is deprecated now.
 - Code was updated to pass `python3 -m compileall` in preparation for py3 port.
 - Continuous test are executed only against latest related Twisted and latest

--- a/ldaptor/protocols/ldap/fetchschema.py
+++ b/ldaptor/protocols/ldap/fetchschema.py
@@ -1,6 +1,7 @@
 from ldaptor.protocols.ldap import ldaperrors, ldapsyntax
 from ldaptor.protocols import pureldap
 from ldaptor import schema
+from ldaptor._encoder import to_bytes
 
 
 def _fetchCb(subschemaSubentry, client):
@@ -19,9 +20,9 @@ def _fetchCb(subschemaSubentry, client):
             attributeTypes = []
             objectClasses = []
             for text in o.get("attributeTypes", []):
-                attributeTypes.append(schema.AttributeTypeDescription(str(text)))
+                attributeTypes.append(schema.AttributeTypeDescription(to_bytes(text)))
             for text in o.get("objectClasses", []):
-                objectClasses.append(schema.ObjectClassDescription(str(text)))
+                objectClasses.append(schema.ObjectClassDescription(to_bytes(text)))
             assert attributeTypes, "LDAP server doesn't give attributeTypes for subschemaSubentry dn=%s" % o.dn
             return (attributeTypes, objectClasses)
         else:

--- a/ldaptor/test/test_encoder.py
+++ b/ldaptor/test/test_encoder.py
@@ -6,10 +6,10 @@ from twisted.trial import unittest
 
 import six
 
-from ldaptor._encoder import to_bytes, WireStrAlias
+import ldaptor._encoder
 
 
-class WireableObject(object):
+class WireableObject(ldaptor._encoder.WireStrAlias):
     """
     Object with bytes representation as a constant toWire value
     """
@@ -26,7 +26,7 @@ class EncoderTests(unittest.TestCase):
         to get its bytes representation if it has one
         """
         obj = WireableObject()
-        self.assertEqual(to_bytes(obj), b'wire')
+        self.assertEqual(ldaptor._encoder.to_bytes(obj), b'wire')
 
     def test_unicode_object(self):
         """
@@ -34,7 +34,7 @@ class EncoderTests(unittest.TestCase):
         to to_bytes function
         """
         obj = six.u('unicode')
-        self.assertEqual(to_bytes(obj), b'unicode')
+        self.assertEqual(ldaptor._encoder.to_bytes(obj), b'unicode')
 
     def test_bytes_object(self):
         """
@@ -42,7 +42,7 @@ class EncoderTests(unittest.TestCase):
         if passed to to_bytes function
         """
         obj = b'bytes'
-        self.assertEqual(to_bytes(obj), b'bytes')
+        self.assertEqual(ldaptor._encoder.to_bytes(obj), b'bytes')
 
 
 class WireStrAliasTests(unittest.TestCase):
@@ -51,5 +51,15 @@ class WireStrAliasTests(unittest.TestCase):
         """
         WireStrAlias.toWire is an abstract method and raises NotImplementedError
         """
-        obj = WireStrAlias()
+        obj = ldaptor._encoder.WireStrAlias()
         self.assertRaises(NotImplementedError, obj.toWire)
+
+    def test_str_deprecation_warning(self):
+        """
+        WireStrAlias.__str__ generates DeprecationWarning before calling WireStrAlias.toWire method
+        """
+        obj = WireableObject()
+        msg = 'WireableObject.__str__ method is deprecated and will not be used ' \
+            'for getting bytes representation in the future releases, use ' \
+            'WireableObject.toWire instead'
+        self.assertWarns(DeprecationWarning, msg, ldaptor._encoder.__file__, obj.__str__)

--- a/ldaptor/test/test_fetchschema.py
+++ b/ldaptor/test/test_fetchschema.py
@@ -7,6 +7,8 @@ from ldaptor.protocols.ldap import fetchschema
 from ldaptor import schema
 from ldaptor.protocols import pureldap
 from ldaptor.testutil import LDAPClientTestDriver
+from ldaptor._encoder import to_bytes
+
 
 class OnWire(unittest.TestCase):
     cn = """( 2.5.4.3 NAME ( 'cn' 'commonName' ) DESC 'RFC2256: common name(s) for which the entity is known by' SUP name )"""
@@ -65,7 +67,7 @@ class OnWire(unittest.TestCase):
                           )
         self.failUnlessEqual(len(val), 2)
 
-        self.failUnlessEqual([str(x) for x in val[0]],
-                             [str(schema.AttributeTypeDescription(self.cn))])
-        self.failUnlessEqual([str(x) for x in val[1]],
-                             [str(schema.ObjectClassDescription(self.dcObject))])
+        self.failUnlessEqual([to_bytes(x) for x in val[0]],
+                             [to_bytes(schema.AttributeTypeDescription(self.cn))])
+        self.failUnlessEqual([to_bytes(x) for x in val[1]],
+                             [to_bytes(schema.ObjectClassDescription(self.dcObject))])


### PR DESCRIPTION
Greetings!

While fixing quick start example to make it Python 3 compatible I found some inconsistencies in `ldapsyntax` module. But before I can fix them I need to make its dependent `fetchschema` and `schema` modules Python 3 compatible as they were still using strings instead of explicit byte strings. Additional test cases for `test_schema` were implemented as the changes in `schema` module affected some lines not covered by tests.

### Contributor Checklist:

* [x] I have updated the release notes at `docs/source/NEWS.rst` 
* [x] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
