### PR TITLE
Python 3 compatibility fix for schema and fetchschema modules (second attempt)

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -22,7 +22,8 @@ Changes
 - ``toWire`` method is used to get bytes representation of ``ldaptor.protocols.pureber``,
   ``ldaptor.protocols.pureldap``, ``ldaptor.protocols.ldap.distinguishedname``,
   ``ldaptor.protocols.ldap.ldaperrors``, ``ldaptor.protocols.ldap.ldapclient``,
-  ``ldaptor.protocols.ldap.ldapserver``, ``ldaptor.ldiftree`` and ``ldaptor.entry`` classes
+  ``ldaptor.protocols.ldap.ldapserver``, ``ldaptor.protocols.ldap.fetchschema``,
+  ``ldaptor.schema``, ``ldaptor.ldiftree`` and ``ldaptor.entry`` classes
   instead of ``__str__`` which is deprecated now.
 - Code was updated to pass `python3 -m compileall` in preparation for py3 port.
 - Continuous test are executed only against latest related Twisted and latest

--- a/ldaptor/protocols/ldap/fetchschema.py
+++ b/ldaptor/protocols/ldap/fetchschema.py
@@ -1,6 +1,7 @@
 from ldaptor.protocols.ldap import ldaperrors, ldapsyntax
 from ldaptor.protocols import pureldap
 from ldaptor import schema
+from ldaptor._encoder import to_bytes
 
 
 def _fetchCb(subschemaSubentry, client):
@@ -19,9 +20,9 @@ def _fetchCb(subschemaSubentry, client):
             attributeTypes = []
             objectClasses = []
             for text in o.get("attributeTypes", []):
-                attributeTypes.append(schema.AttributeTypeDescription(str(text)))
+                attributeTypes.append(schema.AttributeTypeDescription(to_bytes(text)))
             for text in o.get("objectClasses", []):
-                objectClasses.append(schema.ObjectClassDescription(str(text)))
+                objectClasses.append(schema.ObjectClassDescription(to_bytes(text)))
             assert attributeTypes, "LDAP server doesn't give attributeTypes for subschemaSubentry dn=%s" % o.dn
             return (attributeTypes, objectClasses)
         else:

--- a/ldaptor/schema.py
+++ b/ldaptor/schema.py
@@ -598,8 +598,8 @@ class SyntaxDescription(ASN1ParserThingie, WireStrAlias):
 
     def _parse(self, text):
 
-        assert text[0] == b'('
-        assert text[-1] == b')'
+        assert text[:1] == b'('
+        assert text[-1:] == b')'
         text=text[1:-1]
         text = text.lstrip()
 
@@ -611,7 +611,7 @@ class SyntaxDescription(ASN1ParserThingie, WireStrAlias):
         if peekWord(text) == b"DESC":
             text = text[len(b"DESC "):]
             text = text.lstrip()
-            assert text[0] == b"'"
+            assert text[:1] == b"'"
             text = text[1:]
             end = text.index(b"'")
             self.desc = text[:end]
@@ -684,8 +684,8 @@ class MatchingRuleDescription(ASN1ParserThingie, WireStrAlias):
 
     def _parse(self, text):
 
-        assert text[0] == b'('
-        assert text[-1] == b')'
+        assert text[:1] == b'('
+        assert text[-1:] == b')'
         text = text[1:-1]
         text = text.lstrip()
 
@@ -697,12 +697,12 @@ class MatchingRuleDescription(ASN1ParserThingie, WireStrAlias):
         if peekWord(text) == b"NAME":
             text = text[len(b"NAME "):]
             text = text.lstrip()
-            if text[0] == b"'":
+            if text[:1] == b"'":
                 text = text[1:]
                 end = text.index(b"'")
                 self.name = (text[:end],)
                 text = text[end+1:]
-            elif text[0] == b"(":
+            elif text[:1] == b"(":
                 text = text[1:]
                 text = text.lstrip()
                 end = text.index(b")")
@@ -716,7 +716,7 @@ class MatchingRuleDescription(ASN1ParserThingie, WireStrAlias):
         if peekWord(text) == b"DESC":
             text = text[len(b"DESC "):]
             text = text.lstrip()
-            assert text[0] == b"'"
+            assert text[:1] == b"'"
             text = text[1:]
             end = text.index(b"'")
             self.desc = text[:end]

--- a/ldaptor/test/test_fetchschema.py
+++ b/ldaptor/test/test_fetchschema.py
@@ -7,6 +7,8 @@ from ldaptor.protocols.ldap import fetchschema
 from ldaptor import schema
 from ldaptor.protocols import pureldap
 from ldaptor.testutil import LDAPClientTestDriver
+from ldaptor._encoder import to_bytes
+
 
 class OnWire(unittest.TestCase):
     cn = """( 2.5.4.3 NAME ( 'cn' 'commonName' ) DESC 'RFC2256: common name(s) for which the entity is known by' SUP name )"""
@@ -65,7 +67,7 @@ class OnWire(unittest.TestCase):
                           )
         self.failUnlessEqual(len(val), 2)
 
-        self.failUnlessEqual([str(x) for x in val[0]],
-                             [str(schema.AttributeTypeDescription(self.cn))])
-        self.failUnlessEqual([str(x) for x in val[1]],
-                             [str(schema.ObjectClassDescription(self.dcObject))])
+        self.failUnlessEqual([to_bytes(x) for x in val[0]],
+                             [to_bytes(schema.AttributeTypeDescription(self.cn))])
+        self.failUnlessEqual([to_bytes(x) for x in val[1]],
+                             [to_bytes(schema.ObjectClassDescription(self.dcObject))])

--- a/ldaptor/test/test_server.py
+++ b/ldaptor/test/test_server.py
@@ -17,6 +17,7 @@ from ldaptor.protocols.ldap import ldapserver, ldapclient, ldaperrors, \
     fetchschema
 from ldaptor.protocols import pureldap, pureber
 from ldaptor.test import util, test_schema
+from ldaptor._encoder import to_bytes
 
 
 def wrapCommit(entry, cb, *args, **kwds):
@@ -794,13 +795,13 @@ class TestSchema(unittest.TestCase):
         (attributeTypes, objectClasses) = util.pumpingDeferredResult(d)
 
         self.failUnlessEqual(
-            [str(x) for x in attributeTypes],
-            [str(schema.AttributeTypeDescription(x)) for x in [
+            [to_bytes(x) for x in attributeTypes],
+            [to_bytes(schema.AttributeTypeDescription(x)) for x in [
                 test_schema.AttributeType_KnownValues.knownValues[0][0]]])
 
         self.failUnlessEqual(
-            [str(x) for x in objectClasses],
-            [str(schema.ObjectClassDescription(x)) for x in [
+            [to_bytes(x) for x in objectClasses],
+            [to_bytes(schema.ObjectClassDescription(x)) for x in [
                 test_schema.OBJECTCLASSES['organization'],
                 test_schema.OBJECTCLASSES['organizationalUnit']]])
 


### PR DESCRIPTION
Greetings!

While fixing quick start example to make it Python 3 compatible I found some inconsistencies in ldapsyntax module. But before I can fix them I need to make its dependent fetchschema and schema modules Python 3 compatible as they were still using strings instead of explicit byte strings. Additional test cases for test_schema were implemented as the changes in schema module affected some lines not covered by tests.

The previous PR has caused "unexpected coverage difference" (increase actually) in codecov. This one has some additional changes in `test_server` which I hope will pass.

### Contributor Checklist:

* [x] I have updated the release notes at `docs/source/NEWS.rst` 
* [x] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
