### PR TITLE
Quick start example was made agnostic to the Python version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,30 +22,34 @@ Quick Usage Example
 
 .. code-block:: python
 
-   from twisted.internet import reactor, defer
-   from ldaptor.protocols.ldap import ldapclient, ldapsyntax, ldapconnector
+    from twisted.internet import reactor, defer
+    from ldaptor.protocols.ldap import ldapclient, ldapsyntax, ldapconnector
 
-   @defer.inlineCallbacks
-   def example():
-      serverip = '192.168.128.21'
-      basedn = 'dc=example,dc=com'
-      binddn = 'bjensen@example.com'
-      bindpw = 'secret'
-      query = '(cn=Babs*)'
-      c = ldapconnector.LDAPClientCreator(reactor, ldapclient.LDAPClient)
-      overrides = {basedn: (serverip, 389)}
-      client = yield c.connect(basedn, overrides=overrides)
-      yield client.bind(binddn, bindpw)
-      o = ldapsyntax.LDAPEntry(client, basedn)
-      results = yield o.search(filterText=query)
-      for entry in results:
-         print(entry)
+    @defer.inlineCallbacks
+    def example():
+        # The following arguments may be also specified as unicode strings
+        # but it is recommended to use byte strings for ldaptor objects
+        serverip = b'192.168.128.21'
+        basedn = b'dc=example,dc=com'
+        binddn = b'bjensen@example.com'
+        bindpw = b'secret'
+        query = b'(cn=Babs*)'
+        c = ldapconnector.LDAPClientCreator(reactor, ldapclient.LDAPClient)
+        overrides = {basedn: (serverip, 389)}
+        client = yield c.connect(basedn, overrides=overrides)
+        yield client.bind(binddn, bindpw)
+        o = ldapsyntax.LDAPEntry(client, basedn)
+        results = yield o.search(filterText=query)
+        for entry in results:
+            # Received entry attributes are stored as byte strings
+            data = entry.toWire()
+            print(data.decode('utf-8'))
 
-   if __name__ == '__main__':
-      df = example()
-      df.addErrback(lambda err: err.printTraceback())
-      df.addCallback(lambda _: reactor.stop())
-      reactor.run()
+    if __name__ == '__main__':
+        df = example()
+        df.addErrback(lambda err: err.printTraceback())
+        df.addCallback(lambda _: reactor.stop())
+        reactor.run()
 
 
 Installation

--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -19,11 +19,7 @@ Changes
 
 - Using modern classmethod decorator instead of old-style method call.
 - Usage of zope.interfaces was updated in preparation for python3 port.
-- ``toWire`` method is used to get bytes representation of ``ldaptor.protocols.pureber``,
-  ``ldaptor.protocols.pureldap``, ``ldaptor.protocols.ldap.distinguishedname``,
-  ``ldaptor.protocols.ldap.ldaperrors``, ``ldaptor.protocols.ldap.ldapclient``,
-  ``ldaptor.protocols.ldap.ldapserver``, ``ldaptor.protocols.ldap.fetchschema``,
-  ``ldaptor.schema``, ``ldaptor.ldiftree`` and ``ldaptor.entry`` classes
+- ``toWire`` method is used to get bytes representation of `ldaptor` classes
   instead of ``__str__`` which is deprecated now.
 - Code was updated to pass `python3 -m compileall` in preparation for py3 port.
 - Continuous test are executed only against latest related Twisted and latest
@@ -34,6 +30,7 @@ Changes
   port.
 - Remove Python 3.3 from tox as it is EOL.
 - Add API documentation for ``LDAPAttributeSet`` and ``startTLS``.
+- Quick start example was made agnostic to the Python version.
 
 Bugfixes
 ^^^^^^^^

--- a/ldaptor/protocols/ldap/ldif.py
+++ b/ldaptor/protocols/ldap/ldif.py
@@ -18,9 +18,11 @@ import six
 
 from ldaptor._encoder import to_bytes
 
+encodestring = base64.encodestring if six.PY2 else base64.encodebytes
+
 
 def base64_encode(s):
-    return b''.join(base64.encodestring(s).split(b'\n')) + b'\n'
+    return b''.join(encodestring(s).split(b'\n')) + b'\n'
 
 
 def attributeAsLDIF_base64(attribute, value):

--- a/ldaptor/test/test_ldapsyntax.py
+++ b/ldaptor/test/test_ldapsyntax.py
@@ -560,8 +560,8 @@ class LDAPSyntaxSearch(unittest.TestCase):
                     client=client,
                     dn='cn=foo,dc=example,dc=com',
                     attributes={
-                        'foo': ['a'],
-                        'bar': ['b', 'c'],
+                        b'foo': [b'a'],
+                        b'bar': [b'b', b'c'],
                     }
                 )
             )
@@ -571,8 +571,8 @@ class LDAPSyntaxSearch(unittest.TestCase):
                     client=client,
                     dn='cn=bar,dc=example,dc=com',
                     attributes={
-                        'foo': ['a'],
-                        'bar': ['d', 'e'],
+                        b'foo': [b'a'],
+                        b'bar': [b'd', b'e'],
                     }
                 )
             )
@@ -691,8 +691,8 @@ class LDAPSyntaxSearch(unittest.TestCase):
                 client=client,
                 dn='cn=foo,dc=example,dc=com',
                 attributes={
-                'foo': ['a'],
-                'bar': ['b', 'c'],
+                b'foo': [b'a'],
+                b'bar': [b'b', b'c'],
                 }))
             self.failUnless(val[0].complete)
 
@@ -701,8 +701,8 @@ class LDAPSyntaxSearch(unittest.TestCase):
                 client=client,
                 dn='cn=bar,dc=example,dc=com',
                 attributes={
-                'foo': ['a'],
-                'bar': ['d', 'e'],
+                b'foo': [b'a'],
+                b'bar': [b'd', b'e'],
                 }))
             self.failUnless(val[1].complete)
         d.addCallback(cb)
@@ -814,13 +814,13 @@ class LDAPSyntaxSearch(unittest.TestCase):
                 client=client,
                 dn='cn=foo,dc=example,dc=com',
                 attributes={
-                'bar': ['b', 'c'],
+                b'bar': [b'b', b'c'],
                 }),
                 ldapsyntax.LDAPEntry(
                 client=client,
                 dn='cn=bar,dc=example,dc=com',
                 attributes={
-                'bar': ['b', 'c'],
+                b'bar': [b'b', b'c'],
                 })])
         d.addCallback(cb)
         return d
@@ -1530,11 +1530,11 @@ class LDAPSyntaxFetch(unittest.TestCase):
 
             has=o.keys()
             has.sort()
-            want=['foo', 'bar']
+            want=[b'foo', b'bar']
             want.sort()
             self.assertEqual(has, want)
-            self.assertEqual(o['foo'], ['a'])
-            self.assertEqual(o['bar'], ['b', 'c'])
+            self.assertEqual(o['foo'], [b'a'])
+            self.assertEqual(o['bar'], [b'b', b'c'])
         d.addCallback(cb)
         return d
 
@@ -1565,11 +1565,11 @@ class LDAPSyntaxFetch(unittest.TestCase):
 
             has=o.keys()
             has.sort()
-            want=['foo', 'bar']
+            want=[b'foo', b'bar']
             want.sort()
             self.assertEqual(has, want)
-            self.assertEqual(o['foo'], ['a'])
-            self.assertEqual(o['bar'], ['b', 'c'])
+            self.assertEqual(o['foo'], [b'a'])
+            self.assertEqual(o['bar'], [b'b', b'c'])
         d.addCallback(cb)
         return d
 
@@ -1578,8 +1578,8 @@ class LDAPSyntaxFetch(unittest.TestCase):
         client = LDAPClientTestDriver(
             [   pureldap.LDAPSearchResultEntry(objectName='cn=foo,dc=example,dc=com',
                                                attributes=(
-            ('foo', ['a']),
-            ('bar', ['b', 'c']),
+            (b'foo', [b'a']),
+            (b'bar', [b'b', b'c']),
             )),
                 pureldap.LDAPSearchResultDone(resultCode=0,
                                               matchedDN='',
@@ -1588,25 +1588,25 @@ class LDAPSyntaxFetch(unittest.TestCase):
         o=ldapsyntax.LDAPEntry(client=client,
                                dn='cn=foo,dc=example,dc=com',
                                attributes={
-            'foo': ['x'],
-            'quux': ['baz', 'xyzzy']
+            b'foo': [b'x'],
+            b'quux': [b'baz', b'xyzzy']
             })
-        d=o.fetch('foo', 'bar', 'thud')
+        d=o.fetch(b'foo', b'bar', b'thud')
         def cb(dummy):
             client.assertSent(pureldap.LDAPSearchRequest(
                 baseObject='cn=foo,dc=example,dc=com',
                 scope=pureldap.LDAP_SCOPE_baseObject,
-                attributes=('foo', 'bar', 'thud'),
+                attributes=(b'foo', b'bar', b'thud'),
                 ))
 
             has=o.keys()
             has.sort()
-            want=['foo', 'bar', 'quux']
+            want=[b'foo', b'bar', b'quux']
             want.sort()
             self.assertEqual(has, want)
-            self.assertEqual(o['foo'], ['a'])
-            self.assertEqual(o['bar'], ['b', 'c'])
-            self.assertEqual(o['quux'], ['baz', 'xyzzy'])
+            self.assertEqual(o[b'foo'], [b'a'])
+            self.assertEqual(o[b'bar'], [b'b', b'c'])
+            self.assertEqual(o[b'quux'], [b'baz', b'xyzzy'])
         d.addCallback(cb)
         return d
 


### PR DESCRIPTION
Greetings!

Quick start example now works for the both Python versions. It required several bytes/unicode fixes in `ldapsyntax` module and minor changes in the example itself.

Also made small `DeprecationWarning` fix for `ldif` module, hope you don't mind it is in the same pull request.

### Contributor Checklist:

* [x] I have updated the release notes at `docs/source/NEWS.rst` 
* [x] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
