### PR TITLE
Python 3 compatibility fix for the documentation examples

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -30,7 +30,7 @@ Changes
   port.
 - Remove Python 3.3 from tox as it is EOL.
 - Add API documentation for ``LDAPAttributeSet`` and ``startTLS``.
-- Quick start example was made agnostic to the Python version.
+- Quick start and cookbook examples were made agnostic to the Python version.
 
 Bugfixes
 ^^^^^^^^

--- a/docs/source/cookbook/client_paged_search_results.py
+++ b/docs/source/cookbook/client_paged_search_results.py
@@ -1,0 +1,126 @@
+#! /usr/bin/env python
+
+from __future__ import print_function
+import argparse
+from twisted.internet import defer
+from twisted.internet.endpoints import clientFromString, connectProtocol
+from twisted.internet.task import react
+from ldaptor.protocols.ldap.ldapclient import LDAPClient
+from ldaptor.protocols.ldap.ldapsyntax import LDAPEntry
+from ldaptor.protocols import (
+    pureber,
+    pureldap
+)
+import sys
+
+@defer.inlineCallbacks
+def onConnect(client, args):
+    binddn = args.bind_dn
+    bindpw = args.passwd_file.read().strip()
+    if args.start_tls:
+        yield client.startTLS()
+    try:
+        yield client.bind(binddn, bindpw)
+    except Exception as ex:
+        print(ex)
+        raise
+    page_size = args.page_size
+    cookie = ''
+    page = 1
+    count = 0
+    while True:
+        results, cookie = yield process_entry(
+            client,
+            args,
+            args.filter,
+            page_size=page_size,
+            cookie=cookie)
+        count += len(results)
+        print("Page {}".format(page))
+        display_results(results)
+        if len(cookie) == 0:
+            break
+        page += 1
+    print("There were {} results returned in total.".format(count))
+
+@defer.inlineCallbacks
+def process_entry(client, args, search_filter, page_size=100, cookie=''):
+    basedn = args.base_dn
+    control_value = pureber.BERSequence([
+        pureber.BERInteger(page_size),
+        pureber.BEROctetString(cookie),
+    ])
+    controls = [('1.2.840.113556.1.4.319', None, control_value)]
+    o = LDAPEntry(client, basedn)
+    results, resp_controls  = yield o.search(
+        filterText=search_filter,
+        attributes=['dn'],
+        controls=controls,
+        return_controls=True)
+    cookie = get_paged_search_cookie(resp_controls)
+    defer.returnValue((results, cookie))
+
+def display_results(results):
+    for entry in results:
+        print(entry.dn.toWire())
+
+def get_paged_search_cookie(controls):
+    """
+    Input: semi-parsed controls list from LDAP response; list of tuples (controlType, criticality, controlValue).
+    Parses the controlValue and returns the cookie as a byte string.
+    """
+    control_value = controls[0][2]
+    ber_context = pureber.BERDecoderContext()
+    ber_seq, bytes_used = pureber.berDecodeObject(ber_context, control_value)
+    raw_cookie = ber_seq[1]
+    cookie = raw_cookie.value
+    return cookie
+
+def onError(err):
+    err.printDetailedTraceback(file=sys.stderr)
+
+def main(reactor, args):
+    endpoint_str = args.endpoint
+    e = clientFromString(reactor, endpoint_str)
+    d = connectProtocol(e, LDAPClient())
+    d.addCallback(onConnect, args)
+    d.addErrback(onError)
+    return d
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="AD LDAP demo.")
+    parser.add_argument(
+        "endpoint",
+        action="store",
+        help="The Active Directory service endpoint.  See https://twistedmatrix.com/documents/current/core/howto/endpoints.html#clients")
+    parser.add_argument(
+        "bind_dn",
+        action="store",
+        help="The DN to BIND to the service as.")
+    parser.add_argument(
+        "passwd_file",
+        action="store",
+        type=argparse.FileType('r'),
+        help="A file containing the password used to log into the service.")
+    parser.add_argument(
+        "base_dn",
+        action="store",
+        help="The base DN to start from when searching.")
+    parser.add_argument(
+        "-f",
+        "--filter",
+        action='store',
+        help='LDAP filter')
+    parser.add_argument(
+        "-p",
+        "--page-size",
+        type=int,
+        action='store',
+        default=100,
+        help='Page size (default 100).')
+    parser.add_argument(
+        "--start-tls",
+        action="store_true",
+        help="Request StartTLS after connecting to the service.")
+    args = parser.parse_args()
+    react(main, [args])

--- a/docs/source/cookbook/clients.rst
+++ b/docs/source/cookbook/clients.rst
@@ -108,7 +108,7 @@ Code
 
 For `ad.example.com` domain, store the admin password in a file named
 `pass_file` and run the following example,
-where `10.20.1.2` is replaced with the IP of your AD server, and ::
+where `10.20.1.2` is replaced with the IP of your AD server::
 
     python docs/source/cookbook/client_paged_search_results.py \
         tcp:host=10.20.1.2:port=389 \

--- a/docs/source/cookbook/clients.rst
+++ b/docs/source/cookbook/clients.rst
@@ -117,6 +117,21 @@ where `10.20.1.2` is replaced with the IP of your AD server, and ::
         'CN=Users,DC=ad,DC=example,DC=com' \
         --page-size 5
 
+The output should look like::
+
+    Page 1
+    b'CN=Users,DC=ad,DC=example,DC=com'
+    b'CN=Administrator,CN=Users,DC=ad,DC=example,DC=com'
+    b'CN=Guest,CN=Users,DC=ad,DC=example,DC=com'
+    b'CN=SUPPORT_388945a0,CN=Users,DC=ad,DC=example,DC=com'
+    b'CN=HelpServicesGroup,CN=Users,DC=ad,DC=example,DC=com'
+    Page 2
+    b'CN=TelnetClients,CN=Users,DC=ad,DC=example,DC=com'
+    b'CN=krbtgt,CN=Users,DC=ad,DC=example,DC=com'
+    b'CN=Domain Computers,CN=Users,DC=ad,DC=example,DC=com'
+    There were 8 results returned in total.
+
+
 .. literalinclude:: client_paged_search_results.py
    :language: python
    :emphasize-lines: 41, 67-77

--- a/docs/source/cookbook/clients.rst
+++ b/docs/source/cookbook/clients.rst
@@ -106,134 +106,22 @@ request to process the results one page at a time.
 Code
 ''''
 
-.. code-block:: python
+For `ad.example.com` domain, store the admin password in a file named
+`pass_file` and run the following example,
+where `10.20.1.2` is replaced with the IP of your AD server, and ::
 
-    #! /usr/bin/env python
+    python docs/source/cookbook/client_paged_search_results.py \
+        tcp:host=10.20.1.2:port=389 \
+        'CN=Administrator,CN=Users,DC=ad,DC=example,DC=com' \
+        pass_file \
+        'CN=Users,DC=ad,DC=example,DC=com' \
+        --page-size 5
 
-    from __future__ import print_function
-    import argparse
-    from twisted.internet import defer
-    from twisted.internet.endpoints import clientFromString, connectProtocol
-    from twisted.internet.task import react
-    from ldaptor.protocols.ldap.ldapclient import LDAPClient
-    from ldaptor.protocols.ldap.ldapsyntax import LDAPEntry
-    from ldaptor.protocols import (
-        pureber,
-        pureldap
-    )
-    import sys
+.. literalinclude:: client_paged_search_results.py
+   :language: python
+   :emphasize-lines: 41, 67-77
+   :linenos:
 
-    @defer.inlineCallbacks
-    def onConnect(client, args):
-        binddn = args.bind_dn
-        bindpw = args.passwd_file.read().strip()
-        if args.start_tls:
-            yield client.startTLS()
-        try:
-            yield client.bind(binddn, bindpw)
-        except Exception as ex:
-            print(ex)
-            raise
-        page_size = args.page_size
-        cookie = ''
-        page = 1
-        count = 0
-        while True:
-            results, cookie = yield process_entry(
-                client, 
-                args, 
-                args.filter, 
-                page_size=page_size,
-                cookie=cookie)
-            count += len(results)
-            print("Page {}".format(page))
-            display_results(results)
-            if len(cookie) == 0:
-                break
-            page += 1
-        print("There were {} results returned in total.".format(count))
-
-    @defer.inlineCallbacks
-    def process_entry(client, args, search_filter, page_size=100, cookie=''):
-        basedn = args.base_dn
-        control_value = pureber.BERSequence([
-            pureber.BERInteger(page_size),
-            pureber.BEROctetString(cookie),
-        ])
-        controls = [('1.2.840.113556.1.4.319', None, control_value)]
-        o = LDAPEntry(client, basedn)
-        results, resp_controls  = yield o.search(
-            filterText=search_filter,
-            attributes=['dn'],
-            controls=controls,
-            return_controls=True)
-        cookie = get_paged_search_cookie(resp_controls)
-        defer.returnValue((results, cookie))
-
-    def display_results(results):
-        for entry in results:
-            print(entry.dn)
-
-    def get_paged_search_cookie(controls):
-        """
-        Input: semi-parsed controls list from LDAP response; list of tuples (controlType, criticality, controlValue).
-        Parses the controlValue and returns the cookie as a byte string.
-        """
-        control_value = controls[0][2]
-        ber_context = pureber.BERDecoderContext()
-        ber_seq, bytes_used = pureber.berDecodeObject(ber_context, control_value)
-        raw_cookie = ber_seq[1]
-        cookie = raw_cookie.value
-        return cookie 
-
-    def onError(err):
-        err.printDetailedTraceback(file=sys.stderr)
-
-    def main(reactor, args):
-        endpoint_str = args.endpoint
-        e = clientFromString(reactor, endpoint_str)
-        d = connectProtocol(e, LDAPClient())
-        d.addCallback(onConnect, args)
-        d.addErrback(onError)
-        return d
-
-    if __name__ == "__main__":
-        parser = argparse.ArgumentParser(description="AD LDAP demo.")
-        parser.add_argument(
-            "endpoint",
-            action="store",
-            help="The Active Directory service endpoint.  See https://twistedmatrix.com/documents/current/core/howto/endpoints.html#clients")
-        parser.add_argument(
-            "bind_dn",
-            action="store",
-            help="The DN to BIND to the service as.")
-        parser.add_argument(
-            "passwd_file",
-            action="store",
-            type=argparse.FileType('r'),
-            help="A file containing the password used to log into the service.")
-        parser.add_argument(
-            "base_dn",
-            action="store",
-            help="The base DN to start from when searching.")
-        parser.add_argument(
-            "-f",
-            "--filter",
-            action='store',
-            help='LDAP filter')
-        parser.add_argument(
-            "-p",
-            "--page-size",
-            type=int,
-            action='store',
-            default=100,
-            help='Page size (default 100).')
-        parser.add_argument(
-            "--start-tls",
-            action="store_true",
-            help="Request StartTLS after connecting to the service.")
-        args = parser.parse_args()
-        react(main, [args])
 
 ''''''''''
 Discussion

--- a/ldaptor/protocols/ldap/ldapserver.py
+++ b/ldaptor/protocols/ldap/ldapserver.py
@@ -250,7 +250,7 @@ class LDAPServer(BaseLDAPServer):
     def _cbSearchGotBase(self, base, dn, request, reply):
         def _sendEntryToClient(entry):
             requested_attribs = request.attributes
-            if len(requested_attribs) > 0 and '*' not in requested_attribs:
+            if len(requested_attribs) > 0 and b'*' not in requested_attribs:
                 filtered_attribs = [
                     (k, entry.get(k)) for k in requested_attribs if k in entry]
             else:

--- a/ldaptor/test/test_server.py
+++ b/ldaptor/test/test_server.py
@@ -469,6 +469,29 @@ class LDAPServerTest(unittest.TestCase):
                     pureldap.LDAPSearchResultDone(resultCode=0),
                     id=2).toWire()])
 
+    def test_search_all_attributes(self):
+        self.server.dataReceived(
+            pureldap.LDAPMessage(
+                pureldap.LDAPSearchRequest(
+                    baseObject='cn=thingie,ou=stuff,dc=example,dc=com',
+                    attributes=['*']
+                ),
+                id=2).toWire()
+        )
+        six.assertCountEqual(self,
+             self._makeResultList(self.server.transport.value()),
+             [
+                 pureldap.LDAPMessage(
+                     pureldap.LDAPSearchResultEntry(
+                         objectName='cn=thingie,ou=stuff,dc=example,dc=com',
+                         attributes=[
+                             ('objectClass', ['a', 'b']),
+                             ('cn', ['thingie'])]),
+                     id=2).toWire(),
+                 pureldap.LDAPMessage(
+                     pureldap.LDAPSearchResultDone(resultCode=0),
+                     id=2).toWire()])
+
     def test_rootDSE(self):
         self.server.dataReceived(
             pureldap.LDAPMessage(

--- a/ldaptor/test/test_server.py
+++ b/ldaptor/test/test_server.py
@@ -116,6 +116,51 @@ class LDAPServerTest(unittest.TestCase):
             value.append(o.toWire())
         return value
 
+    def makeSearch(self, baseObject=None, scope=None, derefAliases=None,
+                    sizeLimit=None, timeLimit=None, typesOnly=None,
+                    filter=None, attributes=None, tag=None):
+        """Shortcut for sending LDAPSearchRequest to the test server"""
+        self.server.dataReceived(
+            pureldap.LDAPMessage(
+                pureldap.LDAPSearchRequest(baseObject=baseObject, scope=scope, derefAliases=derefAliases,
+                                           sizeLimit=sizeLimit, timeLimit=timeLimit, typesOnly=typesOnly,
+                                           filter=filter, attributes=attributes, tag=tag),
+                id=2,
+            ).toWire()
+        )
+
+    def assertSearchResults(self, results=None, resultCode=0):
+        """
+        Shortcut for checking results returned by test server on LDAPSearchRequest.
+        Results must be prepared as a list of dictionaries with 'objectName' and 'attributes' keys
+        """
+        if results is None:
+            results = []
+
+        messages = []
+
+        for result in results:
+            message = pureldap.LDAPMessage(
+                pureldap.LDAPSearchResultEntry(
+                    objectName=result['objectName'],
+                    attributes=result['attributes']
+                ),
+                id=2
+            )
+            messages.append(message)
+
+        messages.append(
+            pureldap.LDAPMessage(
+                pureldap.LDAPSearchResultDone(resultCode=resultCode),
+                id=2
+            )
+        )
+        six.assertCountEqual(
+            self,
+            self._makeResultList(self.server.transport.value()),
+            [msg.toWire() for msg in messages]
+        )
+
     def test_bind(self):
         self.server.dataReceived(
             pureldap.LDAPMessage(pureldap.LDAPBindRequest(), id=4).toWire())
@@ -286,236 +331,184 @@ class LDAPServerTest(unittest.TestCase):
                 id=2).toWire())
 
     def test_search_outOfTree(self):
-        self.server.dataReceived(
-            pureldap.LDAPMessage(
-                pureldap.LDAPSearchRequest(
-                    baseObject='dc=invalid'),
-                id=2).toWire())
-        self.assertEqual(
-            self.server.transport.value(),
-            pureldap.LDAPMessage(
-                pureldap.LDAPSearchResultDone(
-                    resultCode=ldaperrors.LDAPNoSuchObject.resultCode),
-                id=2).toWire())
+        """Attempt to get nonexistent DN results in noSuchObject error response"""
+        self.makeSearch(baseObject='dc=invalid')
+        self.assertSearchResults(resultCode=ldaperrors.LDAPNoSuchObject.resultCode)
 
     def test_search_matchAll_oneResult(self):
-        self.server.dataReceived(
-            pureldap.LDAPMessage(
-                pureldap.LDAPSearchRequest(
-                    baseObject='cn=thingie,ou=stuff,dc=example,dc=com'),
-                id=2).toWire())
-        six.assertCountEqual(self,
-            self._makeResultList(self.server.transport.value()),
-            [
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchResultEntry(
-                        objectName='cn=thingie,ou=stuff,dc=example,dc=com',
-                        attributes=[
-                            ('objectClass', ['a', 'b']),
-                            ('cn', ['thingie'])]),
-                    id=2).toWire(),
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchResultDone(resultCode=0),
-                    id=2).toWire()])
+        """Searching for a single object with receiving all its attributes"""
+        self.makeSearch(baseObject='cn=thingie,ou=stuff,dc=example,dc=com')
+        self.assertSearchResults([
+            {
+                'objectName': 'cn=thingie,ou=stuff,dc=example,dc=com',
+                'attributes': [
+                    ('objectClass', ['a', 'b']),
+                    ('cn', ['thingie']),
+                ]
+            }
+        ])
 
     def test_search_matchAll_oneResult_filtered(self):
-        self.server.dataReceived(
-            pureldap.LDAPMessage(
-                pureldap.LDAPSearchRequest(
-                    baseObject='cn=thingie,ou=stuff,dc=example,dc=com',
-                    attributes=['cn']),
-                id=2).toWire())
-        six.assertCountEqual(self,
-            self._makeResultList(self.server.transport.value()),
-            [
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchResultEntry(
-                        objectName='cn=thingie,ou=stuff,dc=example,dc=com',
-                        attributes=[
-                            ('cn', ['thingie'])]),
-                    id=2).toWire(),
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchResultDone(resultCode=0),
-                    id=2).toWire()])
+        """Searching for a single object with receiving a specified set of its attributes"""
+        self.makeSearch(
+            baseObject='cn=thingie,ou=stuff,dc=example,dc=com',
+            attributes=['cn']
+        )
+        self.assertSearchResults([
+            {
+                'objectName': 'cn=thingie,ou=stuff,dc=example,dc=com',
+                'attributes': [
+                    ('cn', ['thingie']),
+                ]
+            }
+        ])
 
     def test_search_matchAll_oneResult_filteredNoAttribsRemaining(self):
-        self.server.dataReceived(
-            pureldap.LDAPMessage(
-                pureldap.LDAPSearchRequest(
-                    baseObject='cn=thingie,ou=stuff,dc=example,dc=com',
-                    attributes=['xyzzy']),
-                id=2).toWire())
-        self.assertEqual(
-            self.server.transport.value(),
-            pureldap.LDAPMessage(
-                pureldap.LDAPSearchResultDone(resultCode=0),
-                id=2).toWire())
+        """
+        Attempt to search an existing object with a set of nonexistent attributes
+        results in an empty successful response
+        """
+        self.makeSearch(
+            baseObject='cn=thingie,ou=stuff,dc=example,dc=com',
+            attributes=['xyzzy']
+        )
+        self.assertSearchResults()
 
     def test_search_matchAll_manyResults(self):
-        self.server.dataReceived(
-            pureldap.LDAPMessage(
-                pureldap.LDAPSearchRequest(
-                    baseObject='ou=stuff,dc=example,dc=com'), id=2).toWire())
-
-        six.assertCountEqual(self,
-            [
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchResultEntry(
-                        objectName='ou=stuff,dc=example,dc=com',
-                        attributes=[
-                            ('objectClass', ['a', 'b']),
-                            ('ou', ['stuff'])]),
-                    id=2).toWire(),
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchResultEntry(
-                        objectName='cn=another,ou=stuff,dc=example,dc=com',
-                        attributes=[
-                            ('objectClass', ['a', 'b']),
-                            ('cn', ['another'])]),
-                    id=2).toWire(),
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchResultEntry(
-                        objectName='cn=thingie,ou=stuff,dc=example,dc=com',
-                        attributes=[
-                            ('objectClass', ['a', 'b']),
-                            ('cn', ['thingie'])]),
-                    id=2).toWire(),
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchResultDone(resultCode=0),
-                    id=2).toWire()],
-            self._makeResultList(self.server.transport.value()))
+        """Searching for a tree object with receiving it and all its children (default scope)"""
+        self.makeSearch(baseObject='ou=stuff,dc=example,dc=com')
+        self.assertSearchResults([
+            {
+                'objectName': 'ou=stuff,dc=example,dc=com',
+                'attributes': [
+                    ('objectClass', ['a', 'b']),
+                    ('ou', ['stuff']),
+                ]
+            },
+            {
+                'objectName': 'cn=another,ou=stuff,dc=example,dc=com',
+                'attributes': [
+                    ('objectClass', ['a', 'b']),
+                    ('cn', ['another']),
+                ]
+            },
+            {
+                'objectName': 'cn=thingie,ou=stuff,dc=example,dc=com',
+                'attributes': [
+                    ('objectClass', ['a', 'b']),
+                    ('cn', ['thingie']),
+                ]
+            }
+        ])
 
     def test_search_scope_oneLevel(self):
-        self.server.dataReceived(
-            pureldap.LDAPMessage(
-                pureldap.LDAPSearchRequest(
-                    baseObject='ou=stuff,dc=example,dc=com',
-                    scope=pureldap.LDAP_SCOPE_singleLevel),
-                id=2).toWire())
-        six.assertCountEqual(self,
-            self._makeResultList(self.server.transport.value()),
-            [
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchResultEntry(
-                        objectName='cn=thingie,ou=stuff,dc=example,dc=com',
-                        attributes=[
-                            ('objectClass', ['a', 'b']),
-                            ('cn', ['thingie'])]),
-                    id=2).toWire(),
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchResultEntry(
-                        objectName='cn=another,ou=stuff,dc=example,dc=com',
-                        attributes=[
-                            ('objectClass', ['a', 'b']),
-                            ('cn', ['another'])]),
-                    id=2).toWire(),
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchResultDone(resultCode=0),
-                    id=2).toWire()])
+        """Searching for a tree object with receiving its children but without parent itself"""
+        self.makeSearch(
+            baseObject='ou=stuff,dc=example,dc=com',
+            scope=pureldap.LDAP_SCOPE_singleLevel
+        )
+        self.assertSearchResults([
+            {
+                'objectName': 'cn=thingie,ou=stuff,dc=example,dc=com',
+                'attributes': [
+                    ('objectClass', ['a', 'b']),
+                    ('cn', ['thingie']),
+                ]
+            },
+            {
+                'objectName': 'cn=another,ou=stuff,dc=example,dc=com',
+                'attributes': [
+                    ('objectClass', ['a', 'b']),
+                    ('cn', ['another']),
+                ]
+            }
+        ])
 
     def test_search_scope_wholeSubtree(self):
-        self.server.dataReceived(
-            pureldap.LDAPMessage(
-                pureldap.LDAPSearchRequest(
-                    baseObject='ou=stuff,dc=example,dc=com',
-                    scope=pureldap.LDAP_SCOPE_wholeSubtree),
-                id=2).toWire())
-        six.assertCountEqual(self,
-            self._makeResultList(self.server.transport.value()),
-            [
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchResultEntry(
-                        objectName='ou=stuff,dc=example,dc=com',
-                        attributes=[
-                            ('objectClass', ['a', 'b']),
-                            ('ou', ['stuff'])]),
-                    id=2).toWire(),
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchResultEntry(
-                        objectName='cn=another,ou=stuff,dc=example,dc=com',
-                        attributes=[
-                            ('objectClass', ['a', 'b']),
-                            ('cn', ['another'])]),
-                    id=2).toWire(),
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchResultEntry(
-                        objectName='cn=thingie,ou=stuff,dc=example,dc=com',
-                        attributes=[
-                            ('objectClass', ['a', 'b']),
-                            ('cn', ['thingie'])]),
-                    id=2).toWire(),
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchResultDone(resultCode=0),
-                    id=2).toWire()])
+        """
+        Searching for a tree object with receiving it and all its children.
+        This is a default behavior but here it is explicitly specified.
+        """
+        self.makeSearch(
+            baseObject='ou=stuff,dc=example,dc=com',
+            scope=pureldap.LDAP_SCOPE_wholeSubtree
+        )
+        self.assertSearchResults([
+            {
+                'objectName': 'ou=stuff,dc=example,dc=com',
+                'attributes': [
+                    ('objectClass', ['a', 'b']),
+                    ('ou', ['stuff']),
+                ]
+            },
+            {
+                'objectName': 'cn=another,ou=stuff,dc=example,dc=com',
+                'attributes': [
+                    ('objectClass', ['a', 'b']),
+                    ('cn', ['another']),
+                ]
+            },
+            {
+                'objectName': 'cn=thingie,ou=stuff,dc=example,dc=com',
+                'attributes': [
+                    ('objectClass', ['a', 'b']),
+                    ('cn', ['thingie']),
+                ]
+            }
+        ])
 
     def test_search_scope_baseObject(self):
-        self.server.dataReceived(
-            pureldap.LDAPMessage(
-                pureldap.LDAPSearchRequest(
-                    baseObject='ou=stuff,dc=example,dc=com',
-                    scope=pureldap.LDAP_SCOPE_baseObject),
-                id=2).toWire())
-        six.assertCountEqual(self,
-            self._makeResultList(self.server.transport.value()),
-            [
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchResultEntry(
-                        objectName='ou=stuff,dc=example,dc=com',
-                        attributes=[
-                            ('objectClass', ['a', 'b']),
-                            ('ou', ['stuff'])]),
-                    id=2).toWire(),
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchResultDone(resultCode=0),
-                    id=2).toWire()])
+        """Searching for a tree object with receiving it without its children"""
+        self.makeSearch(
+            baseObject='ou=stuff,dc=example,dc=com',
+            scope=pureldap.LDAP_SCOPE_baseObject
+        )
+        self.assertSearchResults([
+            {
+                'objectName': 'ou=stuff,dc=example,dc=com',
+                'attributes': [
+                    ('objectClass', ['a', 'b']),
+                    ('ou', ['stuff']),
+                ]
+            }
+        ])
 
     def test_search_all_attributes(self):
-        self.server.dataReceived(
-            pureldap.LDAPMessage(
-                pureldap.LDAPSearchRequest(
-                    baseObject='cn=thingie,ou=stuff,dc=example,dc=com',
-                    attributes=['*']
-                ),
-                id=2).toWire()
+        """
+        Search request with the list of attributes passed as '*'
+        returns objects with all their attributes
+        """
+        self.makeSearch(
+            baseObject='cn=thingie,ou=stuff,dc=example,dc=com',
+            attributes=['*']
         )
-        six.assertCountEqual(self,
-             self._makeResultList(self.server.transport.value()),
-             [
-                 pureldap.LDAPMessage(
-                     pureldap.LDAPSearchResultEntry(
-                         objectName='cn=thingie,ou=stuff,dc=example,dc=com',
-                         attributes=[
-                             ('objectClass', ['a', 'b']),
-                             ('cn', ['thingie'])]),
-                     id=2).toWire(),
-                 pureldap.LDAPMessage(
-                     pureldap.LDAPSearchResultDone(resultCode=0),
-                     id=2).toWire()])
+        self.assertSearchResults([
+            {
+                'objectName': 'cn=thingie,ou=stuff,dc=example,dc=com',
+                'attributes': [
+                     ('objectClass', ['a', 'b']),
+                     ('cn', ['thingie']),
+                ]
+            }
+        ])
 
     def test_rootDSE(self):
-        self.server.dataReceived(
-            pureldap.LDAPMessage(
-                pureldap.LDAPSearchRequest(
-                    baseObject='',
-                    scope=pureldap.LDAP_SCOPE_baseObject,
-                    filter=pureldap.LDAPFilter_present('objectClass')),
-                id=2).toWire())
-        six.assertCountEqual(self,
-            self._makeResultList(self.server.transport.value()),
-            [
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchResultEntry(
-                        objectName='',
-                        attributes=[
-                            ('supportedLDAPVersion', ['3']),
-                            ('namingContexts', ['dc=example,dc=com']),
-                            ('supportedExtension',
-                                [pureldap.LDAPPasswordModifyRequest.oid])]),
-                    id=2).toWire(),
-                pureldap.LDAPMessage(
-                    pureldap.LDAPSearchResultDone(
-                        resultCode=ldaperrors.Success.resultCode),
-                    id=2).toWire()])
+        """Searching for a root object"""
+        self.makeSearch(
+            baseObject='',
+            scope=pureldap.LDAP_SCOPE_baseObject,
+            filter=pureldap.LDAPFilter_present('objectClass')
+        )
+        self.assertSearchResults([
+            {
+                'objectName': '',
+                'attributes': [
+                    ('supportedLDAPVersion', ['3']),
+                    ('namingContexts', ['dc=example,dc=com']),
+                    ('supportedExtension', [pureldap.LDAPPasswordModifyRequest.oid]),
+                ]
+            }
+        ])
 
     def test_delete(self):
         self.server.dataReceived(


### PR DESCRIPTION
Greetings!

Documentation examples were tested for Python 2.7 and 3.5. Quick start and client examples were fixed to support Python 3. Server, proxy and merger examples were already correct.

I did not test [Searching with the Paged Search Result Control](https://ldaptor.readthedocs.io/en/latest/cookbook/clients.html#searching-with-the-paged-search-result-control) example: it looks like it should be tested with Active Directory server but I have no one :)

### Contributor Checklist:

* [x] I have updated the release notes at `docs/source/NEWS.rst` 
* [x] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
