### PR TITLE
DeprecationWarning stacklevel for Python 3 compatibility classes

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Release 19.1 (Unreleased)
+-------------------------
+
+Bugfixes
+^^^^^^^^
+
+- ``DeprecationWarning`` stacklevel was set to mark the caller of the deprecated
+  methods of the ``ldaptor._encoder`` classes.
 
 Release 19.0 (2019-03-05)
 -------------------------

--- a/ldaptor/_encoder.py
+++ b/ldaptor/_encoder.py
@@ -58,7 +58,7 @@ class WireStrAlias(object):
         warnings.warn('{0}.__str__ method is deprecated and will not be used '
                       'for getting bytes representation in the future '
                       'releases, use {0}.toWire instead'.format(self.__class__.__name__),
-                      category=DeprecationWarning)
+                      category=DeprecationWarning, stacklevel=2)
         warnings.simplefilter('default', DeprecationWarning)
         return self.toWire()
 
@@ -77,7 +77,7 @@ class TextStrAlias(object):
         warnings.warn('{0}.__str__ method is deprecated and will not be used '
                       'for getting human readable representation in the future '
                       'releases, use {0}.getText instead'.format(self.__class__.__name__),
-                      category=DeprecationWarning)
+                      category=DeprecationWarning, stacklevel=2)
         warnings.simplefilter('default', DeprecationWarning)
         text = self.getText()
         return to_bytes(text) if six.PY2 else text

--- a/ldaptor/test/test_encoder.py
+++ b/ldaptor/test/test_encoder.py
@@ -67,11 +67,14 @@ class WireStrAliasTests(unittest.TestCase):
 class TextStrAliasTests(unittest.TestCase):
 
     def test_deprecation_warning(self):
-        obj = TextObject()
+        str(TextObject())
         msg = 'TextObject.__str__ method is deprecated and will not be used ' \
               'for getting human readable representation in the future ' \
               'releases, use TextObject.getText instead'
-        self.assertWarns(DeprecationWarning, msg, ldaptor._encoder.__file__, obj.__str__)
+        warnings = self.flushWarnings()
+        self.assertEqual(len(warnings), 1)
+        self.assertEqual(warnings[0]['category'], DeprecationWarning)
+        self.assertEqual(warnings[0]['message'], msg)
 
     def test_getText_not_implemented(self):
         """


### PR DESCRIPTION
`DeprecationWarning` stacklevel was set for the `ldaptor._encoder` classes to show the actual caller of the deprecated methods.

### Contributor Checklist:

* [x] I have updated the release notes at `docs/source/NEWS.rst` 
* [x] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
