### PR TITLE
LDAPSearchResultReference basic implementation

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -4,11 +4,17 @@ Changelog
 Release 19.1 (Unreleased)
 -------------------------
 
+Features
+^^^^^^^^
+
+- Basic implementation of ``ldaptor.protocols.pureldap.LDAPSearchResultReference``.
+
 Bugfixes
 ^^^^^^^^
 
 - ``DeprecationWarning`` stacklevel was set to mark the caller of the deprecated
   methods of the ``ldaptor._encoder`` classes.
+- ``NotImplementedError`` for ``ldaptor.protocols.pureldap.LDAPSearchResultReference`` was fixed.
 
 Release 19.0 (2019-03-05)
 -------------------------

--- a/ldaptor/test/test_pureldap.py
+++ b/ldaptor/test/test_pureldap.py
@@ -211,6 +211,21 @@ class KnownValues(unittest.TestCase):
          [0x42, 0x00]
         ),
 
+        (pureldap.LDAPSearchResultReference,
+         [],
+         {'uris': [pureldap.LDAPString(b'ldap://example.com/dc=foo,dc=example,dc=com'),
+                   pureldap.LDAPString(b'ldap://example.com/dc=bar,dc=example,dc=com')]
+          },
+         None,
+         [0x73, 90]
+         + [0x04]
+         + [len(b'ldap://example.com/dc=foo,dc=example,dc=com')]
+         + l(b'ldap://example.com/dc=foo,dc=example,dc=com')
+         + [0x04]
+         + [len(b'ldap://example.com/dc=bar,dc=example,dc=com')]
+         + l(b'ldap://example.com/dc=bar,dc=example,dc=com'),
+        ),
+
         (pureldap.LDAPSearchResultDone,
          [],
          {'resultCode': 0,
@@ -1074,6 +1089,18 @@ class TestRepresentations(unittest.TestCase):
                 objectName='uid=mohamed,ou=people,dc=example,dc=fr',
                 attributes=[
                     ('uid', ['mohamed'])
+                ],
+                tag=tag
+            )
+            repr(resp)
+
+    def test_search_result_reference_repr(self):
+        tags = [pureldap.LDAPSearchResultReference.tag, 'tag']
+        for tag in tags:
+            resp = pureldap.LDAPSearchResultReference(
+                uris=[
+                    pureldap.LDAPString(b'ldap://example.com/dc=foo,dc=example,dc=com'),
+                    pureldap.LDAPString(b'ldap://example.com/dc=foo,dc=example,dc=com')
                 ],
                 tag=tag
             )


### PR DESCRIPTION
This PR is a fix for issue #144 . `LDAPSearchResultReference` class was not fully implemented and did not have tests before (so I accidently broke it while porting `pureldap` code for Python 3). I attempted to implement it accordingly to the [RFC](https://tools.ietf.org/html/rfc4511#section-4.5.3) but not sure if it really works: I need a LDAP server with this feature to test it (Active Directory for example).

### Contributor Checklist:

* [x] I have updated the release notes at `docs/source/NEWS.rst` 
* [x] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
