### PR TITLE
LDAPException.__str__ method was returned

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -4,11 +4,19 @@ Changelog
 Release 19.1 (Unreleased)
 -------------------------
 
+Features
+^^^^^^^^
+
+- Explicit ``ldaptor.protocols.ldap.ldaperrors`` classes declaration was made
+  to allow syntax highlighting for this module.
+
 Bugfixes
 ^^^^^^^^
 
 - ``DeprecationWarning`` stacklevel was set to mark the caller of the deprecated
   methods of the ``ldaptor._encoder`` classes.
+- Regression bug with ``LDAPException`` instances was fixed (``ldaptor.protocols.ldap.ldapclient``
+  exceptions failed to get their string representations).
 
 Release 19.0 (2019-03-05)
 -------------------------

--- a/ldaptor/protocols/ldap/ldaperrors.py
+++ b/ldaptor/protocols/ldap/ldaperrors.py
@@ -13,25 +13,43 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-# make pyflakes not complain about undefined names
+import six
 
-from ldaptor._encoder import WireStrAlias, to_bytes
-
-reverse = None
-LDAPOther = None
+from ldaptor._encoder import to_bytes
 
 
 def get(resultCode, errorMessage):
     """Get an instance of the correct exception for this resultCode."""
-
-    klass = reverse.get(resultCode)
-    if klass is not None:
-        return klass(errorMessage)
-    else:
-        return LDAPUnknownError(resultCode, errorMessage)
+    return LDAPExceptionCollection.get_instance(resultCode, errorMessage)
 
 
-class LDAPResult:
+class LDAPExceptionCollection(type):
+    """
+    Storage for the LDAP result codes and
+    the corresponding classes.
+    """
+
+    collection = {}
+
+    def __new__(mcs, name, bases, attributes):
+        cls = type.__new__(mcs, name, bases, attributes)
+        code = attributes.get('resultCode')
+        if code is not None:
+            assert isinstance(code, int)
+            assert isinstance(attributes.get('name'), bytes)
+            mcs.collection[code] = cls
+        return cls
+
+    @classmethod
+    def get_instance(mcs, code, message):
+        """Get an instance of the correct exception for this result code."""
+        cls = mcs.collection.get(code)
+        if cls is not None:
+            return cls(message)
+        return LDAPUnknownError(code, message)
+
+
+class LDAPResult(six.with_metaclass(LDAPExceptionCollection)):
     resultCode = None
     name = None
 
@@ -44,35 +62,26 @@ class Success(LDAPResult):
         pass
 
 
-class LDAPException(WireStrAlias, Exception, LDAPResult):
-
-    def _get_message(self):
-        return self.__message
-
-    def _set_message(self, value):
-        self.__message = value
-
-    message = property(_get_message, _set_message)
-
+class LDAPException(Exception, LDAPResult):
     def __init__(self, message=None):
         Exception.__init__(self)
         self.message = message
 
+    def __str__(self):
+        message = self.toWire()
+        return message if six.PY2 else message.decode('utf-8')
+
     def toWire(self):
-        message = self.message
-        if message:
-            return b'%s: %s' % (self.name, to_bytes(message))
-        elif self.name:
+        if self.message:
+            return b'%s: %s' % (self.name, to_bytes(self.message))
+        if self.name:
             return self.name
-        else:
-            return b'Unknown LDAP error %r' % self
+        return b'Unknown LDAP error %r' % self
 
 
 class LDAPUnknownError(LDAPException):
-    resultCode = None
-
     def __init__(self, resultCode, message=None):
-        assert resultCode not in reverse, \
+        assert resultCode not in LDAPExceptionCollection.collection, \
             "resultCode %r must be unknown" % resultCode
         self.code = resultCode
         LDAPException.__init__(self, message)
@@ -85,74 +94,212 @@ class LDAPUnknownError(LDAPException):
             return codeName
 
 
-def init(**errors):
-    global reverse
-    reverse = {}
-    for name, value in errors.items():
-        if value == errors['success']:
-            klass = Success
-        else:
-            classname = 'LDAP'+name[0].upper()+name[1:]
-            klass = type(
-                classname,
-                (LDAPException,),
-                {
-                    'resultCode': value,
-                    'name': to_bytes(name),
-                    },
-                )
-            globals()[classname] = klass
-        reverse[value] = klass
+class LDAPOperationsError(LDAPException):
+    resultCode = 1
+    name = b'operationsError'
 
 
-init(
-    success=0,
-    operationsError=1,
-    protocolError=2,
-    timeLimitExceeded=3,
-    sizeLimitExceeded=4,
-    compareFalse=5,
-    compareTrue=6,
-    authMethodNotSupported=7,
-    strongAuthRequired=8,
-    # 9 reserved
-    referral=10,
-    adminLimitExceeded=11,
-    unavailableCriticalExtension=12,
-    confidentialityRequired=13,
-    saslBindInProgress=14,
-    noSuchAttribute=16,
-    undefinedAttributeType=17,
-    inappropriateMatching=18,
-    constraintViolation=19,
-    attributeOrValueExists=20,
-    invalidAttributeSyntax=21,
-    # 22-31 unused
-    noSuchObject=32,
-    aliasProblem=33,
-    invalidDNSyntax=34,
-    # 35 reserved for undefined isLeaf
-    aliasDereferencingProblem=36,
-    # 37-47 unused
-    inappropriateAuthentication=48,
-    invalidCredentials=49,
-    insufficientAccessRights=50,
-    busy=51,
-    unavailable=52,
-    unwillingToPerform=53,
-    loopDetect=54,
-    # 55-63 unused
-    namingViolation=64,
-    objectClassViolation=65,
-    notAllowedOnNonLeaf=66,
-    notAllowedOnRDN=67,
-    entryAlreadyExists=68,
-    objectClassModsProhibited=69,
-    # 70 reserved for CLDAP
-    affectsMultipleDSAs=71,
-    # 72-79 unused
-    other=80,
-    # 81-90 reserved for APIs
-    )
+class LDAPProtocolError(LDAPException):
+    resultCode = 2
+    name = b'protocolError'
 
+
+class LDAPTimeLimitExceeded(LDAPException):
+    resultCode = 3
+    name = b'timeLimitExceeded'
+
+
+class LDAPSizeLimitExceeded(LDAPException):
+    resultCode = 4
+    name = b'sizeLimitExceeded'
+
+
+class LDAPCompareFalse(LDAPException):
+    resultCode = 5
+    name = b'compareFalse'
+
+
+class LDAPCompareTrue(LDAPException):
+    resultCode = 6
+    name = b'compareTrue'
+
+
+class LDAPAuthMethodNotSupported(LDAPException):
+    resultCode = 7
+    name = b'authMethodNotSupported'
+
+
+class LDAPStrongAuthRequired(LDAPException):
+    resultCode = 8
+    name = b'strongAuthRequired'
+
+# 9 reserved
+
+
+class LDAPReferral(LDAPException):
+    resultCode = 10
+    name = b'referral'
+
+
+class LDAPAdminLimitExceeded(LDAPException):
+    resultCode = 11
+    name = b'adminLimitExceeded'
+
+
+class LDAPUnavailableCriticalExtension(LDAPException):
+    resultCode = 12
+    name = b'unavailableCriticalExtension'
+
+
+class LDAPConfidentialityRequired(LDAPException):
+    resultCode = 13
+    name = b'confidentialityRequired'
+
+
+class LDAPSaslBindInProgress(LDAPException):
+    resultCode = 14
+    name = b'saslBindInProgress'
+
+
+class LDAPNoSuchAttribute(LDAPException):
+    resultCode = 16
+    name = b'noSuchAttribute'
+
+
+class LDAPUndefinedAttributeType(LDAPException):
+    resultCode = 17
+    name = b'undefinedAttributeType'
+
+
+class LDAPInappropriateMatching(LDAPException):
+    resultCode = 18
+    name = b'inappropriateMatching'
+
+
+class LDAPConstraintViolation(LDAPException):
+    resultCode = 19
+    name = b'constraintViolation'
+
+
+class LDAPAttributeOrValueExists(LDAPException):
+    resultCode = 20
+    name = b'attributeOrValueExists'
+
+
+class LDAPInvalidAttributeSyntax(LDAPException):
+    resultCode = 21
+    name = b'invalidAttributeSyntax'
+
+# 22-31 unused
+
+
+class LDAPNoSuchObject(LDAPException):
+    resultCode = 32
+    name = b'noSuchObject'
+
+
+class LDAPAliasProblem(LDAPException):
+    resultCode = 33
+    name = b'aliasProblem'
+
+
+class LDAPInvalidDNSyntax(LDAPException):
+    resultCode = 34
+    name = b'invalidDNSyntax'
+
+# 35 reserved for undefined isLeaf
+
+
+class LDAPAliasDereferencingProblem(LDAPException):
+    resultCode = 36
+    name = b'aliasDereferencingProblem'
+
+# 37-47 unused
+
+
+class LDAPInappropriateAuthentication(LDAPException):
+    resultCode = 48
+    name = b'inappropriateAuthentication'
+
+
+class LDAPInvalidCredentials(LDAPException):
+    resultCode = 49
+    name = b'invalidCredentials'
+
+
+class LDAPInsufficientAccessRights(LDAPException):
+    resultCode = 50
+    name = b'insufficientAccessRights'
+
+
+class LDAPBusy(LDAPException):
+    resultCode = 51
+    name = b'busy'
+
+
+class LDAPUnavailable(LDAPException):
+    resultCode = 52
+    name = b'unavailable'
+
+
+class LDAPUnwillingToPerform(LDAPException):
+    resultCode = 53
+    name = b'unwillingToPerform'
+
+
+class LDAPLoopDetect(LDAPException):
+    resultCode = 54
+    name = b'loopDetect'
+
+# 55-63 unused
+
+
+class LDAPNamingViolation(LDAPException):
+    resultCode = 64
+    name = b'namingViolation'
+
+
+class LDAPObjectClassViolation(LDAPException):
+    resultCode = 65
+    name = b'objectClassViolation'
+
+
+class LDAPNotAllowedOnNonLeaf(LDAPException):
+    resultCode = 66
+    name = b'notAllowedOnNonLeaf'
+
+
+class LDAPNotAllowedOnRDN(LDAPException):
+    resultCode = 67
+    name = b'notAllowedOnRDN'
+
+
+class LDAPEntryAlreadyExists(LDAPException):
+    resultCode = 68
+    name = b'entryAlreadyExists'
+
+
+class LDAPObjectClassModsProhibited(LDAPException):
+    resultCode = 69
+    name = b'objectClassModsProhibited'
+
+# 70 reserved for CLDAP
+
+
+class LDAPAffectsMultipleDSAs(LDAPException):
+    resultCode = 71
+    name = b'affectsMultipleDSAs'
+
+# 72-79 unused
+
+
+class LDAPOther(LDAPException):
+    resultCode = 80
+    name = b'other'
+
+# 81-90 reserved for APIs
+
+
+# Backwards compatibility
 other = LDAPOther.resultCode
+reverse = LDAPExceptionCollection.collection

--- a/ldaptor/test/test_ldaperrors.py
+++ b/ldaptor/test/test_ldaperrors.py
@@ -64,3 +64,12 @@ class LDAPExceptionTests(unittest.TestCase):
         """Unknown exception with no message"""
         exception = ldaperrors.LDAPUnknownError(57)
         self.assertEqual(exception.toWire(), b'unknownError(57)')
+
+
+class LDAPExceptionStrTests(unittest.TestCase):
+    """Getting string representations of LDAP exceptions"""
+
+    def test_exception_with_message(self):
+        """Exception with a text message"""
+        exception = ldaperrors.LDAPProtocolError('Error message')
+        self.assertEqual(str(exception), 'protocolError: Error message')


### PR DESCRIPTION
Exception fixes:

- `__str__` method was returned as its absence caused `ldapclient` exceptions to fail;
- explicit exception classes declaration was made to allow code highlighting (hope you do not mind, it always bothered me :)

### Contributor Checklist:

* [x] I have updated the release notes at `docs/source/NEWS.rst` 
* [x] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
