### PR TITLE
StartTLS fix for Python 3

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -9,6 +9,8 @@ Bugfixes
 
 - ``DeprecationWarning`` stacklevel was set to mark the caller of the deprecated
   methods of the ``ldaptor._encoder`` classes.
+- StartTLS regression bug was fixed: ``ldaptor.protocols.pureldap.LDAPStartTLSRequest.oid`` and
+  ``ldaptor.protocols.pureldap.LDAPStartTLSResponse.oid`` must be of bytes type.
 
 Release 19.0 (2019-03-05)
 -------------------------

--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -1497,7 +1497,7 @@ class LDAPStartTLSRequest(LDAPExtendedRequest):
     Request to start Transport Layer Security.
     See RFC 2830 for details.
     """
-    oid = '1.3.6.1.4.1.1466.20037'
+    oid = b'1.3.6.1.4.1.1466.20037'
 
     def __init__(self, requestName=None, tag=None):
         assert (requestName is None
@@ -1522,7 +1522,7 @@ class LDAPStartTLSResponse(LDAPExtendedResponse):
     Response to start Transport Layer Security.
     See RFC 4511 section 4.14.2 for details.
     """
-    oid = '1.3.6.1.4.1.1466.20037'
+    oid = b'1.3.6.1.4.1.1466.20037'
 
     def __init__(self, resultCode=None, matchedDN=None, errorMessage=None,
                  referral=None, serverSaslCreds=None,


### PR DESCRIPTION
There was a StartTLS connection error caused by `pureldap` classes `LDAPStartTLSRequest` and `LDAPStartTLSResponse` which had `oid`s of str type. Changed them to bytes.

No unit tests for successful StartTLS connection were implemented before and I have not found a proper way to write them: `LDAPClient._cbStartTLS` method raises an exception
```
AttributeError("StringTransport instance has no attribute 'startTLS'"
```
in the line
```
self.transport.startTLS(ctx)
```
So I tested a LDAP client against an external LDAP server to check that it works.

### Contributor Checklist:

* [x] I have updated the release notes at `docs/source/NEWS.rst` 
* [ ] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
