### PR TITLE
Pureldap and pureber repr fixes

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -15,7 +15,9 @@ Changes
 ^^^^^^^
 
 - ``ldaptor.protocols.pureldap.LDAPPasswordModifyRequest`` string representation now contains
-  ``userIdentity``, ``oldPasswd`` and ``newPasswd`` attributes.
+  ``userIdentity``, ``oldPasswd`` and ``newPasswd`` attributes. Password attributes are represented as asterisks.
+- ``ldaptor.protocols.pureldap.LDAPBindRequest`` string representation is now using asterisks to represent
+  ``auth`` attribute.
 
 Bugfixes
 ^^^^^^^^

--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -11,6 +11,12 @@ Features
 - Explicit ``ldaptor.protocols.ldap.ldaperrors`` classes declaration was made
   to allow syntax highlighting for this module.
 
+Changes
+^^^^^^^
+
+- ``ldaptor.protocols.pureldap.LDAPPasswordModifyRequest`` string representation now contains
+  ``userIdentity``, ``oldPasswd`` and ``newPasswd`` attributes.
+
 Bugfixes
 ^^^^^^^^
 
@@ -21,6 +27,10 @@ Bugfixes
   exceptions failed to get their string representations).
 - StartTLS regression bug was fixed: ``ldaptor.protocols.pureldap.LDAPStartTLSRequest.oid`` and
   ``ldaptor.protocols.pureldap.LDAPStartTLSResponse.oid`` must be of bytes type.
+- ``ldaptor.protocols.pureldap`` and ``ldaptor.protocols.pureber`` string representations were fixed:
+  `LDAPResult(resultCode=0, matchedDN='uid=user')` instead of `LDAPResult(resultCode=0, matchedDN="b'uid=user'")`.
+- ``ldaptor.protocols.pureldap.LDAPMatchingRuleAssertion`` initialization for Python 3 was failed for bytes arguments.
+- ``ldaptor.protocols.pureldap.LDAPExtendedResponse`` custom tag parameter was not used.
 
 Release 19.0 (2019-03-05)
 -------------------------

--- a/ldaptor/_encoder.py
+++ b/ldaptor/_encoder.py
@@ -34,6 +34,16 @@ def to_unicode(value):
     return value
 
 
+def repr_converter(value):
+    """
+    Converts value to its string representation:
+
+    * Byte string for Python 2
+    * Unicode string for Python 3
+    """
+    return to_bytes(value) if six.PY2 else to_unicode(value)
+
+
 def get_strings(value):
     """
     Getting tuple of available string values

--- a/ldaptor/protocols/pureber.py
+++ b/ldaptor/protocols/pureber.py
@@ -32,7 +32,7 @@
 
 import six
 
-from ldaptor._encoder import to_bytes, to_unicode, WireStrAlias
+from ldaptor._encoder import to_bytes, repr_converter, WireStrAlias
 
 # xxxxxxxx
 # |/|\.../
@@ -224,7 +224,7 @@ class BEROctetString(BERBase):
         return result
 
     def __repr__(self):
-        value = to_bytes(self.value) if six.PY2 else to_unicode(self.value)
+        value = repr_converter(self.value)
         if self.tag == self.__class__.tag:
             return self.__class__.__name__ + "(value=%s)" \
                    % repr(value)

--- a/ldaptor/protocols/pureber.py
+++ b/ldaptor/protocols/pureber.py
@@ -32,7 +32,7 @@
 
 import six
 
-from ldaptor._encoder import to_bytes, WireStrAlias
+from ldaptor._encoder import to_bytes, to_unicode, WireStrAlias
 
 # xxxxxxxx
 # |/|\.../
@@ -224,13 +224,14 @@ class BEROctetString(BERBase):
         return result
 
     def __repr__(self):
+        value = to_bytes(self.value) if six.PY2 else to_unicode(self.value)
         if self.tag == self.__class__.tag:
             return self.__class__.__name__ + "(value=%s)" \
-                   % repr(self.value)
+                   % repr(value)
         else:
             return self.__class__.__name__ \
                    + "(value=%s, tag=%d)" \
-                     % (repr(self.value), self.tag)
+                     % (repr(value), self.tag)
 
 
 class BERNull(BERBase):

--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -28,7 +28,7 @@ from ldaptor.protocols.pureber import (
 
     berDecodeMultiple, berDecodeObject, int2berlen,
     )
-from ldaptor._encoder import to_bytes, to_unicode
+from ldaptor._encoder import to_bytes, repr_converter
 
 next_ldap_message_id = 1
 
@@ -212,12 +212,11 @@ class LDAPBindRequest(LDAPProtocolRequest, BERSequence):
             ], tag=self.tag).toWire()
 
     def __repr__(self):
-        converter = to_bytes if six.PY2 else to_unicode
         auth = '*' * len(self.auth)
         l = []
         l.append('version=%d' % self.version)
-        l.append('dn=%s' % repr(converter(self.dn)))
-        l.append('auth=%s' % repr(converter(auth)))
+        l.append('dn=%s' % repr(repr_converter(self.dn)))
+        l.append('auth=%s' % repr(repr_converter(auth)))
         if self.tag != self.__class__.tag:
             l.append('tag=%d' % self.tag)
         l.append('sasl=%s' % repr(self.sasl))
@@ -255,10 +254,9 @@ class LDAPSearchResultReference(LDAPProtocolResponse, BERSequence):
         return BERSequence(BERSequence(self.uris), tag=self.tag).toWire()
 
     def __repr__(self):
-        converter = to_bytes if six.PY2 else to_unicode
         return '{}(uris={}{})'.format(
             self.__class__.__name__,
-            repr([converter(uri) for uri in self.uris]),
+            repr([repr_converter(uri) for uri in self.uris]),
             ', tag={}'.format(self.tag) if self.tag != self.__class__.tag else '',
         )
 
@@ -307,13 +305,12 @@ class LDAPResult(LDAPProtocolResponse, BERSequence):
             ], tag=self.tag).toWire()
 
     def __repr__(self):
-        converter = to_bytes if six.PY2 else to_unicode
         l = []
         l.append('resultCode=%r' % self.resultCode)
         if self.matchedDN:
-            l.append('matchedDN=%r' % converter(self.matchedDN))
+            l.append('matchedDN=%r' % repr_converter(self.matchedDN))
         if self.errorMessage:
-            l.append('errorMessage=%r' % converter(self.errorMessage))
+            l.append('errorMessage=%r' % repr_converter(self.errorMessage))
         if self.referral:
             l.append('referral=%r' % self.referral)
         if self.tag != self.__class__.tag:
@@ -555,7 +552,7 @@ class LDAPFilter_substrings(BERSequence):
             BERSequence(self.substrings)], tag=self.tag).toWire()
 
     def __repr__(self):
-        tp = to_bytes(self.type) if six.PY2 else to_unicode(self.type)
+        tp = repr_converter(self.type)
         if self.tag==self.__class__.tag:
             return self.__class__.__name__\
                    +"(type=%s, substrings=%s)"\
@@ -850,7 +847,7 @@ class LDAPSearchRequest(LDAPProtocolRequest, BERSequence):
             ], tag=self.tag).toWire()
 
     def __repr__(self):
-        base = to_bytes(self.baseObject) if six.PY2 else to_unicode(self.baseObject)
+        base = repr_converter(self.baseObject)
         if self.tag == self.__class__.tag:
             return self.__class__.__name__ \
                    + ("(baseObject=%s, scope=%s, derefAliases=%s, " \
@@ -908,9 +905,8 @@ class LDAPSearchResultEntry(LDAPProtocolResponse, BERSequence):
         ], tag=self.tag).toWire()
 
     def __repr__(self):
-        converter = to_bytes if six.PY2 else to_unicode
-        name = converter(self.objectName)
-        attributes = [(converter(key), [converter(v) for v in value]) for (key, value) in self.attributes]
+        name = repr_converter(self.objectName)
+        attributes = [(repr_converter(key), [repr_converter(v) for v in value]) for (key, value) in self.attributes]
         return '{}(objectName={}, attributes={}{})'.format(
             self.__class__.__name__,
             repr(name),
@@ -1062,7 +1058,7 @@ class LDAPModifyRequest(LDAPProtocolRequest, BERSequence):
         return BERSequence(l, tag=self.tag).toWire()
 
     def __repr__(self):
-        name = to_bytes(self.object) if six.PY2 else to_unicode(self.object)
+        name = repr_converter(self.object)
         if self.tag==self.__class__.tag:
             return self.__class__.__name__+"(object=%s, modification=%s)"\
                    %(repr(name), repr(self.modification))
@@ -1119,7 +1115,7 @@ class LDAPAddRequest(LDAPProtocolRequest, BERSequence):
             ], tag=self.tag).toWire()
 
     def __repr__(self):
-        entry = to_bytes(self.entry) if six.PY2 else to_unicode(self.entry)
+        entry = repr_converter(self.entry)
         if self.tag==self.__class__.tag:
             return self.__class__.__name__+"(entry=%s, attributes=%s)"\
                    %(repr(entry), repr(self.attributes))
@@ -1151,7 +1147,7 @@ class LDAPDelRequest(LDAPProtocolRequest, LDAPString):
         return LDAPString.toWire(self)
 
     def __repr__(self):
-        entry = to_bytes(self.value) if six.PY2 else to_unicode(self.value)
+        entry = repr_converter(self.value)
         if self.tag == self.__class__.tag:
             return self.__class__.__name__ + "(entry=%s)" \
                    % repr(entry)
@@ -1235,14 +1231,13 @@ class LDAPModifyDNRequest(LDAPProtocolRequest, BERSequence):
         return BERSequence(l, tag=self.tag).toWire()
 
     def __repr__(self):
-        converter = to_bytes if six.PY2 else to_unicode
         l = [
-            "entry=%s" % repr(converter(self.entry)),
-            "newrdn=%s" % repr(converter(self.newrdn)),
+            "entry=%s" % repr(repr_converter(self.entry)),
+            "newrdn=%s" % repr(repr_converter(self.newrdn)),
             "deleteoldrdn=%s" % repr(self.deleteoldrdn),
             ]
         if self.newSuperior is not None:
-            l.append("newSuperior=%s" % repr(converter(self.newSuperior)))
+            l.append("newSuperior=%s" % repr(repr_converter(self.newSuperior)))
         if self.tag != self.__class__.tag:
             l.append("tag=%d" % self.tag)
         return self.__class__.__name__ + "(" + ', '.join(l) + ")"
@@ -1293,8 +1288,7 @@ class LDAPCompareRequest(LDAPProtocolRequest, BERSequence):
         return BERSequence(l, tag=self.tag).toWire()
 
     def __repr__(self):
-        entry = to_bytes(self.entry) if six.PY2 else to_unicode(self.entry)
-        l = ["entry={}".format(repr(entry)), "ava={}".format(repr(self.ava))]
+        l = ["entry={}".format(repr(repr_converter(self.entry))), "ava={}".format(repr(self.ava))]
         return "{}({})".format(self.__class__.__name__, ', '.join(l))
 
 

--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -213,10 +213,11 @@ class LDAPBindRequest(LDAPProtocolRequest, BERSequence):
 
     def __repr__(self):
         converter = to_bytes if six.PY2 else to_unicode
+        auth = '*' * len(self.auth)
         l = []
         l.append('version=%d' % self.version)
         l.append('dn=%s' % repr(converter(self.dn)))
-        l.append('auth=%s' % repr(converter(self.auth)))
+        l.append('auth=%s' % repr(converter(auth)))
         if self.tag != self.__class__.tag:
             l.append('tag=%d' % self.tag)
         l.append('sasl=%s' % repr(self.sasl))
@@ -1394,11 +1395,21 @@ class LDAPPasswordModifyRequest_userIdentity(BEROctetString):
     tag = CLASS_CONTEXT | 0
 
 
-class LDAPPasswordModifyRequest_oldPasswd(BEROctetString):
+class LDAPPasswordModifyRequest_passwd(BEROctetString):
+    def __repr__(self):
+        value = '*' * len(self.value)
+        return '{}(value={}{})'.format(
+            self.__class__.__name__,
+            repr(value),
+            ', tag={}'.format(self.tag) if self.tag != self.__class__.tag else '',
+        )
+
+
+class LDAPPasswordModifyRequest_oldPasswd(LDAPPasswordModifyRequest_passwd):
     tag = CLASS_CONTEXT | 1
 
 
-class LDAPPasswordModifyRequest_newPasswd(BEROctetString):
+class LDAPPasswordModifyRequest_newPasswd(LDAPPasswordModifyRequest_passwd):
     tag = CLASS_CONTEXT | 2
 
 

--- a/ldaptor/test/test_pureldap.py
+++ b/ldaptor/test/test_pureldap.py
@@ -1094,9 +1094,9 @@ class TestRepresentations(unittest.TestCase):
         """LDAPBindRequest.__repr__ with custom tag attribute"""
         dns = [b'uid=user,ou=users,dc=example,dc=org', u'uid=user,ou=users,dc=example,dc=org']
         for dn in dns:
-            req = pureldap.LDAPBindRequest(dn=dn, tag=42)
+            req = pureldap.LDAPBindRequest(dn=dn, auth='pass', tag=42)
             req_repr = "LDAPBindRequest(version=3, dn='uid=user,ou=users,dc=example,dc=org', " \
-                       "auth='', tag=42, sasl=False)"
+                       "auth='****', tag=42, sasl=False)"
             self.assertEqual(repr(req), req_repr)
 
     def test_bind_response_repr(self):
@@ -1416,8 +1416,8 @@ class TestRepresentations(unittest.TestCase):
                     )
                     pmr_repr = "LDAPPasswordModifyRequest(userIdentity=LDAPPasswordModifyRequest_userIdentity(" \
                                "value='uid=user,ou=users,dc=example,dc=org'), " \
-                               "oldPasswd=LDAPPasswordModifyRequest_oldPasswd(value='qwerty'), " \
-                               "newPasswd=LDAPPasswordModifyRequest_newPasswd(value='asdfgh'))"
+                               "oldPasswd=LDAPPasswordModifyRequest_oldPasswd(value='******'), " \
+                               "newPasswd=LDAPPasswordModifyRequest_newPasswd(value='******'))"
                     self.assertEqual(repr(pmr), pmr_repr)
 
     def test_password_modify_request_with_tag_repr(self):
@@ -1436,8 +1436,8 @@ class TestRepresentations(unittest.TestCase):
                     )
                     pmr_repr = "LDAPPasswordModifyRequest(userIdentity=LDAPPasswordModifyRequest_userIdentity(" \
                                "value='uid=user,ou=users,dc=example,dc=org'), " \
-                               "oldPasswd=LDAPPasswordModifyRequest_oldPasswd(value='qwerty'), " \
-                               "newPasswd=LDAPPasswordModifyRequest_newPasswd(value='asdfgh'), tag=42)"
+                               "oldPasswd=LDAPPasswordModifyRequest_oldPasswd(value='******'), " \
+                               "newPasswd=LDAPPasswordModifyRequest_newPasswd(value='******'), tag=42)"
                     self.assertEqual(repr(pmr), pmr_repr)
 
     def test_starttls_request_repr(self):

--- a/ldaptor/test/test_pureldap.py
+++ b/ldaptor/test/test_pureldap.py
@@ -1082,26 +1082,482 @@ class TestRepresentations(unittest.TestCase):
     Test representations of common LDAP opbjects.
     """
 
-    def test_search_result_repr(self):
-        tags = [pureldap.LDAPSearchResultEntry.tag, "foobaz"]
-        for tag in tags:
-            resp = pureldap.LDAPSearchResultEntry(
-                objectName='uid=mohamed,ou=people,dc=example,dc=fr',
-                attributes=[
-                    ('uid', ['mohamed'])
-                ],
-                tag=tag
+    def test_bind_request_repr(self):
+        """LDAPBindRequest.__repr__"""
+        dns = [b'uid=user,ou=users,dc=example,dc=org', u'uid=user,ou=users,dc=example,dc=org']
+        for dn in dns:
+            req = pureldap.LDAPBindRequest(dn=dn)
+            req_repr = "LDAPBindRequest(version=3, dn='uid=user,ou=users,dc=example,dc=org', auth='', sasl=False)"
+            self.assertEqual(repr(req), req_repr)
+
+    def test_bind_request_with_tag_repr(self):
+        """LDAPBindRequest.__repr__ with custom tag attribute"""
+        dns = [b'uid=user,ou=users,dc=example,dc=org', u'uid=user,ou=users,dc=example,dc=org']
+        for dn in dns:
+            req = pureldap.LDAPBindRequest(dn=dn, tag=42)
+            req_repr = "LDAPBindRequest(version=3, dn='uid=user,ou=users,dc=example,dc=org', " \
+                       "auth='', tag=42, sasl=False)"
+            self.assertEqual(repr(req), req_repr)
+
+    def test_bind_response_repr(self):
+        """LDAPBindResponse.__repr__"""
+        matched_dns = [b'uid=user,ou=users,dc=example,dc=org', u'uid=user,ou=users,dc=example,dc=org']
+        for matched_dn in matched_dns:
+            res = pureldap.LDAPBindResponse(resultCode=0, matchedDN=matched_dn)
+            res_repr = "LDAPBindResponse(resultCode=0, matchedDN='uid=user,ou=users,dc=example,dc=org')"
+            self.assertEqual(repr(res), res_repr)
+
+    def test_result_with_matched_dn_repr(self):
+        """LDAPResult.__repr__ with matchedDN attribute"""
+        matched_dns = [b'uid=user,ou=users,dc=example,dc=org', u'uid=user,ou=users,dc=example,dc=org']
+        for matched_dn in matched_dns:
+            res = pureldap.LDAPResult(resultCode=0, matchedDN=matched_dn)
+            res_repr = "LDAPResult(resultCode=0, matchedDN='uid=user,ou=users,dc=example,dc=org')"
+            self.assertEqual(repr(res), res_repr)
+
+    def test_result_with_error_message_repr(self):
+        """LDAPResult.__repr__ with errorMessage attribute"""
+        error_messages = [b'error_message', u'error_message']
+        for error_message in error_messages:
+            res = pureldap.LDAPResult(resultCode=1, errorMessage=error_message)
+            res_repr = "LDAPResult(resultCode=1, errorMessage='error_message')"
+            self.assertEqual(repr(res), res_repr)
+
+    def test_result_with_tag_repr(self):
+        """LDAPResult.__repr__ with custom tag attribute"""
+        res = pureldap.LDAPResult(resultCode=0, tag=42)
+        res_repr = "LDAPResult(resultCode=0, tag=42)"
+        self.assertEqual(repr(res), res_repr)
+
+    def test_search_request_repr(self):
+        """LDAPSearchRequest.__repr__"""
+        base_objects = [b'ou=users,dc=example,dc=org', u'ou=users,dc=example,dc=org']
+        for base_object in base_objects:
+            req = pureldap.LDAPSearchRequest(
+                baseObject=base_object,
+                filter=pureldap.LDAPFilter_equalityMatch(
+                    attributeDesc=pureber.BEROctetString('key'),
+                    assertionValue=pureber.BEROctetString('value'),
+                ),
             )
-            repr(resp)
+            req_repr = "LDAPSearchRequest(baseObject='ou=users,dc=example,dc=org', scope=2, derefAliases=0, " \
+                       "sizeLimit=0, timeLimit=0, typesOnly=0, filter=LDAPFilter_equalityMatch(" \
+                       "attributeDesc=BEROctetString(value='key'), assertionValue=BEROctetString(value='value')), " \
+                       "attributes=[])"
+            self.assertEqual(repr(req), req_repr)
+
+    def test_search_request_with_tag_repr(self):
+        """LDAPSearchRequest.__repr__ with custom tag attribute"""
+        base_objects = [b'ou=users,dc=example,dc=org', u'ou=users,dc=example,dc=org']
+        for base_object in base_objects:
+            req = pureldap.LDAPSearchRequest(
+                baseObject=base_object,
+                filter=pureldap.LDAPFilter_equalityMatch(
+                    attributeDesc=pureber.BEROctetString('key'),
+                    assertionValue=pureber.BEROctetString('value'),
+                ),
+                tag=42,
+            )
+            req_repr = "LDAPSearchRequest(baseObject='ou=users,dc=example,dc=org', scope=2, derefAliases=0, " \
+                       "sizeLimit=0, timeLimit=0, typesOnly=0, filter=LDAPFilter_equalityMatch(" \
+                       "attributeDesc=BEROctetString(value='key'), assertionValue=BEROctetString(value='value')), " \
+                       "attributes=[], tag=42)"
+            self.assertEqual(repr(req), req_repr)
+
+    def test_search_result_entry_repr(self):
+        """LDAPSearchResultEntry.__repr__"""
+        object_names = [b'uid=mohamed,ou=people,dc=example,dc=fr', u'uid=mohamed,ou=people,dc=example,dc=fr']
+        attributes_list = [(b'uid', [b'mohamed']), (u'uid', [u'mohamed'])]
+        for object_name in object_names:
+            for attributes in attributes_list:
+                resp = pureldap.LDAPSearchResultEntry(
+                    objectName=object_name,
+                    attributes=[attributes],
+                )
+                resp_repr = "LDAPSearchResultEntry(objectName='uid=mohamed,ou=people,dc=example,dc=fr', " \
+                            "attributes=[('uid', ['mohamed'])])"
+                self.assertEqual(repr(resp), resp_repr)
+
+    def test_search_result_entry_with_tag_repr(self):
+        """LDAPSearchResultEntry.__repr__ with custom tag attribute"""
+        object_names = [b'uid=mohamed,ou=people,dc=example,dc=fr', u'uid=mohamed,ou=people,dc=example,dc=fr']
+        attributes_list = [(b'uid', [b'mohamed']), (u'uid', [u'mohamed'])]
+        for object_name in object_names:
+            for attributes in attributes_list:
+                resp = pureldap.LDAPSearchResultEntry(
+                    objectName=object_name,
+                    attributes=[attributes],
+                    tag=42,
+                )
+                resp_repr = "LDAPSearchResultEntry(objectName='uid=mohamed,ou=people,dc=example,dc=fr', " \
+                            "attributes=[('uid', ['mohamed'])], tag=42)"
+                self.assertEqual(repr(resp), resp_repr)
 
     def test_search_result_reference_repr(self):
-        tags = [pureldap.LDAPSearchResultReference.tag, 'tag']
-        for tag in tags:
-            resp = pureldap.LDAPSearchResultReference(
-                uris=[
-                    pureldap.LDAPString(b'ldap://example.com/dc=foo,dc=example,dc=com'),
-                    pureldap.LDAPString(b'ldap://example.com/dc=foo,dc=example,dc=com')
-                ],
-                tag=tag
+        """LDAPSearchResultReference.__repr__"""
+        uris_list = [
+            [
+                b'ldap://example.com/dc=foo,dc=example,dc=com',
+                b'ldap://example.com/dc=foo,dc=example,dc=com',
+            ],
+            [
+                u'ldap://example.com/dc=foo,dc=example,dc=com',
+                u'ldap://example.com/dc=foo,dc=example,dc=com',
+            ]
+        ]
+        for uris in uris_list:
+            resp = pureldap.LDAPSearchResultReference(uris=uris)
+            resp_repr = "LDAPSearchResultReference(uris=['ldap://example.com/dc=foo,dc=example,dc=com', " \
+                        "'ldap://example.com/dc=foo,dc=example,dc=com'])"
+            self.assertEqual(repr(resp), resp_repr)
+
+    def test_search_result_reference_with_tag_repr(self):
+        """LDAPSearchResultReference.__repr__ with custom tag attribute"""
+        uris_list = [
+            [
+                b'ldap://example.com/dc=foo,dc=example,dc=com',
+                b'ldap://example.com/dc=foo,dc=example,dc=com',
+            ],
+            [
+                u'ldap://example.com/dc=foo,dc=example,dc=com',
+                u'ldap://example.com/dc=foo,dc=example,dc=com',
+            ]
+        ]
+        for uris in uris_list:
+            resp = pureldap.LDAPSearchResultReference(uris=uris, tag=42)
+            resp_repr = "LDAPSearchResultReference(uris=['ldap://example.com/dc=foo,dc=example,dc=com', " \
+                        "'ldap://example.com/dc=foo,dc=example,dc=com'], tag=42)"
+            self.assertEqual(repr(resp), resp_repr)
+
+    def test_modify_request_repr(self):
+        """LDAPModifyRequest.__repr__"""
+        object_names = [b'uid=user,ou=users,dc=example,dc=org', u'uid=user,ou=users,dc=example,dc=org']
+        for object_name in object_names:
+            mr = pureldap.LDAPModifyRequest(
+                object=object_name,
+                modification=pureber.BERSequence([
+                    pureber.BEREnumerated(0),
+                    pureber.BERSequence([
+                        pureldap.LDAPAttributeDescription('key'),
+                        pureber.BERSet([pureldap.LDAPString('value')])
+                    ]),
+                ]),
             )
-            repr(resp)
+            mr_repr = "LDAPModifyRequest(object='uid=user,ou=users,dc=example,dc=org', " \
+                      "modification=BERSequence(value=[BEREnumerated(value=0), " \
+                      "BERSequence(value=[LDAPAttributeDescription(value='key'), " \
+                      "BERSet(value=[LDAPString(value='value')])])]))"
+            self.assertEqual(repr(mr), mr_repr)
+
+    def test_modify_request_with_tag_repr(self):
+        """LDAPModifyRequest.__repr__ with custom tag attribute"""
+        object_names = [b'uid=user,ou=users,dc=example,dc=org', u'uid=user,ou=users,dc=example,dc=org']
+        for object_name in object_names:
+            mr = pureldap.LDAPModifyRequest(
+                object=object_name,
+                modification=pureber.BERSequence([
+                    pureber.BEREnumerated(0),
+                    pureber.BERSequence([
+                        pureldap.LDAPAttributeDescription('key'),
+                        pureber.BERSet([pureldap.LDAPString('value')])
+                    ]),
+                ]),
+                tag=42,
+            )
+            mr_repr = "LDAPModifyRequest(object='uid=user,ou=users,dc=example,dc=org', " \
+                      "modification=BERSequence(value=[BEREnumerated(value=0), " \
+                      "BERSequence(value=[LDAPAttributeDescription(value='key'), " \
+                      "BERSet(value=[LDAPString(value='value')])])]), tag=42)"
+            self.assertEqual(repr(mr), mr_repr)
+
+    def test_add_request_repr(self):
+        """LDAPAddRequest.__repr__"""
+        entries = [b'uid=user,ou=users,dc=example,dc=org', u'uid=user,ou=users,dc=example,dc=org']
+        for entry in entries:
+            ar = pureldap.LDAPAddRequest(
+                entry=entry,
+                attributes=[
+                    (
+                        pureldap.LDAPAttributeDescription('key'),
+                        pureber.BERSet([pureldap.LDAPAttributeValue('value')]),
+                    ),
+                ],
+            )
+            ar_repr = "LDAPAddRequest(entry='uid=user,ou=users,dc=example,dc=org', " \
+                      "attributes=[(LDAPAttributeDescription(value='key'), " \
+                      "BERSet(value=[LDAPAttributeValue(value='value')]))])"
+            self.assertEqual(repr(ar), ar_repr)
+
+    def test_add_request_with_tag_repr(self):
+        """LDAPAddRequest.__repr__ with custom tag attribute"""
+        entries = [b'uid=user,ou=users,dc=example,dc=org', u'uid=user,ou=users,dc=example,dc=org']
+        for entry in entries:
+            ar = pureldap.LDAPAddRequest(
+                entry=entry,
+                attributes=[
+                    (
+                        pureldap.LDAPAttributeDescription('key'),
+                        pureber.BERSet([pureldap.LDAPAttributeValue('value')]),
+                    ),
+                ],
+                tag=42,
+            )
+            ar_repr = "LDAPAddRequest(entry='uid=user,ou=users,dc=example,dc=org', " \
+                      "attributes=[(LDAPAttributeDescription(value='key'), " \
+                      "BERSet(value=[LDAPAttributeValue(value='value')]))], tag=42)"
+            self.assertEqual(repr(ar), ar_repr)
+
+    def test_del_request_repr(self):
+        """LDAPDelRequest.__repr__"""
+        entries = [b'uid=user,ou=users,dc=example,dc=org', u'uid=user,ou=users,dc=example,dc=org']
+        for entry in entries:
+            dr = pureldap.LDAPDelRequest(entry=entry)
+            dr_repr = "LDAPDelRequest(entry='uid=user,ou=users,dc=example,dc=org')"
+            self.assertEqual(repr(dr), dr_repr)
+
+    def test_del_request_with_tag_repr(self):
+        """LDAPDelRequest.__repr__ with custom tag attribute"""
+        entries = [b'uid=user,ou=users,dc=example,dc=org', u'uid=user,ou=users,dc=example,dc=org']
+        for entry in entries:
+            dr = pureldap.LDAPDelRequest(entry=entry, tag=42)
+            dr_repr = "LDAPDelRequest(entry='uid=user,ou=users,dc=example,dc=org', tag=42)"
+            self.assertEqual(repr(dr), dr_repr)
+
+    def test_modify_dn_request_repr(self):
+        """LDAPModifyDNRequest.__repr__"""
+        entries = [b'uid=user,ou=users,dc=example,dc=org', u'uid=user,ou=users,dc=example,dc=org']
+        rdns = [b'uid=newuser', u'uid=newuser']
+        for entry in entries:
+            for rdn in rdns:
+                mdnr = pureldap.LDAPModifyDNRequest(
+                    entry=entry,
+                    newrdn=rdn,
+                    deleteoldrdn=True,
+                )
+                mdnr_repr = "LDAPModifyDNRequest(entry='uid=user,ou=users,dc=example,dc=org', " \
+                            "newrdn='uid=newuser', deleteoldrdn=True)"
+                self.assertEqual(repr(mdnr), mdnr_repr)
+
+    def test_modify_dn_request_with_new_superior_repr(self):
+        """LDAPModifyDNRequest.__repr__ with newSuperior attribute"""
+        entries = [b'uid=user,ou=users,dc=example,dc=org', u'uid=user,ou=users,dc=example,dc=org']
+        rdns = [b'uid=newuser', u'uid=newuser']
+        new_superiors = [b'ou=newusers,dc=example,dc=org', u'ou=newusers,dc=example,dc=org']
+        for entry in entries:
+            for rdn in rdns:
+                for new_superior in new_superiors:
+                    mdnr = pureldap.LDAPModifyDNRequest(
+                        entry=entry,
+                        newrdn=rdn,
+                        deleteoldrdn=False,
+                        newSuperior=new_superior,
+                    )
+                    mdnr_repr = "LDAPModifyDNRequest(entry='uid=user,ou=users,dc=example,dc=org', " \
+                                "newrdn='uid=newuser', deleteoldrdn=False, " \
+                                "newSuperior='ou=newusers,dc=example,dc=org')"
+                    self.assertEqual(repr(mdnr), mdnr_repr)
+
+    def test_modify_dn_request_with_tag_repr(self):
+        """LDAPModifyDNRequest.__repr__ with custom tag attribute"""
+        entries = [b'uid=user,ou=users,dc=example,dc=org', u'uid=user,ou=users,dc=example,dc=org']
+        rdns = [b'uid=newuser', u'uid=newuser']
+        for entry in entries:
+            for rdn in rdns:
+                mdnr = pureldap.LDAPModifyDNRequest(
+                    entry=entry,
+                    newrdn=rdn,
+                    deleteoldrdn=True,
+                    tag=42,
+                )
+                mdnr_repr = "LDAPModifyDNRequest(entry='uid=user,ou=users,dc=example,dc=org', " \
+                            "newrdn='uid=newuser', deleteoldrdn=True, tag=42)"
+                self.assertEqual(repr(mdnr), mdnr_repr)
+
+    def test_compare_request_repr(self):
+        """LDAPCompareRequest.__repr__"""
+        entries = [b'uid=user,ou=users,dc=example,dc=org', u'uid=user,ou=users,dc=example,dc=org']
+        for entry in entries:
+            cr = pureldap.LDAPCompareRequest(
+                entry=entry,
+                ava=pureldap.LDAPAttributeValueAssertion(
+                    pureber.BEROctetString('key'),
+                    pureber.BEROctetString('value'),
+                ),
+            )
+            cr_repr = "LDAPCompareRequest(entry='uid=user,ou=users,dc=example,dc=org', " \
+                      "ava=LDAPAttributeValueAssertion(attributeDesc=BEROctetString(value='key'), " \
+                      "assertionValue=BEROctetString(value='value')))"
+            self.assertEqual(repr(cr), cr_repr)
+
+    def test_abandon_request_repr(self):
+        """LDAPAbandonRequest.__repr__"""
+        ar = pureldap.LDAPAbandonRequest(1)
+        ar_repr = "LDAPAbandonRequest(id=1)"
+        self.assertEqual(repr(ar), ar_repr)
+
+    def test_abandon_request_with_tag_repr(self):
+        """LDAPAbandonRequest.__repr__ with custom tag attribute"""
+        ar = pureldap.LDAPAbandonRequest(1, tag=42)
+        ar_repr = "LDAPAbandonRequest(id=1, tag=42)"
+        self.assertEqual(repr(ar), ar_repr)
+
+    def test_password_modify_request_repr(self):
+        """LDAPPasswordModifyRequest.__repr__"""
+        user_identities = [b'uid=user,ou=users,dc=example,dc=org', u'uid=user,ou=users,dc=example,dc=org']
+        old_passwords = [b'qwerty', u'qwerty']
+        new_passwords = [b'asdfgh', u'asdfgh']
+        for user_identity in user_identities:
+            for old_password in old_passwords:
+                for new_password in new_passwords:
+                    pmr = pureldap.LDAPPasswordModifyRequest(
+                        userIdentity=user_identity,
+                        oldPasswd=old_password,
+                        newPasswd=new_password,
+                    )
+                    pmr_repr = "LDAPPasswordModifyRequest(userIdentity=LDAPPasswordModifyRequest_userIdentity(" \
+                               "value='uid=user,ou=users,dc=example,dc=org'), " \
+                               "oldPasswd=LDAPPasswordModifyRequest_oldPasswd(value='qwerty'), " \
+                               "newPasswd=LDAPPasswordModifyRequest_newPasswd(value='asdfgh'))"
+                    self.assertEqual(repr(pmr), pmr_repr)
+
+    def test_password_modify_request_with_tag_repr(self):
+        """LDAPPasswordModifyRequest.__repr__ with custom tag attribute"""
+        user_identities = [b'uid=user,ou=users,dc=example,dc=org', u'uid=user,ou=users,dc=example,dc=org']
+        old_passwords = [b'qwerty', u'qwerty']
+        new_passwords = [b'asdfgh', u'asdfgh']
+        for user_identity in user_identities:
+            for old_password in old_passwords:
+                for new_password in new_passwords:
+                    pmr = pureldap.LDAPPasswordModifyRequest(
+                        userIdentity=user_identity,
+                        oldPasswd=old_password,
+                        newPasswd=new_password,
+                        tag=42,
+                    )
+                    pmr_repr = "LDAPPasswordModifyRequest(userIdentity=LDAPPasswordModifyRequest_userIdentity(" \
+                               "value='uid=user,ou=users,dc=example,dc=org'), " \
+                               "oldPasswd=LDAPPasswordModifyRequest_oldPasswd(value='qwerty'), " \
+                               "newPasswd=LDAPPasswordModifyRequest_newPasswd(value='asdfgh'), tag=42)"
+                    self.assertEqual(repr(pmr), pmr_repr)
+
+    def test_starttls_request_repr(self):
+        """LDAPStartTLSRequest.__repr__"""
+        req = pureldap.LDAPStartTLSRequest()
+        req_repr = "LDAPStartTLSRequest()"
+        self.assertEqual(repr(req), req_repr)
+
+    def test_starttls_request_with_tag_repr(self):
+        """LDAPStartTLSRequest.__repr__ with custom tag attribute"""
+        ar = pureldap.LDAPStartTLSRequest(tag=42)
+        ar_repr = "LDAPStartTLSRequest(tag=42)"
+        self.assertEqual(repr(ar), ar_repr)
+
+    def test_starttls_response_repr(self):
+        """LDAPStartTLSResponse.__repr__"""
+        resp = pureldap.LDAPStartTLSResponse(resultCode=0)
+        resp_repr = "LDAPStartTLSResponse()"
+        self.assertEqual(repr(resp), resp_repr)
+
+    def test_starttls_response_with_tag_repr(self):
+        """LDAPStartTLSResponse.__repr__ with custom tag attribute"""
+        resp = pureldap.LDAPStartTLSResponse(resultCode=0, tag=42)
+        resp_repr = "LDAPStartTLSResponse(tag=42)"
+        self.assertEqual(repr(resp), resp_repr)
+
+    def test_attribute_value_assertion_repr(self):
+        """LDAPAttributeValueAssertion.__repr__"""
+        attributes = [(b'key', b'value'), (u'key', u'value')]
+        for key, value in attributes:
+            ava = pureldap.LDAPAttributeValueAssertion(
+                pureber.BEROctetString(key),
+                pureber.BEROctetString(value),
+            )
+            ava_repr = "LDAPAttributeValueAssertion(attributeDesc=BEROctetString(value='key'), " \
+                       "assertionValue=BEROctetString(value='value'))"
+            self.assertEqual(repr(ava), ava_repr)
+
+    def test_attribute_value_assertion_with_tag_repr(self):
+        """LDAPAttributeValueAssertion.__repr__ with custom tag attribute"""
+        attributes = [(b'key', b'value'), (u'key', u'value')]
+        for key, value in attributes:
+            ava = pureldap.LDAPAttributeValueAssertion(
+                pureber.BEROctetString(key),
+                pureber.BEROctetString(value),
+                tag=42,
+            )
+            ava_repr = "LDAPAttributeValueAssertion(attributeDesc=BEROctetString(value='key'), " \
+                       "assertionValue=BEROctetString(value='value'), tag=42)"
+            self.assertEqual(repr(ava), ava_repr)
+
+    def test_ldapfilter_not_repr(self):
+        """LDAPFilter_not.__repr__"""
+        values = [b'value', u'value']
+        for value in values:
+            lf = pureldap.LDAPFilter_not(pureber.BEROctetString(value))
+            lf_repr = "LDAPFilter_not(value=BEROctetString(value='value'))"
+            self.assertEqual(repr(lf), lf_repr)
+
+    def test_ldapfilter_not_with_tag_repr(self):
+        """LDAPFilter_not.__repr__ with custom tag attribute"""
+        values = [b'value', u'value']
+        for value in values:
+            lf = pureldap.LDAPFilter_not(pureber.BEROctetString(value), tag=42)
+            lf_repr = "LDAPFilter_not(value=BEROctetString(value='value'), tag=42)"
+            self.assertEqual(repr(lf), lf_repr)
+
+    def test_ldapfilter_substrings_repr(self):
+        """LDAPFilter_substrings.__repr__"""
+        types = [b'cn', u'cn']
+        values = [b'value', u'value']
+        for tp in types:
+            for value in values:
+                lf = pureldap.LDAPFilter_substrings(
+                    type=tp,
+                    substrings=[pureldap.LDAPFilter_substrings_initial(value=value)],
+                )
+                lf_repr = "LDAPFilter_substrings(type='cn', " \
+                          "substrings=[LDAPFilter_substrings_initial(value='value')])"
+                self.assertEqual(repr(lf), lf_repr)
+
+    def test_ldapfilter_substrings_with_tag_repr(self):
+        """LDAPFilter_substrings.__repr__ with custom tag attribute"""
+        types = [b'cn', u'cn']
+        values = [b'value', u'value']
+        for tp in types:
+            for value in values:
+                lf = pureldap.LDAPFilter_substrings(
+                    type=tp,
+                    substrings=[pureldap.LDAPFilter_substrings_initial(value=value)],
+                    tag=42,
+                )
+                lf_repr = "LDAPFilter_substrings(type='cn', " \
+                          "substrings=[LDAPFilter_substrings_initial(value='value')], tag=42)"
+                self.assertEqual(repr(lf), lf_repr)
+
+    def test_matching_rule_assertion_repr(self):
+        """LDAPMatchingRuleAssertion.__repr__"""
+        rules = [b'rule', u'rule']
+        types = [b'type', u'type']
+        values = [b'value', u'value']
+        for rule in rules:
+            for tp in types:
+                for value in values:
+                    mra = pureldap.LDAPMatchingRuleAssertion(rule, tp, value)
+                    mra_repr = "LDAPMatchingRuleAssertion(matchingRule=LDAPMatchingRuleAssertion_matchingRule(" \
+                               "value='rule'), type=LDAPMatchingRuleAssertion_type(value='type'), matchValue=" \
+                               "LDAPMatchingRuleAssertion_matchValue(value='value'), dnAttributes=None)"
+                    self.assertEqual(repr(mra), mra_repr)
+
+    def test_matching_rule_assertion_with_tag_repr(self):
+        """LDAPMatchingRuleAssertion.__repr__ with custom tag attribute"""
+        rules = [b'rule', u'rule']
+        types = [b'type', u'type']
+        values = [b'value', u'value']
+        for rule in rules:
+            for tp in types:
+                for value in values:
+                    mra = pureldap.LDAPMatchingRuleAssertion(rule, tp, value, tag=42)
+                    mra_repr = "LDAPMatchingRuleAssertion(matchingRule=LDAPMatchingRuleAssertion_matchingRule(" \
+                               "value='rule'), type=LDAPMatchingRuleAssertion_type(value='type'), matchValue=" \
+                               "LDAPMatchingRuleAssertion_matchValue(value='value'), dnAttributes=None, tag=42)"
+                    self.assertEqual(repr(mra), mra_repr)


### PR DESCRIPTION
pureldap and pureber minor fixes (mostly string representations):

* `__repr__` method encoding fixes like showing `LDAPResult(resultCode=0, matchedDN='uid=user')` instead of `LDAPResult(resultCode=0, matchedDN="b'uid=user'")`;
* showing `userIdentity`, `oldPasswd` and `newPasswd` in the `LDAPPasswordModifyRequest.__repr__`;
* `LDAPMatchingRuleAssertion.__init__` is now properly initialized with bytes attributes in Python 3;
* `LDAPExtendedResponse` custom tag is now used.

Showing passwords in the `LDAPPasswordModifyRequest` representation may sound not good but `LDAPBindRequest` was implemented in the same way.

Tests for `__repr__` methods were added to avoid test coverage issues.

`LDAPMatchingRuleAssertion` and `LDAPExtendedResponse` fixes are not actually `__repr__` fixes but they are rather trivial. Is it OK to have them in this PR?

### Contributor Checklist:

* [x] I have updated the release notes at `docs/source/NEWS.rst` 
* [x] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
