### PR TITLE
SASL Bind GSS-SPNEGO with no credentials causes List index out of range

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -1,6 +1,23 @@
 Changelog
 =========
 
+Release.next
+-------------------------
+
+Features
+^^^^^^^^
+
+Changes
+^^^^^^^
+
+Bugfixes
+^^^^^^^^
+
+- SASL Bind without credentials caused list index out of range. Issue #157, Fixed
+
+
+
+
 Release 19.1 (2019-09-09)
 -------------------------
 

--- a/ldaptor/test/test_proxy.py
+++ b/ldaptor/test/test_proxy.py
@@ -21,6 +21,19 @@ class Proxy(unittest.TestCase):
             server.transport.value(),
             pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=0), id=4).toWire()
         )
+    
+    def test_bind_sasl_no_credentials(self):
+        # result code 14 is saslInprogress, with some server credentials.
+        server = self.createServer([ pureldap.LDAPBindResponse(resultCode=14, 
+                                                               serverSaslCreds='test123'),])
+
+        server.dataReceived(pureldap.LDAPMessage(pureldap.LDAPBindRequest(auth=('GSS-SPNEGO',None)), id=4).toWire())
+        reactor.iterate() #TODO
+        self.assertEqual(
+            server.transport.value(),
+            pureldap.LDAPMessage(pureldap.LDAPBindResponse(resultCode=14, 
+                                                           serverSaslCreds='test123'), id=4).toWire()
+        )
 
     def test_search(self):
         server = self.createServer([ pureldap.LDAPBindResponse(resultCode=0),

--- a/ldaptor/test/test_proxy.py
+++ b/ldaptor/test/test_proxy.py
@@ -27,7 +27,8 @@ class Proxy(unittest.TestCase):
         server = self.createServer([ pureldap.LDAPBindResponse(resultCode=14, 
                                                                serverSaslCreds='test123'),])
 
-        server.dataReceived(pureldap.LDAPMessage(pureldap.LDAPBindRequest(auth=('GSS-SPNEGO',None)), id=4).toWire())
+        server.dataReceived(pureldap.LDAPMessage(pureldap.LDAPBindRequest(
+            auth=('GSS-SPNEGO', None), sasl=True), id=4).toWire())
         reactor.iterate() #TODO
         self.assertEqual(
             server.transport.value(),


### PR DESCRIPTION
Issue #157
Fixes issue by checking for missing credentails for both LDAP bind request, and bind response.
Also, Sasl credentials was being polluted with BER tag/size data, because .value was not used.
Updated bugfix in News and created test.


### Contributor Checklist:

* [x] I have updated the release notes at `docs/source/NEWS.rst` 
* [x] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.

```
tox -e py27-test-dev ldaptor.test.test_proxy.Proxy.test_bind_sasl_no_credentials
_____________________________________________________________________________________________________ summary ______________________________________________________________________________________________________
  py27-test-dev: commands succeeded
  congratulations :)
```
