### PR TITLE
Replace depricated calls to decodestring with decodebytes

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -9,6 +9,7 @@ Features
 
 Changes
 ^^^^^^^
+- Replaced depricated calls to base64.decodestring with base64.decodebytes
 
 Bugfixes
 ^^^^^^^^

--- a/ldaptor/entry.py
+++ b/ldaptor/entry.py
@@ -238,7 +238,7 @@ class BaseLDAPEntry(WireStrAlias):
             for digest in self.get(key, ()):
                 digest = to_bytes(digest)
                 if digest.startswith(b'{SSHA}'):
-                    raw = base64.decodestring(digest[len(b'{SSHA}'):])
+                    raw = base64.decodebytes(digest[len(b'{SSHA}'):])
                     salt = raw[20:]
                     got = sshaDigest(password, salt)
                     if got == digest:

--- a/ldaptor/protocols/ldap/ldifprotocol.py
+++ b/ldaptor/protocols/ldap/ldifprotocol.py
@@ -80,7 +80,7 @@ class LDIF(basic.LineReceiver, object):
 
     def parseValue(self, val):
         if val.startswith(b':'):
-            return base64.decodestring(val[1:].lstrip(b' '))
+            return base64.decodebytes(val[1:].lstrip(b' '))
         elif val.startswith(b'<'):
             raise NotImplementedError()
         else:

--- a/ldaptor/test/test_server.py
+++ b/ldaptor/test/test_server.py
@@ -718,7 +718,7 @@ class LDAPServerTest(unittest.TestCase):
         self.assertEqual(len(secrets), 1)
         for secret in secrets:
             self.assertEqual(secret[:len(b'{SSHA}')], b'{SSHA}')
-            raw = base64.decodestring(secret[len(b'{SSHA}'):])
+            raw = base64.decodebytes(secret[len(b'{SSHA}'):])
             salt = raw[20:]
             self.assertEqual(entry.sshaDigest(b'hushhush', salt), secret)
 


### PR DESCRIPTION
This change is nominal and removes a warning message about the use of deprecated methods. 

### Contributor Checklist:

* [x] I have updated the release notes at `docs/source/NEWS.rst` 
* [?] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
