### PR TITLE
Add a repr for LDAPBindResponse_serverSaslCreds so that binary data can be logged

### DIFF
--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -340,7 +340,14 @@ class LDAPResult(LDAPProtocolResponse, BERSequence):
 class LDAPBindResponse_serverSaslCreds(BEROctetString):
     tag = CLASS_CONTEXT | 0x07
 
-    pass
+    def __repr__(self):
+        if self.tag == self.__class__.tag:
+            return self.__class__.__name__ + "(value=%s)" \
+                   % self.value
+        else:
+            return self.__class__.__name__ \
+                   + "(value=%s, tag=%d)" \
+                     % (self.value, self.tag)
 
 
 class LDAPBERDecoderContext_BindResponse(BERDecoderContext):

--- a/ldaptor/test/test_pureldap.py
+++ b/ldaptor/test/test_pureldap.py
@@ -1571,8 +1571,8 @@ class TestRepresentations(unittest.TestCase):
         self.assertEqual(actual_repr, expected_repr)
 
     def test_ldap_bind_response_server_sasl_creds_with_tag_repr(self):
-        """ ServerSaslCreds will often have binary data. A custom repr is needed because
-        it cannot be turned into a unicode string like most BEROctetString objects.
+        """ An LDAPBindResponse_serverSaslCreds with a non-standard tag will have that
+        tag show up in the text representation.
         """
         sasl_creds = pureldap.LDAPBindResponse_serverSaslCreds(value=b'NTLMSSP\xbe', tag=12)
         if six.PY3:

--- a/ldaptor/test/test_pureldap.py
+++ b/ldaptor/test/test_pureldap.py
@@ -1561,3 +1561,29 @@ class TestRepresentations(unittest.TestCase):
                                "value='rule'), type=LDAPMatchingRuleAssertion_type(value='type'), matchValue=" \
                                "LDAPMatchingRuleAssertion_matchValue(value='value'), dnAttributes=None, tag=42)"
                     self.assertEqual(repr(mra), mra_repr)
+
+    def test_ldap_bind_response_server_sasl_creds_repr(self):
+        """ ServerSaslCreds will often have binary data. A custom repr is needed because
+        it cannot be turned into a unicode string like most BEROctetString objects.
+        """
+        sasl_creds = pureldap.LDAPBindResponse_serverSaslCreds(value=b'NTLMSSP\xbe')
+        if six.PY3:
+            expected_repr = r"LDAPBindResponse_serverSaslCreds(value=b'NTLMSSP\xbe')"
+        else:
+            expected_repr = "LDAPBindResponse_serverSaslCreds(value=NTLMSSP\xbe)"
+
+        actual_repr = repr(sasl_creds)
+        self.assertEqual(actual_repr, expected_repr)
+
+    def test_ldap_bind_response_server_sasl_creds_with_tag_repr(self):
+        """ ServerSaslCreds will often have binary data. A custom repr is needed because
+        it cannot be turned into a unicode string like most BEROctetString objects.
+        """
+        sasl_creds = pureldap.LDAPBindResponse_serverSaslCreds(value=b'NTLMSSP\xbe', tag=12)
+        if six.PY3:
+            expected_repr = r"LDAPBindResponse_serverSaslCreds(value=b'NTLMSSP\xbe', tag=12)"
+        else:
+            expected_repr = "LDAPBindResponse_serverSaslCreds(value=NTLMSSP\xbe, tag=12)"
+
+        actual_repr = repr(sasl_creds)
+        self.assertEqual(actual_repr, expected_repr)


### PR DESCRIPTION
In practice the `LDAPBindResponse_serverSaslCreds` object has a `value` that is not a utf-8 string like most objects, but is instead binary data.
This means that when you try to `repr()` the message for logging you can't use the default `repr` that is on `BEROctetString` because it tries to do a utf-8 decode.

Since the `LDAPBindResponse_serverSaslCreds` object already existed I just implemented a `__repr__` on it that didn't try to do utf-8 decoding.

As far as testing goes I was able to write a couple unit tests for this functionality and we also are successfully using this patch in our project that uses ldaptor. Due to the default nature of strings in python 2 vs python 3 I could not write a test case that passed in both language versions without using six. If someone knows of a better way please feel free to let me know or just edit the PR directly.

Let me know if you have any other questions or feedback!
Xander

### Contributor Checklist:

* [ ] I have updated the release notes at `docs/source/NEWS.rst` 
* [X] I have updated the automated tests.
* [X] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
