### PR TITLE
return an LDAPSearchResultEntry even if all attributes are filtered

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -13,10 +13,10 @@ Changes
 Bugfixes
 ^^^^^^^^
 
-- SASL Bind without credentials caused list index out of range. Issue #157, Fixed
-- return an LDAPSearchResultEntry even if all attributes are filtered. Issue #166, Fixed
-
-
+- SASL Bind without credentials caused list index out of range. Issue #157.
+- ldaptor.protocols.ldap.ldapserver.LDAPServer.handle_LDAPSearchRequest
+  now returns an LDAPSearchResultEntry without any attributes when there is no match
+  between the requested attributes and the entrie's attributes .Issue #166.
 
 
 Release 19.1 (2019-09-09)

--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -16,7 +16,7 @@ Bugfixes
 - SASL Bind without credentials caused list index out of range. Issue #157.
 - ldaptor.protocols.ldap.ldapserver.LDAPServer.handle_LDAPSearchRequest
   now returns an LDAPSearchResultEntry without any attributes when there is no match
-  between the requested attributes and the entrie's attributes .Issue #166.
+  between the requested attributes and the entrie's attributes. Issue #166.
 
 
 Release 19.1 (2019-09-09)

--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -14,6 +14,7 @@ Bugfixes
 ^^^^^^^^
 
 - SASL Bind without credentials caused list index out of range. Issue #157, Fixed
+- return an LDAPSearchResultEntry even if all attributes are filtered. Issue #166, Fixed
 
 
 

--- a/ldaptor/protocols/ldap/ldapserver.py
+++ b/ldaptor/protocols/ldap/ldapserver.py
@@ -255,11 +255,12 @@ class LDAPServer(BaseLDAPServer):
                     (k, entry.get(k)) for k in requested_attribs if k in entry]
             else:
                 filtered_attribs = entry.items()
-            if len(filtered_attribs) > 0:
-                reply(pureldap.LDAPSearchResultEntry(
+            reply(
+                pureldap.LDAPSearchResultEntry(
                     objectName=entry.dn.getText(),
                     attributes=filtered_attribs,
-                    ))
+                )
+            )
         d = base.search(filterObject=request.filter,
                         attributes=request.attributes,
                         scope=request.scope,

--- a/ldaptor/test/test_server.py
+++ b/ldaptor/test/test_server.py
@@ -365,13 +365,20 @@ class LDAPServerTest(unittest.TestCase):
     def test_search_matchAll_oneResult_filteredNoAttribsRemaining(self):
         """
         Attempt to search an existing object with a set of nonexistent attributes
-        results in an empty successful response
+        results in a successful response with no attributes
         """
         self.makeSearch(
             baseObject='cn=thingie,ou=stuff,dc=example,dc=com',
             attributes=['xyzzy']
         )
-        self.assertSearchResults()
+        self.assertSearchResults(
+            [
+                {
+                    'objectName': 'cn=thingie,ou=stuff,dc=example,dc=com',
+                    'attributes': [],
+                },
+            ],
+        )
 
     def test_search_matchAll_manyResults(self):
         """Searching for a tree object with receiving it and all its children (default scope)"""


### PR DESCRIPTION
## Remove this paragraph

Please have a look at our dev docs before submitting your PR:
https://github.com/twisted/ldaptor/blob/master/CONTRIBUTING.rst


### Contributor Checklist:

* [ ] I have updated the release notes at `docs/source/NEWS.rst` 
* [ ] I have updated the automated tests.
* [ ] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
