### PR TITLE
Release to PyPI on a pushed tag using Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,3 +51,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: tox -e py-test-twlatest,py-test-twtrunk,py-linters,publishcov,release
+
+      - name: upload dist
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.os }}_${{ matrix.python-version}}_dist
+          path: dist
+
+  all-successful:
+    # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
+    runs-on: ubuntu-latest
+    needs: [tox]
+    steps:
+    - name: Download dists for PyPI
+      uses: actions/download-artifact@v2
+      with:
+        name: ubuntu-latest_3.8_dist
+
+    - name: Publish to PyPI for a new tag
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@v1.3.1
+      with:
+        password: ${{ secrets.PYPI_GITHUB_PACKAGE_UPLOAD }}
+
+    - name: note that all tests succeeded
+      run: echo "🎉"

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -47,7 +47,13 @@ Try not to write the release notes as a commit message.
 Release process
 ---------------
 
-The release is done manually.
+The release is done automatically via GitHub actions when a new tag
+is pushed.
+
+PyPI access is done via the HTTP API token stored in GitHub Secrets as
+PYPI_GITHUB_PACKAGE_UPLOAD from
+https://github.com/twisted/ldaptor/settings/secrets
+
 You can test the release process (without the publish) using `tox -e release`.
 Inspect the distributable files with `tree dist`, you could upload them with `twine`.
 

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,6 @@ https://github.com/twisted/ldaptor/blob/master/CONTRIBUTING.rst
 
 ### Contributor Checklist:
 
-* [ ] I have updated the release notes at `docs/source/NEWS.rst` 
+* [ ] I have updated the release notes at `docs/source/NEWS.rst`
 * [ ] I have updated the automated tests.
 * [ ] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.

--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -10,6 +10,7 @@ Features
 Changes
 ^^^^^^^
 
+- PyPI release is now done via GitHub Action
 - the ldaptor whl is now built with pep517.
 - the ldaptor whl is tested with tox. The sdist is now untested,
   deprecated and should only be used for compatability with very old

--- a/ldaptor/__init__.py
+++ b/ldaptor/__init__.py
@@ -1,3 +1,4 @@
+"""A Pure-Python Twisted library for LDAP"""
 __version__ = "19.1.0"
 
 __title__ = "ldaptor"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ whitelist_externals =
     rm
 commands =
     rm -rf {toxinidir}/dist
-    cp -r {distdir} {toxinidir}/dist; # copy the wheel built by tox-wheel
+    cp -r {distdir} {toxinidir}/dist # copy the wheel built by tox-wheel
     {envpython} -m pep517.build --source --out-dir={toxinidir}/dist {toxinidir}
 
 [testenv:publishcov]


### PR DESCRIPTION
# Scope

This add automatic release when a new tag is pushed.

The release is done via GitHub actions 

# Changes

Add a Github Action workflow based on https://github.com/pypa/gh-action-pypi-publish

Use the PyPi token generated by @psi29a 


# How to test

All automated tests are executed before a release.

There is no actual PyPI release if this is a not a tag. 

Every test matrix run uploads their dist as an artifact

Testing might be a trial and error and we might need to manually delete some packages.