### PR TITLE
build wheel only once per tox invocation

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -14,6 +14,7 @@ Changes
 - the ldaptor whl is tested with tox. The sdist is now untested,
   deprecated and should only be used for compatability with very old
   packaging tools.
+- the setup.py file is deprecated and will be removed in a future release.
 
 Bugfixes
 ^^^^^^^^

--- a/ldaptor/test/test_ldiftree.py
+++ b/ldaptor/test/test_ldiftree.py
@@ -57,6 +57,10 @@ class RandomizeListdirTestCase(unittest.TestCase):
 
         self.addCleanup(reverse_listdir)
 
+    def chmod(self, path, mode):
+        self.addCleanup(os.chmod, path, os.stat(path).st_mode)
+        os.chmod(path, mode)
+
 
 class Dir2LDIF(RandomizeListdirTestCase):
     def setUp(self):
@@ -115,7 +119,7 @@ objectClass: top
 
     @skipIfWindowsOrRoot
     def testNoAccess(self):
-        os.chmod(os.path.join(self.tree,
+        self.chmod(os.path.join(self.tree,
                               'dc=com.dir',
                               'dc=example.dir',
                               'cn=foo.ldif'),
@@ -445,29 +449,29 @@ cn: theChild
 
     @skipIfWindowsOrRoot
     def test_children_noAccess_dir_noRead(self):
-        os.chmod(self.meta.path, 0o300)
+        self.chmod(self.meta.path, 0o300)
         d = self.meta.children()
         def eb(fail):
             fail.trap(OSError)
             self.assertEqual(fail.value.errno, errno.EACCES)
-            os.chmod(self.meta.path, 0o755)
+            self.chmod(self.meta.path, 0o755)
         d.addCallbacks(testutil.mustRaise, eb)
         return d
 
     @skipIfWindowsOrRoot
     def test_children_noAccess_dir_noExec(self):
-        os.chmod(self.meta.path, 0o600)
+        self.chmod(self.meta.path, 0o600)
         d = self.meta.children()
         def eb(fail):
             fail.trap(IOError)
             self.assertEqual(fail.value.errno, errno.EACCES)
-            os.chmod(self.meta.path, 0o755)
+            self.chmod(self.meta.path, 0o755)
         d.addCallbacks(testutil.mustRaise, eb)
         return d
 
     @skipIfWindowsOrRoot
     def test_children_noAccess_file(self):
-        os.chmod(os.path.join(self.meta.path, u'cn=foo.ldif'), 0)
+        self.chmod(os.path.join(self.meta.path, u'cn=foo.ldif'), 0)
         d = self.meta.children()
         def eb(fail):
             fail.trap(IOError)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ envlist =
 
 [testenv]
 wheel = True
-wheel_pep571 = True
+wheel_pep517 = True
 wheel_build_env = build
 deps = 
     coverage >= 5.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ envlist =
 [testenv]
 wheel = True
 wheel_pep571 = True
+wheel_build_env = build
 deps = 
     coverage >= 5.3
     pyparsing
@@ -67,6 +68,9 @@ commands =
     {dev,linters}: pyflakes ldaptor
     {dev,linters}: check-manifest
 
+[testenv:build]
+# empty environment to build universal wheel once per tox invocation
+# https://github.com/ionelmc/tox-wheel#build-configuration
 
 [testenv:documentation]
 deps = sphinx


### PR DESCRIPTION
Currently a whl is built for each TOX_ENV, with this PR the whl will be created once before all other TOX_ENVs and reused

### Contributor Checklist:

* [ ] I have updated the release notes at `docs/source/NEWS.rst` 
* [x] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
