### PR TITLE
suppress rtd doc build unknown mimetype warnings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -261,3 +261,5 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+suppress_warnings = ["epub.unknown_project_files"]


### PR DESCRIPTION
RTD only builds html docs on PR branches, and the master build fails when it runs the epub version: https://github.com/readthedocs/readthedocs.org/issues/7116

### Contributor Checklist:

* [ ] I have updated the release notes at `docs/source/NEWS.rst`
* [ ] I have updated the automated tests.
* [ ] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
