### PR TITLE
move linters to pre-commit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml', 'setup.py', 'setup.cfg') }}
+          key:
+            ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml', 'setup.py',
+            'setup.cfg') }}
           restore-keys: |
             ${{ runner.os }}-pip-
 
@@ -63,20 +65,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tox]
     steps:
-    - name: Download dists for PyPI
-      uses: actions/download-artifact@v2
-      with:
-        name: ubuntu-latest_3.8_dist
-        path: dist
+      - name: Download dists for PyPI
+        uses: actions/download-artifact@v2
+        with:
+          name: ubuntu-latest_3.8_dist
+          path: dist
 
-    - name: Display structure of downloaded files
-      run: ls -R
+      - name: Display structure of downloaded files
+        run: ls -R
 
-    - name: Publish to PyPI for a new tag
-      if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@v1.3.1
-      with:
-        password: ${{ secrets.PYPI_GITHUB_PACKAGE_UPLOAD }}
+      - name: Publish to PyPI for a new tag
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@v1.3.1
+        with:
+          password: ${{ secrets.PYPI_GITHUB_PACKAGE_UPLOAD }}
 
-    - name: note that all tests succeeded
-      run: echo "🎉"
+      - name: note that all tests succeeded
+        run: echo "🎉"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,10 +49,14 @@ jobs:
         run: |
           pip install tox
 
+      - name: tox linters
+        if: matrix.python-version != 3.5 && matrix.python-version != 'pypy3'
+        run: tox -e py-linters
+
       - name: tox
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: tox -e py-test-twlatest,py-test-twtrunk,py-linters,publishcov,release
+        run: tox -e py-test-twlatest,py-test-twtrunk,publishcov,release
 
       - name: upload dist
         uses: actions/upload-artifact@v2

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ _trial_temp/
 ldaptor.test.*/
 ldaptor/test/ldif/webtests.tmp
 docs/*.png
-docs/build/
 ldaptor.egg-info
 .idea
 .coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,46 @@
+repos:
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.7.2
+    hooks:
+      - id: pyupgrade
+        args: ["--py3-plus"]
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+      - id: flake8
+
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.6.0
+    hooks:
+      - id: python-check-blanket-noqa
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: check-yaml
+      - id: mixed-line-ending
+
+  - repo: https://github.com/prettier/prettier
+    rev: 2.1.1
+    hooks:
+      - id: prettier
+        args: [--prose-wrap=always, --print-width=88]
+
+  - repo: https://github.com/myint/autoflake
+    rev: v1.4
+    hooks:
+      - id: autoflake
+        args:
+          - --in-place
+          - --remove-all-unused-imports
+          - --expand-star-imports
+          - --remove-duplicate-keys
+          - --remove-unused-variables
+
+  - repo: https://github.com/mgedmin/check-manifest
+    rev: "0.39"
+    hooks:
+      - id: check-manifest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/prettier/prettier
-    rev: 2.1.1
+    rev: 2.1.2
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]
@@ -41,6 +41,6 @@ repos:
           - --remove-unused-variables
 
   - repo: https://github.com/mgedmin/check-manifest
-    rev: "0.39"
+    rev: "0.43"
     hooks:
       - id: check-manifest

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -64,7 +64,7 @@ Building the documentation
 --------------------------
 
 The documentation is managed using Python Sphinx and is generated in
-docs/build.
+build/docs.
 
 There is a helper to build the documentation using tox ::
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include *.rst
 include *.txt
 exclude .readthedocs.yml
+exclude .pre-commit-config.yaml
 include LICENSE
 include docs/source/examples/ldif2ldif
 include ldaptor.schema

--- a/bin/ldaptor-ldap2maradns
+++ b/bin/ldaptor-ldap2maradns
@@ -192,7 +192,6 @@ class MyOptions(usage.Options, usage.Options_service_location, usage.Options_bas
         self.opts['filter'] = filter
 
 if __name__ == "__main__":
-    import sys
     try:
         opts = MyOptions()
         opts.parseOptions()

--- a/bin/ldaptor-ldap2pdns
+++ b/bin/ldaptor-ldap2pdns
@@ -198,7 +198,7 @@ class PdnsPipeProtocol(LineReceiver):
                 d=succeed(['LOG\tUnknown command %s in state %s'
                            % (repr(type), self.state),
                            'END'])
-        except:
+        except BaseException:
             f=Failure()
             d=fail(f)
 
@@ -276,7 +276,6 @@ if __name__ == "__main__":
         sys.stderr.write('{}: {}\n'.format(sys.argv[0], ue))
         sys.exit(1)
 
-    from twisted.python import log
     log.startLogging(sys.stderr, setStdout=0)
 
     cfg = config.LDAPConfig(baseDN=opts['base'],

--- a/bin/ldaptor-passwd
+++ b/bin/ldaptor-passwd
@@ -65,7 +65,7 @@ class PasswdClient(ldapclient.LDAPClient):
         return d
 
     def _report_pwgen_error(self, fail):
-        fail.trap(PwgenException)
+        fail.trap(generate_password.PwgenException)
         print('pwgen:', fail.getErrorMessage(), file=sys.stderr)
         return fail
 

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -3,9 +3,8 @@
 Please have a look at our dev docs before submitting your PR:
 https://github.com/twisted/ldaptor/blob/master/CONTRIBUTING.rst
 
-
 ### Contributor Checklist:
 
-* [ ] I have updated the release notes at `docs/source/NEWS.rst`
-* [ ] I have updated the automated tests.
-* [ ] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
+- [ ] I have updated the release notes at `docs/source/NEWS.rst`
+- [ ] I have updated the automated tests.
+- [ ] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.

--- a/docs/source/examples/addressbook/02_script/addressbook.py
+++ b/docs/source/examples/addressbook/02_script/addressbook.py
@@ -36,7 +36,7 @@ def main():
     d = search(config)
     def _show(results):
         for item in results:
-            print item
+            print(item)
     d.addCallback(_show)
     d.addErrback(defer.logError)
     d.addBoth(lambda _: reactor.stop())

--- a/docs/source/examples/addressbook/05_form/addressbook.py
+++ b/docs/source/examples/addressbook/05_form/addressbook.py
@@ -24,7 +24,7 @@ class ILDAPConfig(Interface):
         DistinguishedName to (host, port) tuples.
         """
 
-class LDAPConfig(object):
+class LDAPConfig:
     implements(ILDAPConfig)
 
     def __init__(self,
@@ -45,17 +45,17 @@ class LDAPConfig(object):
 
 class LDAPSearchFilter(annotate.String):
     def coerce(self, *a, **kw):
-        val = super(LDAPSearchFilter, self).coerce(*a, **kw)
+        val = super().coerce(*a, **kw)
         try:
             f = ldapfilter.parseFilter(val)
         except ldapfilter.InvalidLDAPFilter as e:
-            raise annotate.InputError("%r is not a valid LDAP search filter: %s" % (val, e))
+            raise annotate.InputError("{!r} is not a valid LDAP search filter: {}".format(val, e))
         return f
 
 class IAddressBookSearch(annotate.TypedInterface):
     search = LDAPSearchFilter(label="Search filter")
 
-class CurrentSearch(object):
+class CurrentSearch:
     implements(IAddressBookSearch, inevow.IContainer)
     search = None
 

--- a/docs/source/examples/addressbook/05_form/addressbook.py
+++ b/docs/source/examples/addressbook/05_form/addressbook.py
@@ -3,8 +3,9 @@ from zope.interface import Interface, implements
 from twisted.internet import reactor, defer
 from twisted.cred import portal, checkers
 from nevow import rend, appserver, inevow, \
-     stan, guard, loaders, flat
+     guard, loaders
 from formless import annotate, webform
+import nevow.flat
 
 from ldaptor.protocols.ldap import ldapclient, ldapsyntax, ldapconnector, \
      distinguishedname
@@ -47,9 +48,8 @@ class LDAPSearchFilter(annotate.String):
         val = super(LDAPSearchFilter, self).coerce(*a, **kw)
         try:
             f = ldapfilter.parseFilter(val)
-        except ldapfilter.InvalidLDAPFilter, e:
-            raise annotate.InputError, \
-                  "%r is not a valid LDAP search filter: %s" % (val, e)
+        except ldapfilter.InvalidLDAPFilter as e:
+            raise annotate.InputError("%r is not a valid LDAP search filter: %s" % (val, e))
         return f
 
 class IAddressBookSearch(annotate.TypedInterface):
@@ -139,7 +139,7 @@ class AddressBookRealm:
 
     def requestAvatar(self, avatarId, mind, *interfaces):
         if inevow.IResource not in interfaces:
-            raise NotImplementedError, "no interface"
+            raise NotImplementedError("no interface")
         return (inevow.IResource,
                 self.resource,
                 lambda: None)

--- a/docs/source/examples/addressbook/05_form/searchform.xhtml
+++ b/docs/source/examples/addressbook/05_form/searchform.xhtml
@@ -1,9 +1,7 @@
 <?xml version="1.0"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
-<html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:nevow="http://nevow.com/ns/nevow/0.1">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:nevow="http://nevow.com/ns/nevow/0.1">
   <head>
     <title>Address book search</title>
     <link href="/form_css" rel="stylesheet" />
@@ -18,16 +16,17 @@
     <div nevow:render="haveSearch" nevow:data="search">
       <p nevow:pattern="False">No search given.</p>
       <div nevow:pattern="True">
-	<div nevow:render="sequence" nevow:data="results">
-	  <p nevow:pattern="empty">No entries found.</p>
-	  <pre nevow:pattern="item" nevow:render="string">
+        <div nevow:render="sequence" nevow:data="results">
+          <p nevow:pattern="empty">No entries found.</p>
+          <pre nevow:pattern="item" nevow:render="string">
 	    LDIF output goes here.
-	  </pre>
-	</div>
-	<p>
-	  Used search filter:
-	  <span nevow:render="searchFilter" nevow:data="searchFilter"/>
-	</p>
+	  </pre
+          >
+        </div>
+        <p>
+          Used search filter:
+          <span nevow:render="searchFilter" nevow:data="searchFilter" />
+        </p>
       </div>
     </div>
   </body>

--- a/docs/source/examples/addressbook/06_pretty/addressbook.py
+++ b/docs/source/examples/addressbook/06_pretty/addressbook.py
@@ -47,9 +47,8 @@ class LDAPSearchFilter(annotate.String):
         val = super(LDAPSearchFilter, self).coerce(*a, **kw)
         try:
             f = ldapfilter.parseFilter(val)
-        except ldapfilter.InvalidLDAPFilter, e:
-            raise annotate.InputError, \
-                  "%r is not a valid LDAP search filter: %s" % (val, e)
+        except ldapfilter.InvalidLDAPFilter as e:
+            raise annotate.InputError("%r is not a valid LDAP search filter: %s" % (val, e))
         return f
 
 class IAddressBookSearch(annotate.TypedInterface):
@@ -157,7 +156,7 @@ class AddressBookRealm:
 
     def requestAvatar(self, avatarId, mind, *interfaces):
         if inevow.IResource not in interfaces:
-            raise NotImplementedError, "no interface"
+            raise NotImplementedError("no interface")
         return (inevow.IResource,
                 self.resource,
                 lambda: None)

--- a/docs/source/examples/addressbook/06_pretty/addressbook.py
+++ b/docs/source/examples/addressbook/06_pretty/addressbook.py
@@ -23,7 +23,7 @@ class ILDAPConfig(Interface):
         DistinguishedName to (host, port) tuples.
         """
 
-class LDAPConfig(object):
+class LDAPConfig:
     implements(ILDAPConfig)
 
     def __init__(self,
@@ -44,17 +44,17 @@ class LDAPConfig(object):
 
 class LDAPSearchFilter(annotate.String):
     def coerce(self, *a, **kw):
-        val = super(LDAPSearchFilter, self).coerce(*a, **kw)
+        val = super().coerce(*a, **kw)
         try:
             f = ldapfilter.parseFilter(val)
         except ldapfilter.InvalidLDAPFilter as e:
-            raise annotate.InputError("%r is not a valid LDAP search filter: %s" % (val, e))
+            raise annotate.InputError("{!r} is not a valid LDAP search filter: {}".format(val, e))
         return f
 
 class IAddressBookSearch(annotate.TypedInterface):
     search = LDAPSearchFilter(label="Search filter")
 
-class CurrentSearch(object):
+class CurrentSearch:
     implements(IAddressBookSearch, inevow.IContainer)
     search = None
 

--- a/docs/source/examples/addressbook/06_pretty/searchform.xhtml
+++ b/docs/source/examples/addressbook/06_pretty/searchform.xhtml
@@ -1,9 +1,7 @@
 <?xml version="1.0"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
-<html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:nevow="http://nevow.com/ns/nevow/0.1">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:nevow="http://nevow.com/ns/nevow/0.1">
   <head>
     <title>Address book search</title>
     <link href="/form_css" rel="stylesheet" />
@@ -18,25 +16,25 @@
     <div nevow:render="haveSearch" nevow:data="search">
       <p nevow:pattern="False">No search given.</p>
       <div nevow:pattern="True">
-	<ol nevow:render="sequence" nevow:data="results">
-	  <p nevow:pattern="empty">No entries found.</p>
-	  <li nevow:pattern="item" style="margin-bottom: 2em;">
-	    <dl nevow:render="iterateMapping">
-	      <dt nevow:pattern="key" nevow:render="string">
-		Attribute type goes here
-	      </dt>
-	      <nevow:invisible nevow:pattern="value" nevow:render="sequence">
-		<dd nevow:pattern="item" nevow:render="string">
-		  Attribute value goes here
-		</dd>
-	      </nevow:invisible>
-	    </dl>
-	  </li>
-	</ol>
-	<p>
-	  Used search filter:
-	  <span nevow:render="searchFilter" nevow:data="searchFilter"/>
-	</p>
+        <ol nevow:render="sequence" nevow:data="results">
+          <p nevow:pattern="empty">No entries found.</p>
+          <li nevow:pattern="item" style="margin-bottom: 2em">
+            <dl nevow:render="iterateMapping">
+              <dt nevow:pattern="key" nevow:render="string">
+                Attribute type goes here
+              </dt>
+              <nevow:invisible nevow:pattern="value" nevow:render="sequence">
+                <dd nevow:pattern="item" nevow:render="string">
+                  Attribute value goes here
+                </dd>
+              </nevow:invisible>
+            </dl>
+          </li>
+        </ol>
+        <p>
+          Used search filter:
+          <span nevow:render="searchFilter" nevow:data="searchFilter" />
+        </p>
       </div>
     </div>
   </body>

--- a/docs/source/examples/addressbook/07_easy/searchform.xhtml
+++ b/docs/source/examples/addressbook/07_easy/searchform.xhtml
@@ -1,9 +1,7 @@
 <?xml version="1.0"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
-<html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:nevow="http://nevow.com/ns/nevow/0.1">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:nevow="http://nevow.com/ns/nevow/0.1">
   <head>
     <title>Address book search</title>
     <link href="/form_css" rel="stylesheet" />
@@ -18,25 +16,25 @@
     <div nevow:render="haveSearch" nevow:data="search">
       <p nevow:pattern="False">No search given.</p>
       <div nevow:pattern="True">
-	<ol nevow:render="sequence" nevow:data="results">
-	  <p nevow:pattern="empty">No entries found.</p>
-	  <li nevow:pattern="item" style="margin-bottom: 2em;">
-	    <dl nevow:render="iterateMapping">
-	      <dt nevow:pattern="key" nevow:render="string">
-		Attribute type goes here
-	      </dt>
-	      <nevow:invisible nevow:pattern="value" nevow:render="sequence">
-		<dd nevow:pattern="item" nevow:render="string">
-		  Attribute value goes here
-		</dd>
-	      </nevow:invisible>
-	    </dl>
-	  </li>
-	</ol>
-	<p>
-	  Used search filter:
-	  <span nevow:render="searchFilter" nevow:data="searchFilter"/>
-	</p>
+        <ol nevow:render="sequence" nevow:data="results">
+          <p nevow:pattern="empty">No entries found.</p>
+          <li nevow:pattern="item" style="margin-bottom: 2em">
+            <dl nevow:render="iterateMapping">
+              <dt nevow:pattern="key" nevow:render="string">
+                Attribute type goes here
+              </dt>
+              <nevow:invisible nevow:pattern="value" nevow:render="sequence">
+                <dd nevow:pattern="item" nevow:render="string">
+                  Attribute value goes here
+                </dd>
+              </nevow:invisible>
+            </dl>
+          </li>
+        </ol>
+        <p>
+          Used search filter:
+          <span nevow:render="searchFilter" nevow:data="searchFilter" />
+        </p>
       </div>
     </div>
   </body>

--- a/docs/source/examples/ldap_parallelsearch.py
+++ b/docs/source/examples/ldap_parallelsearch.py
@@ -22,7 +22,7 @@ import sys
 exitStatus=0
 
 def error(fail):
-    print >>sys.stderr, 'fail:', fail.getErrorMessage()
+    print('fail:', fail.getErrorMessage(), file=sys.stderr)
     global exitStatus
     exitStatus=1
 
@@ -34,7 +34,7 @@ def _search(proto, base, connection, numOfSearches):
     l=[]
     baseEntry = ldapsyntax.LDAPEntry(client=proto,
                                      dn=base)
-    for search in xrange(0, numOfSearches):
+    for search in range(0, numOfSearches):
         d=baseEntry.search(callback=lambda x:
                            _handle_entry(x, connection, search))
         d.addErrback(error)
@@ -46,7 +46,7 @@ def _search(proto, base, connection, numOfSearches):
 def main(base, serviceLocationOverrides, numOfConnections=3, numOfSearches=3):
     log.startLogging(sys.stderr, setStdout=0)
     l=[]
-    for connection in xrange(0, numOfConnections):
+    for connection in range(0, numOfConnections):
         c=ldapconnector.LDAPClientCreator(reactor, ldapclient.LDAPClient)
         d=c.connectAnonymously(base, serviceLocationOverrides)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,8 @@ commands =
     dev: coverage xml -o {toxinidir}/build/coverage.xml
     dev: coverage html -d build/coverage-html
     dev: diff-cover --fail-under 100 --html-report {toxinidir}/build/coverage-diff.html {toxinidir}/build/coverage.xml
-    {dev,linters}: pre-commit run --all-files --show-diff-on-failure {posargs}
+    dev: pre-commit run --all-files --show-diff-on-failure
+    linters: pre-commit {posargs:run --all-files --show-diff-on-failure}
 
 [testenv:build]
 # empty environment to build universal wheel once per tox invocation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,7 @@ deps =
     dev: Twisted[tls]
     dev: diff_cover
     ; Linters are installed both on local dev and the dedicated env.
-    {dev,linters}: pyflakes
-    {dev,linters}: check-manifest
+    {dev,linters}: pre-commit
 
 ; All environment variables are passed.
 passenv = *
@@ -64,8 +63,7 @@ commands =
     dev: coverage xml -o {toxinidir}/build/coverage.xml
     dev: coverage html -d build/coverage-html
     dev: diff-cover --fail-under 100 --html-report {toxinidir}/build/coverage-diff.html {toxinidir}/build/coverage.xml
-    {dev,linters}: pyflakes ldaptor
-    {dev,linters}: check-manifest
+    {dev,linters}: pre-commit run --all-files --show-diff-on-failure {posargs}
 
 [testenv:build]
 # empty environment to build universal wheel once per tox invocation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,10 +73,12 @@ commands =
 [testenv:documentation]
 deps = sphinx
 basepython=python3.8
+changedir = {envtmpdir}
+whitelist_externals = cp
 commands =
-    mkdir -p docs/build
-    sphinx-build -b html -Ean -j 2 -w build/sphinx-errors \
-        docs/source docs/build
+    sphinx-build -b html -Ean -j 2 -w sphinx-errors \
+        {toxinidir}/docs/source ./docs/
+    cp -r . {toxinidir}/build
 
 [testenv:release]
 deps = pep517

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,6 +78,7 @@ tag-format = v{version}
 
 [flake8]
 disable-noqa = True
+max-line-length = 368
 extend-ignore =
 
    E203,  # whitespace before : is not PEP8 compliant (& conflicts with black)
@@ -111,7 +112,6 @@ extend-ignore =
    E306,  # expected 1 blank line before a nested definition, found 0
    E401,  # multiple imports on one line
    E402,  # module level import not at top of file
-   E501,  # line too long (83 > 79 characters)
    E502,  # the backslash is redundant between brackets
    E701,  # multiple statements on one line (colon)
    E713,  # test for membership should be 'not in'

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,3 +74,53 @@ universal = 1
 python-file-with-version = ldaptor/__init__.py
 history-file = docs/source/NEWS.rst
 tag-format = v{version}
+
+
+[flake8]
+disable-noqa = True
+extend-ignore =
+
+   E203,  # whitespace before : is not PEP8 compliant (& conflicts with black)
+
+   E101,  # indentation contains mixed spaces and tabs
+   E111,  # indentation is not a multiple of four
+   E116,  # unexpected indentation (comment)
+   E117,  # over-indented
+   E122,  # continuation line missing indentation or outdented
+   E124,  # closing bracket does not match visual indentation
+   E125,  # continuation line with same indent as next logical line
+   E127,  # continuation line over-indented for visual indent
+   E128,  # continuation line under-indented for visual indent
+   E129,  # visually indented line with same indent as next logical line
+   E131,  # continuation line unaligned for hanging indent
+   E201,  # whitespace after '['
+   E202,  # whitespace before ']'
+   E221,  # multiple spaces before operator
+   E225,  # missing whitespace around operator
+   E227,  # missing whitespace around bitwise or shift operator
+   E228,  # missing whitespace around modulo operator
+   E231,  # missing whitespace after ','
+   E251,  # unexpected spaces around keyword / parameter equals
+   E261,  # at least two spaces before inline comment
+   E262,  # inline comment should start with '# '
+   E265,  # block comment should start with '# '
+   E301,  # expected 1 blank line, found 0
+   E302,  # expected 2 blank lines, found 1
+   E303,  # too many blank lines (3)
+   E305,  # expected 2 blank lines after class or function definition, found 1
+   E306,  # expected 1 blank line before a nested definition, found 0
+   E401,  # multiple imports on one line
+   E402,  # module level import not at top of file
+   E501,  # line too long (83 > 79 characters)
+   E502,  # the backslash is redundant between brackets
+   E701,  # multiple statements on one line (colon)
+   E713,  # test for membership should be 'not in'
+   E741,  # ambiguous variable name 'l'
+   E743,  # ambiguous function definition 'l'
+   W191,  # indentation contains tabs
+   W291,  # trailing whitespace
+   W292,  # no newline at end of file
+   W293,  # blank line contains whitespace
+   W391,  # blank line at end of file
+   W601,  # .has_key() is deprecated, use 'in'
+   W602,  # deprecated form of raising exception


### PR DESCRIPTION
It's recommended to run pyflakes via flake8, and to run flake8 via pre-commit. So I configured them here.

I also configured prettier, and some other pre-commit hooks at the same time.

The advantage of running flake8 via pre-commit is that it also checks files that contain python code, but don't end in `.py`, So I fixed the issues there.

## Contributor Checklist:

* [ ] I have updated the release notes at `docs/source/NEWS.rst`
* [x] I have updated the automated tests.
* [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
