### PR TITLE
Remove repr_converter

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -4,7 +4,9 @@ Changelog
 20.1.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Updated the object representations of pureber and pureldap containers to
+  directly pass on their contained item object representations. Previously
+  they always passed on the repr after decoding to str with utf-8.
 
 
 20.1.0 (2020-09-30)

--- a/ldaptor/_encoder.py
+++ b/ldaptor/_encoder.py
@@ -34,10 +34,6 @@ def to_unicode(value):
     return value
 
 
-def repr_converter(value):
-    return value
-
-
 def get_strings(value):
     """
     Getting tuple of available string values

--- a/ldaptor/_encoder.py
+++ b/ldaptor/_encoder.py
@@ -35,10 +35,7 @@ def to_unicode(value):
 
 
 def repr_converter(value):
-    """
-    Converts value to its string representation:
-    """
-    return to_unicode(value)
+    return value
 
 
 def get_strings(value):

--- a/ldaptor/_encoder.py
+++ b/ldaptor/_encoder.py
@@ -37,9 +37,6 @@ def to_unicode(value):
 def repr_converter(value):
     """
     Converts value to its string representation:
-
-    * Byte string for Python 2
-    * Unicode string for Python 3
     """
     return to_unicode(value)
 

--- a/ldaptor/ldapfilter.py
+++ b/ldaptor/ldapfilter.py
@@ -240,9 +240,8 @@ def parseFilter(s):
     """
     Converting source string to pureldap.LDAPFilter
 
-    Source string is converted to unicode for Python 3
-    as pyparsing cannot parse Python 3 byte strings with
-    the rules declared in this module.
+    Source string is converted to unicode as pyparsing cannot parse bytes
+    objects with the rules declared in this module.
     """
     s = to_unicode(s)
     try:

--- a/ldaptor/ldiftree.py
+++ b/ldaptor/ldiftree.py
@@ -289,14 +289,12 @@ class LDIFTreeEntry(
 
     def __lt__(self, other):
         if not isinstance(other, LDIFTreeEntry):
-            # We don't return NotImplemented so that we get the same
-            # result in Python2 and Python3.
-            raise (TypeError, "unorderable types: {!r} > {!r}".format(self, other))
+            return NotImplemented
         return self.dn < other.dn
 
     def __gt__(self, other):
         if not isinstance(other, LDIFTreeEntry):
-            raise (TypeError, "unorderable types: {!r} < {!r}".format(self, other))
+            return NotImplemented
         return self.dn > other.dn
 
     def commit(self):

--- a/ldaptor/protocols/pureber.py
+++ b/ldaptor/protocols/pureber.py
@@ -33,7 +33,7 @@
 import sys
 from collections import UserList
 
-from ldaptor._encoder import to_bytes, repr_converter, WireStrAlias
+from ldaptor._encoder import to_bytes, WireStrAlias
 
 # xxxxxxxx
 # |/|\.../
@@ -225,7 +225,7 @@ class BEROctetString(BERBase):
         return result
 
     def __repr__(self):
-        value = repr_converter(self.value)
+        value = self.value
         if self.tag == self.__class__.tag:
             return self.__class__.__name__ + "(value=%s)" % repr(value)
         else:

--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -35,7 +35,7 @@ from ldaptor.protocols.pureber import (
     berDecodeObject,
     int2berlen,
 )
-from ldaptor._encoder import to_bytes, repr_converter
+from ldaptor._encoder import to_bytes
 
 next_ldap_message_id = 1
 
@@ -238,8 +238,8 @@ class LDAPBindRequest(LDAPProtocolRequest, BERSequence):
         auth = "*" * len(self.auth)
         l = []
         l.append("version=%d" % self.version)
-        l.append("dn=%s" % repr(repr_converter(self.dn)))
-        l.append("auth=%s" % repr(repr_converter(auth)))
+        l.append("dn=%s" % repr(self.dn))
+        l.append("auth=%s" % repr(auth))
         if self.tag != self.__class__.tag:
             l.append("tag=%d" % self.tag)
         l.append("sasl=%s" % repr(self.sasl))
@@ -280,7 +280,7 @@ class LDAPSearchResultReference(LDAPProtocolResponse, BERSequence):
     def __repr__(self):
         return "{}(uris={}{})".format(
             self.__class__.__name__,
-            repr([repr_converter(uri) for uri in self.uris]),
+            repr([uri for uri in self.uris]),
             ", tag={}".format(self.tag) if self.tag != self.__class__.tag else "",
         )
 
@@ -356,9 +356,9 @@ class LDAPResult(LDAPProtocolResponse, BERSequence):
         l = []
         l.append("resultCode=%r" % self.resultCode)
         if self.matchedDN:
-            l.append("matchedDN=%r" % repr_converter(self.matchedDN))
+            l.append("matchedDN=%r" % self.matchedDN)
         if self.errorMessage:
-            l.append("errorMessage=%r" % repr_converter(self.errorMessage))
+            l.append("errorMessage=%r" % self.errorMessage)
         if self.referral:
             l.append("referral=%r" % self.referral)
         if self.tag != self.__class__.tag:
@@ -649,7 +649,7 @@ class LDAPFilter_substrings(BERSequence):
         ).toWire()
 
     def __repr__(self):
-        tp = repr_converter(self.type)
+        tp = self.type
         if self.tag == self.__class__.tag:
             return self.__class__.__name__ + "(type={}, substrings={})".format(
                 repr(tp),
@@ -990,7 +990,7 @@ class LDAPSearchRequest(LDAPProtocolRequest, BERSequence):
         ).toWire()
 
     def __repr__(self):
-        base = repr_converter(self.baseObject)
+        base = self.baseObject
         if self.tag == self.__class__.tag:
             return self.__class__.__name__ + (
                 "(baseObject=%s, scope=%s, derefAliases=%s, "
@@ -1070,11 +1070,8 @@ class LDAPSearchResultEntry(LDAPProtocolResponse, BERSequence):
         ).toWire()
 
     def __repr__(self):
-        name = repr_converter(self.objectName)
-        attributes = [
-            (repr_converter(key), [repr_converter(v) for v in value])
-            for (key, value) in self.attributes
-        ]
+        name = self.objectName
+        attributes = [(key, [v for v in value]) for (key, value) in self.attributes]
         return "{}(objectName={}, attributes={}{})".format(
             self.__class__.__name__,
             repr(name),
@@ -1224,7 +1221,7 @@ class LDAPModifyRequest(LDAPProtocolRequest, BERSequence):
         return BERSequence(l, tag=self.tag).toWire()
 
     def __repr__(self):
-        name = repr_converter(self.object)
+        name = self.object
         if self.tag == self.__class__.tag:
             return self.__class__.__name__ + "(object={}, modification={})".format(
                 repr(name),
@@ -1286,7 +1283,7 @@ class LDAPAddRequest(LDAPProtocolRequest, BERSequence):
         ).toWire()
 
     def __repr__(self):
-        entry = repr_converter(self.entry)
+        entry = self.entry
         if self.tag == self.__class__.tag:
             return self.__class__.__name__ + "(entry={}, attributes={})".format(
                 repr(entry),
@@ -1322,7 +1319,7 @@ class LDAPDelRequest(LDAPProtocolRequest, LDAPString):
         return LDAPString.toWire(self)
 
     def __repr__(self):
-        entry = repr_converter(self.value)
+        entry = self.value
         if self.tag == self.__class__.tag:
             return self.__class__.__name__ + "(entry=%s)" % repr(entry)
         else:
@@ -1408,12 +1405,12 @@ class LDAPModifyDNRequest(LDAPProtocolRequest, BERSequence):
 
     def __repr__(self):
         l = [
-            "entry=%s" % repr(repr_converter(self.entry)),
-            "newrdn=%s" % repr(repr_converter(self.newrdn)),
+            "entry=%s" % repr(self.entry),
+            "newrdn=%s" % repr(self.newrdn),
             "deleteoldrdn=%s" % repr(self.deleteoldrdn),
         ]
         if self.newSuperior is not None:
-            l.append("newSuperior=%s" % repr(repr_converter(self.newSuperior)))
+            l.append("newSuperior=%s" % repr(self.newSuperior))
         if self.tag != self.__class__.tag:
             l.append("tag=%d" % self.tag)
         return self.__class__.__name__ + "(" + ", ".join(l) + ")"
@@ -1458,7 +1455,7 @@ class LDAPCompareRequest(LDAPProtocolRequest, BERSequence):
 
     def __repr__(self):
         l = [
-            "entry={}".format(repr(repr_converter(self.entry))),
+            "entry={}".format(repr(self.entry)),
             "ava={}".format(repr(self.ava)),
         ]
         return "{}({})".format(self.__class__.__name__, ", ".join(l))

--- a/ldaptor/test/test_pureldap.py
+++ b/ldaptor/test/test_pureldap.py
@@ -1243,58 +1243,94 @@ class TestRepresentations(unittest.TestCase):
 
     def test_bind_request_repr(self):
         """LDAPBindRequest.__repr__"""
-        dns = [
-            b"uid=user,ou=users,dc=example,dc=org",
-            "uid=user,ou=users,dc=example,dc=org",
-        ]
-        for dn in dns:
-            req = pureldap.LDAPBindRequest(dn=dn)
-            req_repr = "LDAPBindRequest(version=3, dn='uid=user,ou=users,dc=example,dc=org', auth='', sasl=False)"
-            self.assertEqual(repr(req), req_repr)
+        self.assertEqual(
+            repr(pureldap.LDAPBindRequest(dn=b"uid=user,ou=users,dc=example,dc=org")),
+            (
+                "LDAPBindRequest(version=3, dn=b'uid=user,ou=users,dc=example,dc=org', "
+                "auth='', sasl=False)"
+            ),
+        )
+        self.assertEqual(
+            repr(pureldap.LDAPBindRequest(dn="uid=user,ou=users,dc=example,dc=org")),
+            (
+                "LDAPBindRequest(version=3, dn='uid=user,ou=users,dc=example,dc=org', "
+                "auth='', sasl=False)"
+            ),
+        )
 
     def test_bind_request_with_tag_repr(self):
         """LDAPBindRequest.__repr__ with custom tag attribute"""
-        dns = [
-            b"uid=user,ou=users,dc=example,dc=org",
-            "uid=user,ou=users,dc=example,dc=org",
-        ]
-        for dn in dns:
-            req = pureldap.LDAPBindRequest(dn=dn, auth="pass", tag=42)
-            req_repr = (
+        self.assertEqual(
+            repr(
+                pureldap.LDAPBindRequest(
+                    dn=b"uid=user,ou=users,dc=example,dc=org", auth=b"pass", tag=42
+                )
+            ),
+            (
+                "LDAPBindRequest(version=3, dn=b'uid=user,ou=users,dc=example,dc=org', "
+                "auth='****', tag=42, sasl=False)"
+            ),
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPBindRequest(
+                    dn="uid=user,ou=users,dc=example,dc=org", auth="pass", tag=42
+                )
+            ),
+            (
                 "LDAPBindRequest(version=3, dn='uid=user,ou=users,dc=example,dc=org', "
                 "auth='****', tag=42, sasl=False)"
-            )
-            self.assertEqual(repr(req), req_repr)
+            ),
+        )
 
     def test_bind_response_repr(self):
         """LDAPBindResponse.__repr__"""
-        matched_dns = [
-            b"uid=user,ou=users,dc=example,dc=org",
-            "uid=user,ou=users,dc=example,dc=org",
-        ]
-        for matched_dn in matched_dns:
-            res = pureldap.LDAPBindResponse(resultCode=0, matchedDN=matched_dn)
-            res_repr = "LDAPBindResponse(resultCode=0, matchedDN='uid=user,ou=users,dc=example,dc=org')"
-            self.assertEqual(repr(res), res_repr)
+        self.assertEqual(
+            repr(
+                pureldap.LDAPBindResponse(
+                    resultCode=0, matchedDN=b"uid=user,ou=users,dc=example,dc=org"
+                )
+            ),
+            "LDAPBindResponse(resultCode=0, matchedDN=b'uid=user,ou=users,dc=example,dc=org')",
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPBindResponse(
+                    resultCode=0, matchedDN="uid=user,ou=users,dc=example,dc=org"
+                )
+            ),
+            "LDAPBindResponse(resultCode=0, matchedDN='uid=user,ou=users,dc=example,dc=org')",
+        )
 
     def test_result_with_matched_dn_repr(self):
         """LDAPResult.__repr__ with matchedDN attribute"""
-        matched_dns = [
-            b"uid=user,ou=users,dc=example,dc=org",
-            "uid=user,ou=users,dc=example,dc=org",
-        ]
-        for matched_dn in matched_dns:
-            res = pureldap.LDAPResult(resultCode=0, matchedDN=matched_dn)
-            res_repr = "LDAPResult(resultCode=0, matchedDN='uid=user,ou=users,dc=example,dc=org')"
-            self.assertEqual(repr(res), res_repr)
+        self.assertEqual(
+            repr(
+                pureldap.LDAPResult(
+                    resultCode=0, matchedDN=b"uid=user,ou=users,dc=example,dc=org"
+                )
+            ),
+            "LDAPResult(resultCode=0, matchedDN=b'uid=user,ou=users,dc=example,dc=org')",
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPResult(
+                    resultCode=0, matchedDN="uid=user,ou=users,dc=example,dc=org"
+                )
+            ),
+            "LDAPResult(resultCode=0, matchedDN='uid=user,ou=users,dc=example,dc=org')",
+        )
 
     def test_result_with_error_message_repr(self):
         """LDAPResult.__repr__ with errorMessage attribute"""
-        error_messages = [b"error_message", "error_message"]
-        for error_message in error_messages:
-            res = pureldap.LDAPResult(resultCode=1, errorMessage=error_message)
-            res_repr = "LDAPResult(resultCode=1, errorMessage='error_message')"
-            self.assertEqual(repr(res), res_repr)
+        self.assertEqual(
+            repr(pureldap.LDAPResult(resultCode=1, errorMessage=b"error_message")),
+            "LDAPResult(resultCode=1, errorMessage=b'error_message')",
+        )
+        self.assertEqual(
+            repr(pureldap.LDAPResult(resultCode=1, errorMessage="error_message")),
+            "LDAPResult(resultCode=1, errorMessage='error_message')",
+        )
 
     def test_result_with_tag_repr(self):
         """LDAPResult.__repr__ with custom tag attribute"""
@@ -1304,340 +1340,533 @@ class TestRepresentations(unittest.TestCase):
 
     def test_search_request_repr(self):
         """LDAPSearchRequest.__repr__"""
-        base_objects = [b"ou=users,dc=example,dc=org", "ou=users,dc=example,dc=org"]
-        for base_object in base_objects:
-            req = pureldap.LDAPSearchRequest(
-                baseObject=base_object,
-                filter=pureldap.LDAPFilter_equalityMatch(
-                    attributeDesc=pureber.BEROctetString("key"),
-                    assertionValue=pureber.BEROctetString("value"),
-                ),
-            )
-            req_repr = (
+        self.assertEqual(
+            repr(
+                pureldap.LDAPSearchRequest(
+                    baseObject=b"ou=users,dc=example,dc=org",
+                    filter=pureldap.LDAPFilter_equalityMatch(
+                        attributeDesc=pureber.BEROctetString(b"key"),
+                        assertionValue=pureber.BEROctetString(b"value"),
+                    ),
+                )
+            ),
+            (
+                "LDAPSearchRequest(baseObject=b'ou=users,dc=example,dc=org', scope=2, derefAliases=0, "
+                "sizeLimit=0, timeLimit=0, typesOnly=0, filter=LDAPFilter_equalityMatch("
+                "attributeDesc=BEROctetString(value=b'key'), assertionValue=BEROctetString(value=b'value')), "
+                "attributes=[])"
+            ),
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPSearchRequest(
+                    baseObject="ou=users,dc=example,dc=org",
+                    filter=pureldap.LDAPFilter_equalityMatch(
+                        attributeDesc=pureber.BEROctetString("key"),
+                        assertionValue=pureber.BEROctetString("value"),
+                    ),
+                )
+            ),
+            (
                 "LDAPSearchRequest(baseObject='ou=users,dc=example,dc=org', scope=2, derefAliases=0, "
                 "sizeLimit=0, timeLimit=0, typesOnly=0, filter=LDAPFilter_equalityMatch("
                 "attributeDesc=BEROctetString(value='key'), assertionValue=BEROctetString(value='value')), "
                 "attributes=[])"
-            )
-            self.assertEqual(repr(req), req_repr)
+            ),
+        )
 
     def test_search_request_with_tag_repr(self):
         """LDAPSearchRequest.__repr__ with custom tag attribute"""
-        base_objects = [b"ou=users,dc=example,dc=org", "ou=users,dc=example,dc=org"]
-        for base_object in base_objects:
-            req = pureldap.LDAPSearchRequest(
-                baseObject=base_object,
-                filter=pureldap.LDAPFilter_equalityMatch(
-                    attributeDesc=pureber.BEROctetString("key"),
-                    assertionValue=pureber.BEROctetString("value"),
-                ),
-                tag=42,
-            )
-            req_repr = (
+        self.assertEqual(
+            repr(
+                pureldap.LDAPSearchRequest(
+                    baseObject=b"ou=users,dc=example,dc=org",
+                    filter=pureldap.LDAPFilter_equalityMatch(
+                        attributeDesc=pureber.BEROctetString(b"key"),
+                        assertionValue=pureber.BEROctetString(b"value"),
+                    ),
+                    tag=42,
+                )
+            ),
+            (
+                "LDAPSearchRequest(baseObject=b'ou=users,dc=example,dc=org', scope=2, derefAliases=0, "
+                "sizeLimit=0, timeLimit=0, typesOnly=0, filter=LDAPFilter_equalityMatch("
+                "attributeDesc=BEROctetString(value=b'key'), assertionValue=BEROctetString(value=b'value')), "
+                "attributes=[], tag=42)"
+            ),
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPSearchRequest(
+                    baseObject="ou=users,dc=example,dc=org",
+                    filter=pureldap.LDAPFilter_equalityMatch(
+                        attributeDesc=pureber.BEROctetString("key"),
+                        assertionValue=pureber.BEROctetString("value"),
+                    ),
+                    tag=42,
+                )
+            ),
+            (
                 "LDAPSearchRequest(baseObject='ou=users,dc=example,dc=org', scope=2, derefAliases=0, "
                 "sizeLimit=0, timeLimit=0, typesOnly=0, filter=LDAPFilter_equalityMatch("
                 "attributeDesc=BEROctetString(value='key'), assertionValue=BEROctetString(value='value')), "
                 "attributes=[], tag=42)"
-            )
-            self.assertEqual(repr(req), req_repr)
+            ),
+        )
 
     def test_search_result_entry_repr(self):
         """LDAPSearchResultEntry.__repr__"""
-        object_names = [
-            b"uid=mohamed,ou=people,dc=example,dc=fr",
-            "uid=mohamed,ou=people,dc=example,dc=fr",
-        ]
-        attributes_list = [(b"uid", [b"mohamed"]), ("uid", ["mohamed"])]
-        for object_name in object_names:
-            for attributes in attributes_list:
-                resp = pureldap.LDAPSearchResultEntry(
-                    objectName=object_name,
-                    attributes=[attributes],
+        self.assertEqual(
+            repr(
+                pureldap.LDAPSearchResultEntry(
+                    objectName=b"uid=mohamed,ou=people,dc=example,dc=fr",
+                    attributes=[(b"uid", [b"mohamed"])],
                 )
-                resp_repr = (
-                    "LDAPSearchResultEntry(objectName='uid=mohamed,ou=people,dc=example,dc=fr', "
-                    "attributes=[('uid', ['mohamed'])])"
+            ),
+            (
+                "LDAPSearchResultEntry(objectName=b'uid=mohamed,ou=people,dc=example,dc=fr', "
+                "attributes=[(b'uid', [b'mohamed'])])"
+            ),
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPSearchResultEntry(
+                    objectName="uid=mohamed,ou=people,dc=example,dc=fr",
+                    attributes=[("uid", ["mohamed"])],
                 )
-                self.assertEqual(repr(resp), resp_repr)
+            ),
+            (
+                "LDAPSearchResultEntry(objectName='uid=mohamed,ou=people,dc=example,dc=fr', "
+                "attributes=[('uid', ['mohamed'])])"
+            ),
+        )
 
     def test_search_result_entry_with_tag_repr(self):
         """LDAPSearchResultEntry.__repr__ with custom tag attribute"""
-        object_names = [
-            b"uid=mohamed,ou=people,dc=example,dc=fr",
-            "uid=mohamed,ou=people,dc=example,dc=fr",
-        ]
-        attributes_list = [(b"uid", [b"mohamed"]), ("uid", ["mohamed"])]
-        for object_name in object_names:
-            for attributes in attributes_list:
-                resp = pureldap.LDAPSearchResultEntry(
-                    objectName=object_name,
-                    attributes=[attributes],
+        self.assertEqual(
+            repr(
+                pureldap.LDAPSearchResultEntry(
+                    objectName=b"uid=mohamed,ou=people,dc=example,dc=fr",
+                    attributes=[(b"uid", [b"mohamed"])],
                     tag=42,
                 )
-                resp_repr = (
-                    "LDAPSearchResultEntry(objectName='uid=mohamed,ou=people,dc=example,dc=fr', "
-                    "attributes=[('uid', ['mohamed'])], tag=42)"
+            ),
+            (
+                "LDAPSearchResultEntry(objectName=b'uid=mohamed,ou=people,dc=example,dc=fr', "
+                "attributes=[(b'uid', [b'mohamed'])], tag=42)"
+            ),
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPSearchResultEntry(
+                    objectName="uid=mohamed,ou=people,dc=example,dc=fr",
+                    attributes=[("uid", ["mohamed"])],
+                    tag=42,
                 )
-                self.assertEqual(repr(resp), resp_repr)
+            ),
+            (
+                "LDAPSearchResultEntry(objectName='uid=mohamed,ou=people,dc=example,dc=fr', "
+                "attributes=[('uid', ['mohamed'])], tag=42)"
+            ),
+        )
 
     def test_search_result_reference_repr(self):
         """LDAPSearchResultReference.__repr__"""
-        uris_list = [
-            [
-                b"ldap://example.com/dc=foo,dc=example,dc=com",
-                b"ldap://example.com/dc=foo,dc=example,dc=com",
-            ],
-            [
-                "ldap://example.com/dc=foo,dc=example,dc=com",
-                "ldap://example.com/dc=foo,dc=example,dc=com",
-            ],
-        ]
-        for uris in uris_list:
-            resp = pureldap.LDAPSearchResultReference(uris=uris)
-            resp_repr = (
-                "LDAPSearchResultReference(uris=['ldap://example.com/dc=foo,dc=example,dc=com', "
-                "'ldap://example.com/dc=foo,dc=example,dc=com'])"
-            )
-            self.assertEqual(repr(resp), resp_repr)
+        self.assertEqual(
+            repr(
+                pureldap.LDAPSearchResultReference(
+                    uris=[
+                        b"ldap://example.com/dc=foo,dc=example,dc=com",
+                        b"ldap://example.com/dc=foo,dc=example,dc=com",
+                    ]
+                )
+            ),
+            "LDAPSearchResultReference(uris=[b'ldap://example.com/dc=foo,dc=example,dc=com', "
+            "b'ldap://example.com/dc=foo,dc=example,dc=com'])",
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPSearchResultReference(
+                    uris=[
+                        "ldap://example.com/dc=foo,dc=example,dc=com",
+                        "ldap://example.com/dc=foo,dc=example,dc=com",
+                    ]
+                )
+            ),
+            "LDAPSearchResultReference(uris=['ldap://example.com/dc=foo,dc=example,dc=com', "
+            "'ldap://example.com/dc=foo,dc=example,dc=com'])",
+        )
 
     def test_search_result_reference_with_tag_repr(self):
         """LDAPSearchResultReference.__repr__ with custom tag attribute"""
-        uris_list = [
-            [
-                b"ldap://example.com/dc=foo,dc=example,dc=com",
-                b"ldap://example.com/dc=foo,dc=example,dc=com",
-            ],
-            [
-                "ldap://example.com/dc=foo,dc=example,dc=com",
-                "ldap://example.com/dc=foo,dc=example,dc=com",
-            ],
-        ]
-        for uris in uris_list:
-            resp = pureldap.LDAPSearchResultReference(uris=uris, tag=42)
-            resp_repr = (
-                "LDAPSearchResultReference(uris=['ldap://example.com/dc=foo,dc=example,dc=com', "
-                "'ldap://example.com/dc=foo,dc=example,dc=com'], tag=42)"
-            )
-            self.assertEqual(repr(resp), resp_repr)
+        self.assertEqual(
+            repr(
+                pureldap.LDAPSearchResultReference(
+                    uris=[
+                        b"ldap://example.com/dc=foo,dc=example,dc=com",
+                        b"ldap://example.com/dc=foo,dc=example,dc=com",
+                    ],
+                    tag=42,
+                )
+            ),
+            "LDAPSearchResultReference(uris=[b'ldap://example.com/dc=foo,dc=example,dc=com', "
+            "b'ldap://example.com/dc=foo,dc=example,dc=com'], tag=42)",
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPSearchResultReference(
+                    uris=[
+                        "ldap://example.com/dc=foo,dc=example,dc=com",
+                        "ldap://example.com/dc=foo,dc=example,dc=com",
+                    ],
+                    tag=42,
+                )
+            ),
+            "LDAPSearchResultReference(uris=['ldap://example.com/dc=foo,dc=example,dc=com', "
+            "'ldap://example.com/dc=foo,dc=example,dc=com'], tag=42)",
+        )
 
     def test_modify_request_repr(self):
         """LDAPModifyRequest.__repr__"""
-        object_names = [
-            b"uid=user,ou=users,dc=example,dc=org",
-            "uid=user,ou=users,dc=example,dc=org",
-        ]
-        for object_name in object_names:
-            mr = pureldap.LDAPModifyRequest(
-                object=object_name,
-                modification=pureber.BERSequence(
-                    [
-                        pureber.BEREnumerated(0),
-                        pureber.BERSequence(
-                            [
-                                pureldap.LDAPAttributeDescription("key"),
-                                pureber.BERSet([pureldap.LDAPString("value")]),
-                            ]
-                        ),
-                    ]
-                ),
-            )
-            mr_repr = (
+        self.assertEqual(
+            repr(
+                pureldap.LDAPModifyRequest(
+                    object=b"uid=user,ou=users,dc=example,dc=org",
+                    modification=pureber.BERSequence(
+                        [
+                            pureber.BEREnumerated(0),
+                            pureber.BERSequence(
+                                [
+                                    pureldap.LDAPAttributeDescription(b"key"),
+                                    pureber.BERSet([pureldap.LDAPString(b"value")]),
+                                ]
+                            ),
+                        ]
+                    ),
+                )
+            ),
+            (
+                "LDAPModifyRequest(object=b'uid=user,ou=users,dc=example,dc=org', "
+                "modification=BERSequence(value=[BEREnumerated(value=0), "
+                "BERSequence(value=[LDAPAttributeDescription(value=b'key'), "
+                "BERSet(value=[LDAPString(value=b'value')])])]))"
+            ),
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPModifyRequest(
+                    object="uid=user,ou=users,dc=example,dc=org",
+                    modification=pureber.BERSequence(
+                        [
+                            pureber.BEREnumerated(0),
+                            pureber.BERSequence(
+                                [
+                                    pureldap.LDAPAttributeDescription("key"),
+                                    pureber.BERSet([pureldap.LDAPString("value")]),
+                                ]
+                            ),
+                        ]
+                    ),
+                )
+            ),
+            (
                 "LDAPModifyRequest(object='uid=user,ou=users,dc=example,dc=org', "
                 "modification=BERSequence(value=[BEREnumerated(value=0), "
                 "BERSequence(value=[LDAPAttributeDescription(value='key'), "
                 "BERSet(value=[LDAPString(value='value')])])]))"
-            )
-            self.assertEqual(repr(mr), mr_repr)
+            ),
+        )
 
     def test_modify_request_with_tag_repr(self):
         """LDAPModifyRequest.__repr__ with custom tag attribute"""
-        object_names = [
-            b"uid=user,ou=users,dc=example,dc=org",
-            "uid=user,ou=users,dc=example,dc=org",
-        ]
-        for object_name in object_names:
-            mr = pureldap.LDAPModifyRequest(
-                object=object_name,
-                modification=pureber.BERSequence(
-                    [
-                        pureber.BEREnumerated(0),
-                        pureber.BERSequence(
-                            [
-                                pureldap.LDAPAttributeDescription("key"),
-                                pureber.BERSet([pureldap.LDAPString("value")]),
-                            ]
-                        ),
-                    ]
-                ),
-                tag=42,
-            )
-            mr_repr = (
+        self.assertEqual(
+            repr(
+                pureldap.LDAPModifyRequest(
+                    object=b"uid=user,ou=users,dc=example,dc=org",
+                    modification=pureber.BERSequence(
+                        [
+                            pureber.BEREnumerated(0),
+                            pureber.BERSequence(
+                                [
+                                    pureldap.LDAPAttributeDescription(b"key"),
+                                    pureber.BERSet([pureldap.LDAPString(b"value")]),
+                                ]
+                            ),
+                        ]
+                    ),
+                    tag=42,
+                )
+            ),
+            (
+                "LDAPModifyRequest(object=b'uid=user,ou=users,dc=example,dc=org', "
+                "modification=BERSequence(value=[BEREnumerated(value=0), "
+                "BERSequence(value=[LDAPAttributeDescription(value=b'key'), "
+                "BERSet(value=[LDAPString(value=b'value')])])]), tag=42)"
+            ),
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPModifyRequest(
+                    object="uid=user,ou=users,dc=example,dc=org",
+                    modification=pureber.BERSequence(
+                        [
+                            pureber.BEREnumerated(0),
+                            pureber.BERSequence(
+                                [
+                                    pureldap.LDAPAttributeDescription("key"),
+                                    pureber.BERSet([pureldap.LDAPString("value")]),
+                                ]
+                            ),
+                        ]
+                    ),
+                    tag=42,
+                )
+            ),
+            (
                 "LDAPModifyRequest(object='uid=user,ou=users,dc=example,dc=org', "
                 "modification=BERSequence(value=[BEREnumerated(value=0), "
                 "BERSequence(value=[LDAPAttributeDescription(value='key'), "
                 "BERSet(value=[LDAPString(value='value')])])]), tag=42)"
-            )
-            self.assertEqual(repr(mr), mr_repr)
+            ),
+        )
 
     def test_add_request_repr(self):
         """LDAPAddRequest.__repr__"""
-        entries = [
-            b"uid=user,ou=users,dc=example,dc=org",
-            "uid=user,ou=users,dc=example,dc=org",
-        ]
-        for entry in entries:
-            ar = pureldap.LDAPAddRequest(
-                entry=entry,
-                attributes=[
-                    (
-                        pureldap.LDAPAttributeDescription("key"),
-                        pureber.BERSet([pureldap.LDAPAttributeValue("value")]),
-                    ),
-                ],
-            )
-            ar_repr = (
+        self.assertEqual(
+            repr(
+                pureldap.LDAPAddRequest(
+                    entry=b"uid=user,ou=users,dc=example,dc=org",
+                    attributes=[
+                        (
+                            pureldap.LDAPAttributeDescription(b"key"),
+                            pureber.BERSet([pureldap.LDAPAttributeValue(b"value")]),
+                        ),
+                    ],
+                )
+            ),
+            (
+                "LDAPAddRequest(entry=b'uid=user,ou=users,dc=example,dc=org', "
+                "attributes=[(LDAPAttributeDescription(value=b'key'), "
+                "BERSet(value=[LDAPAttributeValue(value=b'value')]))])"
+            ),
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPAddRequest(
+                    entry="uid=user,ou=users,dc=example,dc=org",
+                    attributes=[
+                        (
+                            pureldap.LDAPAttributeDescription("key"),
+                            pureber.BERSet([pureldap.LDAPAttributeValue("value")]),
+                        ),
+                    ],
+                )
+            ),
+            (
                 "LDAPAddRequest(entry='uid=user,ou=users,dc=example,dc=org', "
                 "attributes=[(LDAPAttributeDescription(value='key'), "
                 "BERSet(value=[LDAPAttributeValue(value='value')]))])"
-            )
-            self.assertEqual(repr(ar), ar_repr)
+            ),
+        )
 
     def test_add_request_with_tag_repr(self):
         """LDAPAddRequest.__repr__ with custom tag attribute"""
-        entries = [
-            b"uid=user,ou=users,dc=example,dc=org",
-            "uid=user,ou=users,dc=example,dc=org",
-        ]
-        for entry in entries:
-            ar = pureldap.LDAPAddRequest(
-                entry=entry,
-                attributes=[
-                    (
-                        pureldap.LDAPAttributeDescription("key"),
-                        pureber.BERSet([pureldap.LDAPAttributeValue("value")]),
-                    ),
-                ],
-                tag=42,
-            )
-            ar_repr = (
+        self.assertEqual(
+            repr(
+                pureldap.LDAPAddRequest(
+                    entry=b"uid=user,ou=users,dc=example,dc=org",
+                    attributes=[
+                        (
+                            pureldap.LDAPAttributeDescription(b"key"),
+                            pureber.BERSet([pureldap.LDAPAttributeValue(b"value")]),
+                        ),
+                    ],
+                    tag=42,
+                )
+            ),
+            (
+                "LDAPAddRequest(entry=b'uid=user,ou=users,dc=example,dc=org', "
+                "attributes=[(LDAPAttributeDescription(value=b'key'), "
+                "BERSet(value=[LDAPAttributeValue(value=b'value')]))], tag=42)"
+            ),
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPAddRequest(
+                    entry="uid=user,ou=users,dc=example,dc=org",
+                    attributes=[
+                        (
+                            pureldap.LDAPAttributeDescription("key"),
+                            pureber.BERSet([pureldap.LDAPAttributeValue("value")]),
+                        ),
+                    ],
+                    tag=42,
+                )
+            ),
+            (
                 "LDAPAddRequest(entry='uid=user,ou=users,dc=example,dc=org', "
                 "attributes=[(LDAPAttributeDescription(value='key'), "
                 "BERSet(value=[LDAPAttributeValue(value='value')]))], tag=42)"
-            )
-            self.assertEqual(repr(ar), ar_repr)
+            ),
+        )
 
     def test_del_request_repr(self):
         """LDAPDelRequest.__repr__"""
-        entries = [
-            b"uid=user,ou=users,dc=example,dc=org",
-            "uid=user,ou=users,dc=example,dc=org",
-        ]
-        for entry in entries:
-            dr = pureldap.LDAPDelRequest(entry=entry)
-            dr_repr = "LDAPDelRequest(entry='uid=user,ou=users,dc=example,dc=org')"
-            self.assertEqual(repr(dr), dr_repr)
+        self.assertEqual(
+            repr(pureldap.LDAPDelRequest(entry=b"uid=user,ou=users,dc=example,dc=org")),
+            "LDAPDelRequest(entry=b'uid=user,ou=users,dc=example,dc=org')",
+        )
+        self.assertEqual(
+            repr(pureldap.LDAPDelRequest(entry="uid=user,ou=users,dc=example,dc=org")),
+            "LDAPDelRequest(entry='uid=user,ou=users,dc=example,dc=org')",
+        )
 
     def test_del_request_with_tag_repr(self):
         """LDAPDelRequest.__repr__ with custom tag attribute"""
-        entries = [
-            b"uid=user,ou=users,dc=example,dc=org",
-            "uid=user,ou=users,dc=example,dc=org",
-        ]
-        for entry in entries:
-            dr = pureldap.LDAPDelRequest(entry=entry, tag=42)
-            dr_repr = (
-                "LDAPDelRequest(entry='uid=user,ou=users,dc=example,dc=org', tag=42)"
-            )
-            self.assertEqual(repr(dr), dr_repr)
+        self.assertEqual(
+            repr(
+                pureldap.LDAPDelRequest(
+                    entry=b"uid=user,ou=users,dc=example,dc=org", tag=42
+                )
+            ),
+            "LDAPDelRequest(entry=b'uid=user,ou=users,dc=example,dc=org', tag=42)",
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPDelRequest(
+                    entry="uid=user,ou=users,dc=example,dc=org", tag=42
+                )
+            ),
+            "LDAPDelRequest(entry='uid=user,ou=users,dc=example,dc=org', tag=42)",
+        )
 
     def test_modify_dn_request_repr(self):
         """LDAPModifyDNRequest.__repr__"""
-        entries = [
-            b"uid=user,ou=users,dc=example,dc=org",
-            "uid=user,ou=users,dc=example,dc=org",
-        ]
-        rdns = [b"uid=newuser", "uid=newuser"]
-        for entry in entries:
-            for rdn in rdns:
-                mdnr = pureldap.LDAPModifyDNRequest(
-                    entry=entry,
-                    newrdn=rdn,
+        self.assertEqual(
+            repr(
+                pureldap.LDAPModifyDNRequest(
+                    entry=b"uid=user,ou=users,dc=example,dc=org",
+                    newrdn=b"uid=newuser",
                     deleteoldrdn=True,
                 )
-                mdnr_repr = (
-                    "LDAPModifyDNRequest(entry='uid=user,ou=users,dc=example,dc=org', "
-                    "newrdn='uid=newuser', deleteoldrdn=True)"
+            ),
+            (
+                "LDAPModifyDNRequest(entry=b'uid=user,ou=users,dc=example,dc=org', "
+                "newrdn=b'uid=newuser', deleteoldrdn=True)"
+            ),
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPModifyDNRequest(
+                    entry="uid=user,ou=users,dc=example,dc=org",
+                    newrdn="uid=newuser",
+                    deleteoldrdn=True,
                 )
-                self.assertEqual(repr(mdnr), mdnr_repr)
+            ),
+            (
+                "LDAPModifyDNRequest(entry='uid=user,ou=users,dc=example,dc=org', "
+                "newrdn='uid=newuser', deleteoldrdn=True)"
+            ),
+        )
 
     def test_modify_dn_request_with_new_superior_repr(self):
         """LDAPModifyDNRequest.__repr__ with newSuperior attribute"""
-        entries = [
-            b"uid=user,ou=users,dc=example,dc=org",
-            "uid=user,ou=users,dc=example,dc=org",
-        ]
-        rdns = [b"uid=newuser", "uid=newuser"]
-        new_superiors = [
-            b"ou=newusers,dc=example,dc=org",
-            "ou=newusers,dc=example,dc=org",
-        ]
-        for entry in entries:
-            for rdn in rdns:
-                for new_superior in new_superiors:
-                    mdnr = pureldap.LDAPModifyDNRequest(
-                        entry=entry,
-                        newrdn=rdn,
-                        deleteoldrdn=False,
-                        newSuperior=new_superior,
-                    )
-                    mdnr_repr = (
-                        "LDAPModifyDNRequest(entry='uid=user,ou=users,dc=example,dc=org', "
-                        "newrdn='uid=newuser', deleteoldrdn=False, "
-                        "newSuperior='ou=newusers,dc=example,dc=org')"
-                    )
-                    self.assertEqual(repr(mdnr), mdnr_repr)
+        self.assertEqual(
+            repr(
+                pureldap.LDAPModifyDNRequest(
+                    entry=b"uid=user,ou=users,dc=example,dc=org",
+                    newrdn=b"uid=newuser",
+                    deleteoldrdn=False,
+                    newSuperior=b"ou=newusers,dc=example,dc=org",
+                )
+            ),
+            (
+                "LDAPModifyDNRequest(entry=b'uid=user,ou=users,dc=example,dc=org', "
+                "newrdn=b'uid=newuser', deleteoldrdn=False, "
+                "newSuperior=b'ou=newusers,dc=example,dc=org')"
+            ),
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPModifyDNRequest(
+                    entry="uid=user,ou=users,dc=example,dc=org",
+                    newrdn="uid=newuser",
+                    deleteoldrdn=False,
+                    newSuperior="ou=newusers,dc=example,dc=org",
+                )
+            ),
+            (
+                "LDAPModifyDNRequest(entry='uid=user,ou=users,dc=example,dc=org', "
+                "newrdn='uid=newuser', deleteoldrdn=False, "
+                "newSuperior='ou=newusers,dc=example,dc=org')"
+            ),
+        )
 
     def test_modify_dn_request_with_tag_repr(self):
         """LDAPModifyDNRequest.__repr__ with custom tag attribute"""
-        entries = [
-            b"uid=user,ou=users,dc=example,dc=org",
-            "uid=user,ou=users,dc=example,dc=org",
-        ]
-        rdns = [b"uid=newuser", "uid=newuser"]
-        for entry in entries:
-            for rdn in rdns:
-                mdnr = pureldap.LDAPModifyDNRequest(
-                    entry=entry,
-                    newrdn=rdn,
+        self.assertEqual(
+            repr(
+                pureldap.LDAPModifyDNRequest(
+                    entry=b"uid=user,ou=users,dc=example,dc=org",
+                    newrdn=b"uid=newuser",
                     deleteoldrdn=True,
                     tag=42,
                 )
-                mdnr_repr = (
-                    "LDAPModifyDNRequest(entry='uid=user,ou=users,dc=example,dc=org', "
-                    "newrdn='uid=newuser', deleteoldrdn=True, tag=42)"
+            ),
+            (
+                "LDAPModifyDNRequest(entry=b'uid=user,ou=users,dc=example,dc=org', "
+                "newrdn=b'uid=newuser', deleteoldrdn=True, tag=42)"
+            ),
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPModifyDNRequest(
+                    entry="uid=user,ou=users,dc=example,dc=org",
+                    newrdn="uid=newuser",
+                    deleteoldrdn=True,
+                    tag=42,
                 )
-                self.assertEqual(repr(mdnr), mdnr_repr)
+            ),
+            (
+                "LDAPModifyDNRequest(entry='uid=user,ou=users,dc=example,dc=org', "
+                "newrdn='uid=newuser', deleteoldrdn=True, tag=42)"
+            ),
+        )
 
     def test_compare_request_repr(self):
         """LDAPCompareRequest.__repr__"""
-        entries = [
-            b"uid=user,ou=users,dc=example,dc=org",
-            "uid=user,ou=users,dc=example,dc=org",
-        ]
-        for entry in entries:
-            cr = pureldap.LDAPCompareRequest(
-                entry=entry,
-                ava=pureldap.LDAPAttributeValueAssertion(
-                    pureber.BEROctetString("key"),
-                    pureber.BEROctetString("value"),
-                ),
-            )
-            cr_repr = (
+        self.assertEqual(
+            repr(
+                pureldap.LDAPCompareRequest(
+                    entry=b"uid=user,ou=users,dc=example,dc=org",
+                    ava=pureldap.LDAPAttributeValueAssertion(
+                        pureber.BEROctetString(b"key"),
+                        pureber.BEROctetString(b"value"),
+                    ),
+                )
+            ),
+            (
+                "LDAPCompareRequest(entry=b'uid=user,ou=users,dc=example,dc=org', "
+                "ava=LDAPAttributeValueAssertion(attributeDesc=BEROctetString(value=b'key'), "
+                "assertionValue=BEROctetString(value=b'value')))"
+            ),
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPCompareRequest(
+                    entry="uid=user,ou=users,dc=example,dc=org",
+                    ava=pureldap.LDAPAttributeValueAssertion(
+                        pureber.BEROctetString("key"),
+                        pureber.BEROctetString("value"),
+                    ),
+                )
+            ),
+            (
                 "LDAPCompareRequest(entry='uid=user,ou=users,dc=example,dc=org', "
                 "ava=LDAPAttributeValueAssertion(attributeDesc=BEROctetString(value='key'), "
                 "assertionValue=BEROctetString(value='value')))"
-            )
-            self.assertEqual(repr(cr), cr_repr)
+            ),
+        )
 
     def test_abandon_request_repr(self):
         """LDAPAbandonRequest.__repr__"""
@@ -1653,52 +1882,71 @@ class TestRepresentations(unittest.TestCase):
 
     def test_password_modify_request_repr(self):
         """LDAPPasswordModifyRequest.__repr__"""
-        user_identities = [
-            b"uid=user,ou=users,dc=example,dc=org",
-            "uid=user,ou=users,dc=example,dc=org",
-        ]
-        old_passwords = [b"qwerty", "qwerty"]
-        new_passwords = [b"asdfgh", "asdfgh"]
-        for user_identity in user_identities:
-            for old_password in old_passwords:
-                for new_password in new_passwords:
-                    pmr = pureldap.LDAPPasswordModifyRequest(
-                        userIdentity=user_identity,
-                        oldPasswd=old_password,
-                        newPasswd=new_password,
-                    )
-                    pmr_repr = (
-                        "LDAPPasswordModifyRequest(userIdentity=LDAPPasswordModifyRequest_userIdentity("
-                        "value='uid=user,ou=users,dc=example,dc=org'), "
-                        "oldPasswd=LDAPPasswordModifyRequest_oldPasswd(value='******'), "
-                        "newPasswd=LDAPPasswordModifyRequest_newPasswd(value='******'))"
-                    )
-                    self.assertEqual(repr(pmr), pmr_repr)
+        self.assertEqual(
+            repr(
+                pureldap.LDAPPasswordModifyRequest(
+                    userIdentity=b"uid=user,ou=users,dc=example,dc=org",
+                    oldPasswd=b"qwerty",
+                    newPasswd=b"asdfgh",
+                )
+            ),
+            (
+                "LDAPPasswordModifyRequest(userIdentity=LDAPPasswordModifyRequest_userIdentity("
+                "value=b'uid=user,ou=users,dc=example,dc=org'), "
+                "oldPasswd=LDAPPasswordModifyRequest_oldPasswd(value='******'), "
+                "newPasswd=LDAPPasswordModifyRequest_newPasswd(value='******'))"
+            ),
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPPasswordModifyRequest(
+                    userIdentity="uid=user,ou=users,dc=example,dc=org",
+                    oldPasswd="qwerty",
+                    newPasswd="asdfgh",
+                )
+            ),
+            (
+                "LDAPPasswordModifyRequest(userIdentity=LDAPPasswordModifyRequest_userIdentity("
+                "value='uid=user,ou=users,dc=example,dc=org'), "
+                "oldPasswd=LDAPPasswordModifyRequest_oldPasswd(value='******'), "
+                "newPasswd=LDAPPasswordModifyRequest_newPasswd(value='******'))"
+            ),
+        )
 
     def test_password_modify_request_with_tag_repr(self):
         """LDAPPasswordModifyRequest.__repr__ with custom tag attribute"""
-        user_identities = [
-            b"uid=user,ou=users,dc=example,dc=org",
-            "uid=user,ou=users,dc=example,dc=org",
-        ]
-        old_passwords = [b"qwerty", "qwerty"]
-        new_passwords = [b"asdfgh", "asdfgh"]
-        for user_identity in user_identities:
-            for old_password in old_passwords:
-                for new_password in new_passwords:
-                    pmr = pureldap.LDAPPasswordModifyRequest(
-                        userIdentity=user_identity,
-                        oldPasswd=old_password,
-                        newPasswd=new_password,
-                        tag=42,
-                    )
-                    pmr_repr = (
-                        "LDAPPasswordModifyRequest(userIdentity=LDAPPasswordModifyRequest_userIdentity("
-                        "value='uid=user,ou=users,dc=example,dc=org'), "
-                        "oldPasswd=LDAPPasswordModifyRequest_oldPasswd(value='******'), "
-                        "newPasswd=LDAPPasswordModifyRequest_newPasswd(value='******'), tag=42)"
-                    )
-                    self.assertEqual(repr(pmr), pmr_repr)
+        self.assertEqual(
+            repr(
+                pureldap.LDAPPasswordModifyRequest(
+                    userIdentity=b"uid=user,ou=users,dc=example,dc=org",
+                    oldPasswd=b"qwerty",
+                    newPasswd=b"asdfgh",
+                    tag=42,
+                )
+            ),
+            (
+                "LDAPPasswordModifyRequest(userIdentity=LDAPPasswordModifyRequest_userIdentity("
+                "value=b'uid=user,ou=users,dc=example,dc=org'), "
+                "oldPasswd=LDAPPasswordModifyRequest_oldPasswd(value='******'), "
+                "newPasswd=LDAPPasswordModifyRequest_newPasswd(value='******'), tag=42)"
+            ),
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPPasswordModifyRequest(
+                    userIdentity="uid=user,ou=users,dc=example,dc=org",
+                    oldPasswd="qwerty",
+                    newPasswd="asdfgh",
+                    tag=42,
+                )
+            ),
+            (
+                "LDAPPasswordModifyRequest(userIdentity=LDAPPasswordModifyRequest_userIdentity("
+                "value='uid=user,ou=users,dc=example,dc=org'), "
+                "oldPasswd=LDAPPasswordModifyRequest_oldPasswd(value='******'), "
+                "newPasswd=LDAPPasswordModifyRequest_newPasswd(value='******'), tag=42)"
+            ),
+        )
 
     def test_starttls_request_repr(self):
         """LDAPStartTLSRequest.__repr__"""
@@ -1726,113 +1974,177 @@ class TestRepresentations(unittest.TestCase):
 
     def test_attribute_value_assertion_repr(self):
         """LDAPAttributeValueAssertion.__repr__"""
-        attributes = [(b"key", b"value"), ("key", "value")]
-        for key, value in attributes:
-            ava = pureldap.LDAPAttributeValueAssertion(
-                pureber.BEROctetString(key),
-                pureber.BEROctetString(value),
-            )
-            ava_repr = (
+        self.assertEqual(
+            repr(
+                pureldap.LDAPAttributeValueAssertion(
+                    pureber.BEROctetString(b"key"),
+                    pureber.BEROctetString(b"value"),
+                )
+            ),
+            (
+                "LDAPAttributeValueAssertion(attributeDesc=BEROctetString(value=b'key'), "
+                "assertionValue=BEROctetString(value=b'value'))"
+            ),
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPAttributeValueAssertion(
+                    pureber.BEROctetString("key"),
+                    pureber.BEROctetString("value"),
+                )
+            ),
+            (
                 "LDAPAttributeValueAssertion(attributeDesc=BEROctetString(value='key'), "
                 "assertionValue=BEROctetString(value='value'))"
-            )
-            self.assertEqual(repr(ava), ava_repr)
+            ),
+        )
 
     def test_attribute_value_assertion_with_tag_repr(self):
         """LDAPAttributeValueAssertion.__repr__ with custom tag attribute"""
-        attributes = [(b"key", b"value"), ("key", "value")]
-        for key, value in attributes:
-            ava = pureldap.LDAPAttributeValueAssertion(
-                pureber.BEROctetString(key),
-                pureber.BEROctetString(value),
-                tag=42,
-            )
-            ava_repr = (
+        self.assertEqual(
+            repr(
+                pureldap.LDAPAttributeValueAssertion(
+                    pureber.BEROctetString(b"key"),
+                    pureber.BEROctetString(b"value"),
+                    tag=42,
+                )
+            ),
+            (
+                "LDAPAttributeValueAssertion(attributeDesc=BEROctetString(value=b'key'), "
+                "assertionValue=BEROctetString(value=b'value'), tag=42)"
+            ),
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPAttributeValueAssertion(
+                    pureber.BEROctetString("key"),
+                    pureber.BEROctetString("value"),
+                    tag=42,
+                )
+            ),
+            (
                 "LDAPAttributeValueAssertion(attributeDesc=BEROctetString(value='key'), "
                 "assertionValue=BEROctetString(value='value'), tag=42)"
-            )
-            self.assertEqual(repr(ava), ava_repr)
+            ),
+        )
 
     def test_ldapfilter_not_repr(self):
         """LDAPFilter_not.__repr__"""
-        values = [b"value", "value"]
-        for value in values:
-            lf = pureldap.LDAPFilter_not(pureber.BEROctetString(value))
-            lf_repr = "LDAPFilter_not(value=BEROctetString(value='value'))"
-            self.assertEqual(repr(lf), lf_repr)
+        self.assertEqual(
+            repr(pureldap.LDAPFilter_not(pureber.BEROctetString(b"value"))),
+            "LDAPFilter_not(value=BEROctetString(value=b'value'))",
+        )
+        self.assertEqual(
+            repr(pureldap.LDAPFilter_not(pureber.BEROctetString("value"))),
+            "LDAPFilter_not(value=BEROctetString(value='value'))",
+        )
 
     def test_ldapfilter_not_with_tag_repr(self):
         """LDAPFilter_not.__repr__ with custom tag attribute"""
-        values = [b"value", "value"]
-        for value in values:
-            lf = pureldap.LDAPFilter_not(pureber.BEROctetString(value), tag=42)
-            lf_repr = "LDAPFilter_not(value=BEROctetString(value='value'), tag=42)"
-            self.assertEqual(repr(lf), lf_repr)
+        self.assertEqual(
+            repr(pureldap.LDAPFilter_not(pureber.BEROctetString(b"value"), tag=42)),
+            "LDAPFilter_not(value=BEROctetString(value=b'value'), tag=42)",
+        )
+        self.assertEqual(
+            repr(pureldap.LDAPFilter_not(pureber.BEROctetString("value"), tag=42)),
+            "LDAPFilter_not(value=BEROctetString(value='value'), tag=42)",
+        )
 
     def test_ldapfilter_substrings_repr(self):
         """LDAPFilter_substrings.__repr__"""
-        types = [b"cn", "cn"]
-        values = [b"value", "value"]
-        for tp in types:
-            for value in values:
-                lf = pureldap.LDAPFilter_substrings(
-                    type=tp,
-                    substrings=[pureldap.LDAPFilter_substrings_initial(value=value)],
+        self.assertEqual(
+            repr(
+                pureldap.LDAPFilter_substrings(
+                    type=b"cn",
+                    substrings=[pureldap.LDAPFilter_substrings_initial(value=b"value")],
                 )
-                lf_repr = (
-                    "LDAPFilter_substrings(type='cn', "
-                    "substrings=[LDAPFilter_substrings_initial(value='value')])"
+            ),
+            (
+                "LDAPFilter_substrings(type=b'cn', "
+                "substrings=[LDAPFilter_substrings_initial(value=b'value')])"
+            ),
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPFilter_substrings(
+                    type="cn",
+                    substrings=[pureldap.LDAPFilter_substrings_initial(value="value")],
                 )
-                self.assertEqual(repr(lf), lf_repr)
+            ),
+            (
+                "LDAPFilter_substrings(type='cn', "
+                "substrings=[LDAPFilter_substrings_initial(value='value')])"
+            ),
+        )
 
     def test_ldapfilter_substrings_with_tag_repr(self):
         """LDAPFilter_substrings.__repr__ with custom tag attribute"""
-        types = [b"cn", "cn"]
-        values = [b"value", "value"]
-        for tp in types:
-            for value in values:
-                lf = pureldap.LDAPFilter_substrings(
-                    type=tp,
-                    substrings=[pureldap.LDAPFilter_substrings_initial(value=value)],
+        self.assertEqual(
+            repr(
+                pureldap.LDAPFilter_substrings(
+                    type=b"cn",
+                    substrings=[pureldap.LDAPFilter_substrings_initial(value=b"value")],
                     tag=42,
                 )
-                lf_repr = (
-                    "LDAPFilter_substrings(type='cn', "
-                    "substrings=[LDAPFilter_substrings_initial(value='value')], tag=42)"
+            ),
+            (
+                "LDAPFilter_substrings(type=b'cn', "
+                "substrings=[LDAPFilter_substrings_initial(value=b'value')], tag=42)"
+            ),
+        )
+        self.assertEqual(
+            repr(
+                pureldap.LDAPFilter_substrings(
+                    type="cn",
+                    substrings=[pureldap.LDAPFilter_substrings_initial(value="value")],
+                    tag=42,
                 )
-                self.assertEqual(repr(lf), lf_repr)
+            ),
+            (
+                "LDAPFilter_substrings(type='cn', "
+                "substrings=[LDAPFilter_substrings_initial(value='value')], tag=42)"
+            ),
+        )
 
     def test_matching_rule_assertion_repr(self):
         """LDAPMatchingRuleAssertion.__repr__"""
-        rules = [b"rule", "rule"]
-        types = [b"type", "type"]
-        values = [b"value", "value"]
-        for rule in rules:
-            for tp in types:
-                for value in values:
-                    mra = pureldap.LDAPMatchingRuleAssertion(rule, tp, value)
-                    mra_repr = (
-                        "LDAPMatchingRuleAssertion(matchingRule=LDAPMatchingRuleAssertion_matchingRule("
-                        "value='rule'), type=LDAPMatchingRuleAssertion_type(value='type'), matchValue="
-                        "LDAPMatchingRuleAssertion_matchValue(value='value'), dnAttributes=None)"
-                    )
-                    self.assertEqual(repr(mra), mra_repr)
+        self.assertEqual(
+            repr(pureldap.LDAPMatchingRuleAssertion(b"rule", b"type", b"value")),
+            (
+                "LDAPMatchingRuleAssertion(matchingRule=LDAPMatchingRuleAssertion_matchingRule("
+                "value=b'rule'), type=LDAPMatchingRuleAssertion_type(value=b'type'), matchValue="
+                "LDAPMatchingRuleAssertion_matchValue(value=b'value'), dnAttributes=None)"
+            ),
+        )
+        self.assertEqual(
+            repr(pureldap.LDAPMatchingRuleAssertion("rule", "type", "value")),
+            (
+                "LDAPMatchingRuleAssertion(matchingRule=LDAPMatchingRuleAssertion_matchingRule("
+                "value='rule'), type=LDAPMatchingRuleAssertion_type(value='type'), matchValue="
+                "LDAPMatchingRuleAssertion_matchValue(value='value'), dnAttributes=None)"
+            ),
+        )
 
     def test_matching_rule_assertion_with_tag_repr(self):
         """LDAPMatchingRuleAssertion.__repr__ with custom tag attribute"""
-        rules = [b"rule", "rule"]
-        types = [b"type", "type"]
-        values = [b"value", "value"]
-        for rule in rules:
-            for tp in types:
-                for value in values:
-                    mra = pureldap.LDAPMatchingRuleAssertion(rule, tp, value, tag=42)
-                    mra_repr = (
-                        "LDAPMatchingRuleAssertion(matchingRule=LDAPMatchingRuleAssertion_matchingRule("
-                        "value='rule'), type=LDAPMatchingRuleAssertion_type(value='type'), matchValue="
-                        "LDAPMatchingRuleAssertion_matchValue(value='value'), dnAttributes=None, tag=42)"
-                    )
-                    self.assertEqual(repr(mra), mra_repr)
+        self.assertEqual(
+            repr(
+                pureldap.LDAPMatchingRuleAssertion(b"rule", b"type", b"value", tag=42)
+            ),
+            (
+                "LDAPMatchingRuleAssertion(matchingRule=LDAPMatchingRuleAssertion_matchingRule("
+                "value=b'rule'), type=LDAPMatchingRuleAssertion_type(value=b'type'), matchValue="
+                "LDAPMatchingRuleAssertion_matchValue(value=b'value'), dnAttributes=None, tag=42)"
+            ),
+        )
+        self.assertEqual(
+            repr(pureldap.LDAPMatchingRuleAssertion("rule", "type", "value", tag=42)),
+            (
+                "LDAPMatchingRuleAssertion(matchingRule=LDAPMatchingRuleAssertion_matchingRule("
+                "value='rule'), type=LDAPMatchingRuleAssertion_type(value='type'), matchValue="
+                "LDAPMatchingRuleAssertion_matchValue(value='value'), dnAttributes=None, tag=42)"
+            ),
+        )
 
     def test_ldap_bind_response_server_sasl_creds_repr(self):
         """ServerSaslCreds will often have binary data. A custom repr is needed because


### PR DESCRIPTION
There's some remnants of py2 compat shims still in the codebase, one of which is repr_converter

In this PR I  remove those remnants of py2/py3 compat code.

However rather than replace repr_converter with to_unicode, I removed it.

Currently the repr_converter causes pureber etc to lie about
their content, worse when provided bytes that cannot be
decoded with utf8 (eg ObjectSID)
the reprs crash causing problems with pytest assertions

### Contributor Checklist:

- [ ] I have updated the release notes at `docs/source/NEWS.rst`
- [x] I have updated the automated tests.
- [ ] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.