### PR TITLE
remove old ImportError/AttributeError based compat code

### DIFF
--- a/docs/source/examples/quickstart_server.py
+++ b/docs/source/examples/quickstart_server.py
@@ -1,9 +1,5 @@
 import sys
-
-try:
-    from cStringIO import StringIO as BytesIO
-except ImportError:
-    from io import BytesIO
+import io
 
 from twisted.application import service
 from twisted.internet.endpoints import serverFromString
@@ -68,7 +64,7 @@ userPassword: eekretsay
 class Tree:
     def __init__(self):
         global LDIF
-        self.f = BytesIO(LDIF)
+        self.f = io.BytesIO(LDIF)
         d = fromLDIFFile(self.f)
         d.addCallback(self.ldifRead)
 

--- a/ldaptor/entry.py
+++ b/ldaptor/entry.py
@@ -10,11 +10,7 @@ from ldaptor import interfaces, attributeset, delta
 from ldaptor._encoder import WireStrAlias, to_bytes, get_strings
 from ldaptor.protocols.ldap import distinguishedname, ldif, ldaperrors
 
-
-try:
-    from hashlib import sha1
-except ImportError:
-    from sha import sha as sha1
+from hashlib import sha1
 
 
 def sshaDigest(passphrase, salt=None):

--- a/ldaptor/protocols/ldap/ldapconnector.py
+++ b/ldaptor/protocols/ldap/ldapconnector.py
@@ -1,30 +1,8 @@
-from twisted.internet import protocol, defer
-from twisted.internet.endpoints import clientFromString
-
-try:
-    from twisted.internet import endpoints
-
-    connectProtocol = endpoints.connectProtocol
-except AttributeError:
-    # Twisted >= 13.1
-    from twisted.internet.protocol import Factory
-
-    def connectProtocol(endpoint, protocol):
-        class OneShotFactory(Factory):
-            def buildProtocol(self, addr):
-                return protocol
-
-        return endpoint.connect(OneShotFactory())
-
+from twisted.internet import defer, protocol
+from twisted.internet.endpoints import clientFromString, connectProtocol
+from twisted.names.srvconnect import SRVConnector
 
 from ldaptor.protocols.ldap import distinguishedname
-
-try:
-    from twisted.internet import utils
-
-    SRVConnector = utils.SRVConnector
-except AttributeError:
-    from twisted.names.srvconnect import SRVConnector
 from ldaptor._encoder import get_strings
 
 


### PR DESCRIPTION
Fixes https://github.com/twisted/ldaptor/issues/4

we now depend on `Twisted[tls]>=15.5.0` for py3.5 support and so don't need the compat shims

### Contributor Checklist:

- [ ] I have updated the release notes at `docs/source/NEWS.rst`
- [ ] I have updated the automated tests.
- [ ] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
