### PR TITLE
Replace use of deprecated decode encode string

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -6,6 +6,7 @@ Changelog
 
 - fix ``ModuleNotFoundError: No module named 'cStringIO'`` in ldaptor-ldap2pdns.
 - move scripts to console_scripts entry_points
+- replace deprecated calls to ``base64.decodestring`` and ``base64.encodestring``.
 
 
 20.1.1 (2020-10-02)

--- a/ldaptor/entry.py
+++ b/ldaptor/entry.py
@@ -26,7 +26,7 @@ def sshaDigest(passphrase, salt=None):
     s = sha1()
     s.update(passphrase)
     s.update(salt)
-    encoded = base64.encodestring(s.digest() + salt).rstrip()
+    encoded = base64.encodebytes(s.digest() + salt).rstrip()
     crypt = b"{SSHA}" + encoded
     return crypt
 
@@ -229,7 +229,7 @@ class BaseLDAPEntry(WireStrAlias):
             for digest in self.get(key, ()):
                 digest = to_bytes(digest)
                 if digest.startswith(b"{SSHA}"):
-                    raw = base64.decodestring(digest[len(b"{SSHA}") :])
+                    raw = base64.decodebytes(digest[len(b"{SSHA}") :])
                     salt = raw[20:]
                     got = sshaDigest(password, salt)
                     if got == digest:

--- a/ldaptor/protocols/ldap/ldif.py
+++ b/ldaptor/protocols/ldap/ldif.py
@@ -17,11 +17,9 @@ import base64
 
 from ldaptor._encoder import to_bytes
 
-encodestring = base64.encodebytes
-
 
 def base64_encode(s):
-    return b"".join(encodestring(s).split(b"\n")) + b"\n"
+    return b"".join(base64.encodebytes(s).split(b"\n")) + b"\n"
 
 
 def attributeAsLDIF_base64(attribute, value):

--- a/ldaptor/protocols/ldap/ldifprotocol.py
+++ b/ldaptor/protocols/ldap/ldifprotocol.py
@@ -76,7 +76,7 @@ class LDIF(basic.LineReceiver):
 
     def parseValue(self, val):
         if val.startswith(b":"):
-            return base64.decodestring(val[1:].lstrip(b" "))
+            return base64.decodebytes(val[1:].lstrip(b" "))
         elif val.startswith(b"<"):
             raise NotImplementedError()
         else:

--- a/ldaptor/test/test_ldif.py
+++ b/ldaptor/test/test_ldif.py
@@ -10,7 +10,7 @@ from ldaptor.protocols.ldap.ldif import attributeAsLDIF, asLDIF, manyAsLDIF
 
 
 def encode(value):
-    return b"".join(base64.encodestring(value).split(b"\n"))
+    return b"".join(base64.encodebytes(value).split(b"\n"))
 
 
 class WireableObject:

--- a/ldaptor/test/test_server.py
+++ b/ldaptor/test/test_server.py
@@ -834,7 +834,7 @@ class LDAPServerTest(unittest.TestCase):
         self.assertEqual(len(secrets), 1)
         for secret in secrets:
             self.assertEqual(secret[: len(b"{SSHA}")], b"{SSHA}")
-            raw = base64.decodestring(secret[len(b"{SSHA}") :])
+            raw = base64.decodebytes(secret[len(b"{SSHA}") :])
             salt = raw[20:]
             self.assertEqual(entry.sshaDigest(b"hushhush", salt), secret)
 


### PR DESCRIPTION
### Contributor Checklist:

- [x] I have updated the release notes at `docs/source/NEWS.rst`
- [ ] I have updated the automated tests.
- [ ] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
