### PR TITLE
use a pep440 direct reference to get Twisted trunk from git

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ deps =
     pyparsing
     passlib
     twlatest: Twisted[tls]
-    twtrunk: https://github.com/twisted/twisted/archive/trunk.tar.gz#egg=Twisted[tls]
+    twtrunk: Twisted[tls] @ https://github.com/twisted/twisted/archive/trunk.tar.gz
     tw162: Twisted[tls]==16.2
     tw160: Twisted[tls]==16.0
     tw154: Twisted[tls]==15.4


### PR DESCRIPTION
instead of legacy `#egg=`

### Contributor Checklist:

- [ ] I have updated the release notes at `docs/source/NEWS.rst`
- [x] I have updated the automated tests.
- [ ] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
