### PR TITLE
use tox-wheel 0.6 isolated_build flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,11 @@ legacy_tox_ini = """
 
 [tox]
 minversion=3.20.0
+isolated_build=true
 requires=
     virtualenv >= 20.1.0
-    tox-wheel >= 0.5.0
-    tox-gh-actions >= 2.0.0
+    tox-wheel >= 0.6.0
+    tox-gh-actions >= 2.1.0
 ;
 ; Tags explanation:
 ; * test - run trial tests
@@ -41,7 +42,6 @@ envlist =
 
 [testenv]
 wheel = True
-wheel_pep517 = True
 wheel_build_env = build
 parallel_show_output = True
 deps = 


### PR DESCRIPTION
tox-wheel used to use its own flag to disable legacy builds, it
now uses the tox native config options:

https://github.com/ionelmc/tox-wheel/commit/97a9e898390c951a94d18d7c89132847e4c108df

### Contributor Checklist:

- [ ] I have updated the release notes at `docs/source/NEWS.rst`
- [ ] I have updated the automated tests.
- [ ] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
