### PR TITLE
check if key in self._object_class_keys

### DIFF
--- a/ldaptor/protocols/ldap/ldapsyntax.py
+++ b/ldaptor/protocols/ldap/ldapsyntax.py
@@ -247,7 +247,7 @@ class LDAPEntryWithClient(entry.EditableLDAPEntry):
         lst = list(self.items())
         lst.sort()
         for key, values in lst:
-            if key != "objectClass":
+            if key not in self._object_class_keys:
                 a.append((key, values))
         return ldif.asLDIF(self.dn.getText(), a)
 


### PR DESCRIPTION
It's possible for `key` to be either `"objectClass"` or `b"objectClass"`.  Other places use this self._object_class_keys to handle this scenario.