### PR TITLE
asText fails when we try to print the filter

### DIFF
--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -21,7 +21,6 @@ from ldaptor.protocols.pureber import (
     int2berlen,
 )
 from ldaptor._encoder import to_bytes
-from ldaptor._encoder import to_unicode
 
 next_ldap_message_id = 1
 
@@ -856,11 +855,11 @@ class LDAPFilter_extensibleMatch(LDAPMatchingRuleAssertion):
 
     def asText(self):
         return '(' + \
-               (to_unicode(self.type.value) if self.type else '') + \
+               (self.type.value.decode() if self.type else '') + \
                (':dn' if self.dnAttributes and self.dnAttributes.value else '') + \
-               ((':' + to_unicode(self.matchingRule.value)) if self.matchingRule else '') + \
+               ((':' + self.matchingRule.value.decode()) if self.matchingRule else '') + \
                ':=' + \
-               self.escaper(to_unicode(self.matchValue.value)) + \
+               self.escaper(self.matchValue.value.decode()) + \
                ')'
 
 

--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -21,6 +21,7 @@ from ldaptor.protocols.pureber import (
     int2berlen,
 )
 from ldaptor._encoder import to_bytes
+from ldaptor._encoder import to_unicode
 
 next_ldap_message_id = 1
 
@@ -571,9 +572,9 @@ class LDAPFilter_equalityMatch(LDAPAttributeValueAssertion):
     def asText(self):
         return (
             "("
-            + self.attributeDesc.value
+            + self.attributeDesc.value.decode()
             + "="
-            + self.escaper(self.assertionValue.value)
+            + self.escaper(self.assertionValue.value.decode())
             + ")"
         )
 
@@ -582,21 +583,21 @@ class LDAPFilter_substrings_initial(LDAPString):
     tag = CLASS_CONTEXT | 0x00
 
     def asText(self):
-        return self.escaper(self.value)
+        return self.escaper(self.value.decode())
 
 
 class LDAPFilter_substrings_any(LDAPString):
     tag = CLASS_CONTEXT | 0x01
 
     def asText(self):
-        return self.escaper(self.value)
+        return self.escaper(self.value.decode())
 
 
 class LDAPFilter_substrings_final(LDAPString):
     tag = CLASS_CONTEXT | 0x02
 
     def asText(self):
-        return self.escaper(self.value)
+        return self.escaper(self.value.decode())
 
 
 class LDAPBERDecoderContext_Filter_substrings(BERDecoderContext):
@@ -673,7 +674,7 @@ class LDAPFilter_substrings(BERSequence):
         if final is None:
             final = ""
 
-        return "(" + self.type + "=" + "*".join([initial] + any + [final]) + ")"
+        return "(" + self.type.decode() + "=" + "*".join([initial] + any + [final]) + ")"
 
 
 class LDAPFilter_greaterOrEqual(LDAPAttributeValueAssertion):
@@ -682,9 +683,9 @@ class LDAPFilter_greaterOrEqual(LDAPAttributeValueAssertion):
     def asText(self):
         return (
             "("
-            + self.attributeDesc.value
+            + self.attributeDesc.value.decode()
             + ">="
-            + self.escaper(self.assertionValue.value)
+            + self.escaper(self.assertionValue.value.decode())
             + ")"
         )
 
@@ -695,9 +696,9 @@ class LDAPFilter_lessOrEqual(LDAPAttributeValueAssertion):
     def asText(self):
         return (
             "("
-            + self.attributeDesc.value
+            + self.attributeDesc.value.decode()
             + "<="
-            + self.escaper(self.assertionValue.value)
+            + self.escaper(self.assertionValue.value.decode())
             + ")"
         )
 
@@ -706,7 +707,7 @@ class LDAPFilter_present(LDAPAttributeDescription):
     tag = CLASS_CONTEXT | 0x07
 
     def asText(self):
-        return "(%s=*)" % self.value
+        return "(" + self.value.decode() + "=*)"
 
 
 class LDAPFilter_approxMatch(LDAPAttributeValueAssertion):
@@ -715,9 +716,9 @@ class LDAPFilter_approxMatch(LDAPAttributeValueAssertion):
     def asText(self):
         return (
             "("
-            + self.attributeDesc.value
+            + self.attributeDesc.value.decode()
             + "~="
-            + self.escaper(self.assertionValue.value)
+            + self.escaper(self.assertionValue.value.decode())
             + ")"
         )
 
@@ -854,15 +855,13 @@ class LDAPFilter_extensibleMatch(LDAPMatchingRuleAssertion):
     tag = CLASS_CONTEXT | 0x09
 
     def asText(self):
-        return (
-            "("
-            + (self.type.value if self.type else "")
-            + (":dn" if self.dnAttributes and self.dnAttributes.value else "")
-            + ((":" + self.matchingRule.value) if self.matchingRule else "")
-            + ":="
-            + self.escaper(self.matchValue.value)
-            + ")"
-        )
+        return '(' + \
+               (to_unicode(self.type.value) if self.type else '') + \
+               (':dn' if self.dnAttributes and self.dnAttributes.value else '') + \
+               ((':' + to_unicode(self.matchingRule.value)) if self.matchingRule else '') + \
+               ':=' + \
+               self.escaper(to_unicode(self.matchValue.value)) + \
+               ')'
 
 
 class LDAPBERDecoderContext_Filter(BERDecoderContext):

--- a/ldaptor/test/test_ldapfilter.py
+++ b/ldaptor/test/test_ldapfilter.py
@@ -75,10 +75,10 @@ class RFC2254Examples(unittest.TestCase):
     def test_extensible_1(self):
         text = "(cn:1.2.3.4.5:=Fred Flintstone)"
         filt = pureldap.LDAPFilter_extensibleMatch(
-            type="cn",
+            type=b"cn",
             dnAttributes=False,
-            matchingRule="1.2.3.4.5",
-            matchValue="Fred Flintstone",
+            matchingRule=b"1.2.3.4.5",
+            matchValue=b"Fred Flintstone",
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
         self.assertEqual(filt.asText(), text)
@@ -86,10 +86,10 @@ class RFC2254Examples(unittest.TestCase):
     def test_extensible_2(self):
         text = "(sn:dn:2.4.6.8.10:=Barney Rubble)"
         filt = pureldap.LDAPFilter_extensibleMatch(
-            type="sn",
+            type=b"sn",
             dnAttributes=True,
-            matchingRule="2.4.6.8.10",
-            matchValue="Barney Rubble",
+            matchingRule=b"2.4.6.8.10",
+            matchValue=b"Barney Rubble",
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
         self.assertEqual(filt.asText(), text)
@@ -97,10 +97,10 @@ class RFC2254Examples(unittest.TestCase):
     def test_extensible_3(self):
         text = "(o:dn:=Ace Industry)"
         filt = pureldap.LDAPFilter_extensibleMatch(
-            type="o",
+            type=b"o",
             dnAttributes=True,
             matchingRule=None,
-            matchValue="Ace Industry",
+            matchValue=b"Ace Industry",
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
         self.assertEqual(filt.asText(), text)
@@ -110,8 +110,8 @@ class RFC2254Examples(unittest.TestCase):
         filt = pureldap.LDAPFilter_extensibleMatch(
             type=None,
             dnAttributes=True,
-            matchingRule="2.4.6.8.10",
-            matchValue="Dino",
+            matchingRule=b"2.4.6.8.10",
+            matchValue=b"Dino",
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
         self.assertEqual(filt.asText(), text)
@@ -119,10 +119,10 @@ class RFC2254Examples(unittest.TestCase):
     def test_extensible_5(self):
         text = "(cn:1.2.3.4.5:=Fred Flintstone)"
         filt = pureldap.LDAPFilter_extensibleMatch(
-            type="cn",
+            type=b"cn",
             dnAttributes=None,
-            matchingRule="1.2.3.4.5",
-            matchValue="Fred Flintstone",
+            matchingRule=b"1.2.3.4.5",
+            matchValue=b"Fred Flintstone",
         )
         self.assertEqual(filt.asText(), text)
 

--- a/ldaptor/test/test_ldapfilter.py
+++ b/ldaptor/test/test_ldapfilter.py
@@ -11,8 +11,8 @@ class RFC2254Examples(unittest.TestCase):
     def test_cn(self):
         text = "(cn=Babs Jensen)"
         filt = pureldap.LDAPFilter_equalityMatch(
-            attributeDesc=pureldap.LDAPAttributeDescription(value="cn"),
-            assertionValue=pureldap.LDAPAssertionValue(value="Babs Jensen"),
+            attributeDesc=pureldap.LDAPAttributeDescription(value=b"cn"),
+            assertionValue=pureldap.LDAPAssertionValue(value=b"Babs Jensen"),
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
         self.assertEqual(filt.asText(), text)
@@ -21,8 +21,8 @@ class RFC2254Examples(unittest.TestCase):
         text = "(!(cn=Tim Howes))"
         filt = pureldap.LDAPFilter_not(
             pureldap.LDAPFilter_equalityMatch(
-                attributeDesc=pureldap.LDAPAttributeDescription(value="cn"),
-                assertionValue=pureldap.LDAPAssertionValue(value="Tim Howes"),
+                attributeDesc=pureldap.LDAPAttributeDescription(value=b"cn"),
+                assertionValue=pureldap.LDAPAssertionValue(value=b"Tim Howes"),
             )
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
@@ -34,20 +34,22 @@ class RFC2254Examples(unittest.TestCase):
             [
                 pureldap.LDAPFilter_equalityMatch(
                     attributeDesc=pureldap.LDAPAttributeDescription(
-                        value="objectClass"
+                        value=b"objectClass"
                     ),
-                    assertionValue=pureldap.LDAPAssertionValue(value="Person"),
+                    assertionValue=pureldap.LDAPAssertionValue(value=b"Person"),
                 ),
                 pureldap.LDAPFilter_or(
                     [
                         pureldap.LDAPFilter_equalityMatch(
-                            attributeDesc=pureldap.LDAPAttributeDescription(value="sn"),
-                            assertionValue=pureldap.LDAPAssertionValue(value="Jensen"),
+                            attributeDesc=pureldap.LDAPAttributeDescription(
+                                value=b"sn"
+                            ),
+                            assertionValue=pureldap.LDAPAssertionValue(value=b"Jensen"),
                         ),
                         pureldap.LDAPFilter_substrings(
-                            type="cn",
+                            type=b"cn",
                             substrings=[
-                                pureldap.LDAPFilter_substrings_initial(value="Babs J")
+                                pureldap.LDAPFilter_substrings_initial(value=b"Babs J")
                             ],
                         ),
                     ]
@@ -60,11 +62,11 @@ class RFC2254Examples(unittest.TestCase):
     def test_substrings(self):
         text = "(o=univ*of*mich*)"
         filt = pureldap.LDAPFilter_substrings(
-            type="o",
+            type=b"o",
             substrings=[
-                pureldap.LDAPFilter_substrings_initial(value="univ"),
-                pureldap.LDAPFilter_substrings_any(value="of"),
-                pureldap.LDAPFilter_substrings_any(value="mich"),
+                pureldap.LDAPFilter_substrings_initial(value=b"univ"),
+                pureldap.LDAPFilter_substrings_any(value=b"of"),
+                pureldap.LDAPFilter_substrings_any(value=b"mich"),
             ],
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
@@ -127,9 +129,9 @@ class RFC2254Examples(unittest.TestCase):
     def test_escape_parens(self):
         text = r"(o=Parens R Us \28for all your parenthetical needs\29)"
         filt = pureldap.LDAPFilter_equalityMatch(
-            attributeDesc=pureldap.LDAPAttributeDescription(value="o"),
+            attributeDesc=pureldap.LDAPAttributeDescription(value=b"o"),
             assertionValue=pureldap.LDAPAssertionValue(
-                value="Parens R Us (for all your parenthetical needs)"
+                value=b"Parens R Us (for all your parenthetical needs)"
             ),
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
@@ -138,9 +140,9 @@ class RFC2254Examples(unittest.TestCase):
     def test_escape_asterisk(self):
         text = r"(cn=*\2A*)"
         filt = pureldap.LDAPFilter_substrings(
-            type="cn",
+            type=b"cn",
             substrings=[
-                pureldap.LDAPFilter_substrings_any(value="*"),
+                pureldap.LDAPFilter_substrings_any(value=b"*"),
             ],
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
@@ -149,8 +151,8 @@ class RFC2254Examples(unittest.TestCase):
     def test_escape_backslash(self):
         text = r"(filename=C:\5cMyFile)"
         filt = pureldap.LDAPFilter_equalityMatch(
-            attributeDesc=pureldap.LDAPAttributeDescription(value="filename"),
-            assertionValue=pureldap.LDAPAssertionValue(value=r"C:\MyFile"),
+            attributeDesc=pureldap.LDAPAttributeDescription(value=b"filename"),
+            assertionValue=pureldap.LDAPAssertionValue(value=br"C:\MyFile"),
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
         self.assertEqual(filt.asText(), text)
@@ -176,15 +178,15 @@ class RFC2254Examples(unittest.TestCase):
 class TestValid(unittest.TestCase):
     def test_item_present(self):
         text = r"(cn=*)"
-        filt = pureldap.LDAPFilter_present(value="cn")
+        filt = pureldap.LDAPFilter_present(value=b"cn")
         self.assertEqual(ldapfilter.parseFilter(text), filt)
         self.assertEqual(filt.asText(), text)
 
     def test_item_simple(self):
         text = r"(cn=foo)"
         filt = pureldap.LDAPFilter_equalityMatch(
-            attributeDesc=pureldap.LDAPAttributeDescription(value="cn"),
-            assertionValue=pureldap.LDAPAssertionValue(value="foo"),
+            attributeDesc=pureldap.LDAPAttributeDescription(value=b"cn"),
+            assertionValue=pureldap.LDAPAssertionValue(value=b"foo"),
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
         self.assertEqual(filt.asText(), text)
@@ -192,9 +194,9 @@ class TestValid(unittest.TestCase):
     def test_item_substring_init(self):
         text = r"(cn=foo*)"
         filt = pureldap.LDAPFilter_substrings(
-            type="cn",
+            type=b"cn",
             substrings=[
-                pureldap.LDAPFilter_substrings_initial("foo"),
+                pureldap.LDAPFilter_substrings_initial(b"foo"),
             ],
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
@@ -203,9 +205,9 @@ class TestValid(unittest.TestCase):
     def test_item_substring_final(self):
         text = r"(cn=*foo)"
         filt = pureldap.LDAPFilter_substrings(
-            type="cn",
+            type=b"cn",
             substrings=[
-                pureldap.LDAPFilter_substrings_final("foo"),
+                pureldap.LDAPFilter_substrings_final(b"foo"),
             ],
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
@@ -214,9 +216,9 @@ class TestValid(unittest.TestCase):
     def test_item_substring_any(self):
         text = r"(cn=*foo*)"
         filt = pureldap.LDAPFilter_substrings(
-            type="cn",
+            type=b"cn",
             substrings=[
-                pureldap.LDAPFilter_substrings_any("foo"),
+                pureldap.LDAPFilter_substrings_any(b"foo"),
             ],
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
@@ -225,10 +227,10 @@ class TestValid(unittest.TestCase):
     def test_item_substring_aa(self):
         text = r"(cn=*foo*bar*)"
         filt = pureldap.LDAPFilter_substrings(
-            type="cn",
+            type=b"cn",
             substrings=[
-                pureldap.LDAPFilter_substrings_any("foo"),
-                pureldap.LDAPFilter_substrings_any("bar"),
+                pureldap.LDAPFilter_substrings_any(b"foo"),
+                pureldap.LDAPFilter_substrings_any(b"bar"),
             ],
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
@@ -237,10 +239,10 @@ class TestValid(unittest.TestCase):
     def test_item_substring_ia(self):
         text = r"(cn=foo*bar*)"
         filt = pureldap.LDAPFilter_substrings(
-            type="cn",
+            type=b"cn",
             substrings=[
-                pureldap.LDAPFilter_substrings_initial("foo"),
-                pureldap.LDAPFilter_substrings_any("bar"),
+                pureldap.LDAPFilter_substrings_initial(b"foo"),
+                pureldap.LDAPFilter_substrings_any(b"bar"),
             ],
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
@@ -249,11 +251,11 @@ class TestValid(unittest.TestCase):
     def test_item_substring_iaa(self):
         text = r"(cn=foo*bar*baz*)"
         filt = pureldap.LDAPFilter_substrings(
-            type="cn",
+            type=b"cn",
             substrings=[
-                pureldap.LDAPFilter_substrings_initial("foo"),
-                pureldap.LDAPFilter_substrings_any("bar"),
-                pureldap.LDAPFilter_substrings_any("baz"),
+                pureldap.LDAPFilter_substrings_initial(b"foo"),
+                pureldap.LDAPFilter_substrings_any(b"bar"),
+                pureldap.LDAPFilter_substrings_any(b"baz"),
             ],
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
@@ -262,10 +264,10 @@ class TestValid(unittest.TestCase):
     def test_item_substring_if(self):
         text = r"(cn=foo*bar)"
         filt = pureldap.LDAPFilter_substrings(
-            type="cn",
+            type=b"cn",
             substrings=[
-                pureldap.LDAPFilter_substrings_initial("foo"),
-                pureldap.LDAPFilter_substrings_final("bar"),
+                pureldap.LDAPFilter_substrings_initial(b"foo"),
+                pureldap.LDAPFilter_substrings_final(b"bar"),
             ],
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
@@ -274,11 +276,11 @@ class TestValid(unittest.TestCase):
     def test_item_substring_iaf(self):
         text = r"(cn=foo*bar*baz)"
         filt = pureldap.LDAPFilter_substrings(
-            type="cn",
+            type=b"cn",
             substrings=[
-                pureldap.LDAPFilter_substrings_initial("foo"),
-                pureldap.LDAPFilter_substrings_any("bar"),
-                pureldap.LDAPFilter_substrings_final("baz"),
+                pureldap.LDAPFilter_substrings_initial(b"foo"),
+                pureldap.LDAPFilter_substrings_any(b"bar"),
+                pureldap.LDAPFilter_substrings_final(b"baz"),
             ],
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
@@ -287,12 +289,12 @@ class TestValid(unittest.TestCase):
     def test_item_substring_iaaf(self):
         text = r"(cn=foo*bar*baz*quux)"
         filt = pureldap.LDAPFilter_substrings(
-            type="cn",
+            type=b"cn",
             substrings=[
-                pureldap.LDAPFilter_substrings_initial("foo"),
-                pureldap.LDAPFilter_substrings_any("bar"),
-                pureldap.LDAPFilter_substrings_any("baz"),
-                pureldap.LDAPFilter_substrings_final("quux"),
+                pureldap.LDAPFilter_substrings_initial(b"foo"),
+                pureldap.LDAPFilter_substrings_any(b"bar"),
+                pureldap.LDAPFilter_substrings_any(b"baz"),
+                pureldap.LDAPFilter_substrings_final(b"quux"),
             ],
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
@@ -301,10 +303,10 @@ class TestValid(unittest.TestCase):
     def test_item_substring_af(self):
         text = r"(cn=*foo*bar)"
         filt = pureldap.LDAPFilter_substrings(
-            type="cn",
+            type=b"cn",
             substrings=[
-                pureldap.LDAPFilter_substrings_any("foo"),
-                pureldap.LDAPFilter_substrings_final("bar"),
+                pureldap.LDAPFilter_substrings_any(b"foo"),
+                pureldap.LDAPFilter_substrings_final(b"bar"),
             ],
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
@@ -313,11 +315,11 @@ class TestValid(unittest.TestCase):
     def test_item_substring_aaf(self):
         text = r"(cn=*foo*bar*baz)"
         filt = pureldap.LDAPFilter_substrings(
-            type="cn",
+            type=b"cn",
             substrings=[
-                pureldap.LDAPFilter_substrings_any("foo"),
-                pureldap.LDAPFilter_substrings_any("bar"),
-                pureldap.LDAPFilter_substrings_final("baz"),
+                pureldap.LDAPFilter_substrings_any(b"foo"),
+                pureldap.LDAPFilter_substrings_any(b"bar"),
+                pureldap.LDAPFilter_substrings_final(b"baz"),
             ],
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
@@ -327,8 +329,8 @@ class TestValid(unittest.TestCase):
         text = r"(!(cn=foo))"
         filt = pureldap.LDAPFilter_not(
             pureldap.LDAPFilter_equalityMatch(
-                attributeDesc=pureldap.LDAPAttributeDescription(value="cn"),
-                assertionValue=pureldap.LDAPAssertionValue(value="foo"),
+                attributeDesc=pureldap.LDAPAttributeDescription(value=b"cn"),
+                assertionValue=pureldap.LDAPAssertionValue(value=b"foo"),
             )
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
@@ -339,12 +341,12 @@ class TestValid(unittest.TestCase):
         filt = pureldap.LDAPFilter_or(
             [
                 pureldap.LDAPFilter_equalityMatch(
-                    attributeDesc=pureldap.LDAPAttributeDescription(value="cn"),
-                    assertionValue=pureldap.LDAPAssertionValue(value="foo"),
+                    attributeDesc=pureldap.LDAPAttributeDescription(value=b"cn"),
+                    assertionValue=pureldap.LDAPAssertionValue(value=b"foo"),
                 ),
                 pureldap.LDAPFilter_equalityMatch(
-                    attributeDesc=pureldap.LDAPAttributeDescription(value="cn"),
-                    assertionValue=pureldap.LDAPAssertionValue(value="bar"),
+                    attributeDesc=pureldap.LDAPAttributeDescription(value=b"cn"),
+                    assertionValue=pureldap.LDAPAssertionValue(value=b"bar"),
                 ),
             ]
         )
@@ -356,12 +358,12 @@ class TestValid(unittest.TestCase):
         filt = pureldap.LDAPFilter_and(
             [
                 pureldap.LDAPFilter_equalityMatch(
-                    attributeDesc=pureldap.LDAPAttributeDescription(value="cn"),
-                    assertionValue=pureldap.LDAPAssertionValue(value="foo"),
+                    attributeDesc=pureldap.LDAPAttributeDescription(value=b"cn"),
+                    assertionValue=pureldap.LDAPAssertionValue(value=b"foo"),
                 ),
                 pureldap.LDAPFilter_equalityMatch(
-                    attributeDesc=pureldap.LDAPAttributeDescription(value="cn"),
-                    assertionValue=pureldap.LDAPAssertionValue(value="bar"),
+                    attributeDesc=pureldap.LDAPAttributeDescription(value=b"cn"),
+                    assertionValue=pureldap.LDAPAssertionValue(value=b"bar"),
                 ),
             ]
         )
@@ -377,26 +379,30 @@ class TestValid(unittest.TestCase):
                         [
                             pureldap.LDAPFilter_equalityMatch(
                                 attributeDesc=pureldap.LDAPAttributeDescription(
-                                    value="cn"
+                                    value=b"cn"
                                 ),
-                                assertionValue=pureldap.LDAPAssertionValue(value="foo"),
+                                assertionValue=pureldap.LDAPAssertionValue(
+                                    value=b"foo"
+                                ),
                             ),
                             pureldap.LDAPFilter_equalityMatch(
                                 attributeDesc=pureldap.LDAPAttributeDescription(
-                                    value="cn"
+                                    value=b"cn"
                                 ),
-                                assertionValue=pureldap.LDAPAssertionValue(value="bar"),
+                                assertionValue=pureldap.LDAPAssertionValue(
+                                    value=b"bar"
+                                ),
                             ),
                         ]
                     )
                 ),
                 pureldap.LDAPFilter_substrings(
-                    type="sn",
+                    type=b"sn",
                     substrings=[
-                        pureldap.LDAPFilter_substrings_initial("a"),
-                        pureldap.LDAPFilter_substrings_any("b"),
-                        pureldap.LDAPFilter_substrings_any("c"),
-                        pureldap.LDAPFilter_substrings_final("d"),
+                        pureldap.LDAPFilter_substrings_initial(b"a"),
+                        pureldap.LDAPFilter_substrings_any(b"b"),
+                        pureldap.LDAPFilter_substrings_any(b"c"),
+                        pureldap.LDAPFilter_substrings_final(b"d"),
                     ],
                 ),
             ]
@@ -407,8 +413,8 @@ class TestValid(unittest.TestCase):
     def test_whitespace_beforeCloseParen(self):
         text = r"(cn=foo )"
         filt = pureldap.LDAPFilter_equalityMatch(
-            attributeDesc=pureldap.LDAPAttributeDescription(value="cn"),
-            assertionValue=pureldap.LDAPAssertionValue(value="foo "),
+            attributeDesc=pureldap.LDAPAttributeDescription(value=b"cn"),
+            assertionValue=pureldap.LDAPAssertionValue(value=b"foo "),
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
         self.assertEqual(filt.asText(), text)
@@ -416,8 +422,8 @@ class TestValid(unittest.TestCase):
     def test_whitespace_afterEq(self):
         text = r"(cn= foo)"
         filt = pureldap.LDAPFilter_equalityMatch(
-            attributeDesc=pureldap.LDAPAttributeDescription(value="cn"),
-            assertionValue=pureldap.LDAPAssertionValue(value=" foo"),
+            attributeDesc=pureldap.LDAPAttributeDescription(value=b"cn"),
+            assertionValue=pureldap.LDAPAssertionValue(value=b" foo"),
         )
         self.assertEqual(ldapfilter.parseFilter(text), filt)
         self.assertEqual(filt.asText(), text)

--- a/ldaptor/test/test_pureldap.py
+++ b/ldaptor/test/test_pureldap.py
@@ -894,13 +894,13 @@ class TestEscaping(unittest.TestCase):
         self.assertEqual(expected, result)
 
     def test_default_escaper(self):
-        chars = "\\*()\0"
+        chars = b"\\*()\0"
         escaped_chars = "\\5c\\2a\\28\\29\\00"
 
         filters = [
             (
                 pureldap.LDAPFilter_equalityMatch(
-                    attributeDesc=pureldap.LDAPAttributeDescription("key"),
+                    attributeDesc=pureldap.LDAPAttributeDescription(b"key"),
                     assertionValue=pureldap.LDAPAttributeValue(chars),
                 ),
                 f"(key={escaped_chars})",
@@ -919,21 +919,21 @@ class TestEscaping(unittest.TestCase):
             ),
             (
                 pureldap.LDAPFilter_greaterOrEqual(
-                    attributeDesc=pureldap.LDAPString("key"),
+                    attributeDesc=pureldap.LDAPString(b"key"),
                     assertionValue=pureldap.LDAPString(chars),
                 ),
                 f"(key>={escaped_chars})",
             ),
             (
                 pureldap.LDAPFilter_lessOrEqual(
-                    attributeDesc=pureldap.LDAPString("key"),
+                    attributeDesc=pureldap.LDAPString(b"key"),
                     assertionValue=pureldap.LDAPString(chars),
                 ),
                 f"(key<={escaped_chars})",
             ),
             (
                 pureldap.LDAPFilter_approxMatch(
-                    attributeDesc=pureldap.LDAPString("key"),
+                    attributeDesc=pureldap.LDAPString(b"key"),
                     assertionValue=pureldap.LDAPString(chars),
                 ),
                 f"(key~={escaped_chars})",
@@ -945,7 +945,7 @@ class TestEscaping(unittest.TestCase):
             self.assertEqual(expected, result)
 
     def test_custom_escaper(self):
-        chars = "HELLO"
+        chars = b"HELLO"
         escaped_chars = "0b10010000b10001010b10011000b10011000b1001111"
 
         def custom_escaper(s):
@@ -954,7 +954,7 @@ class TestEscaping(unittest.TestCase):
         filters = [
             (
                 pureldap.LDAPFilter_equalityMatch(
-                    attributeDesc=pureldap.LDAPAttributeDescription("key"),
+                    attributeDesc=pureldap.LDAPAttributeDescription(b"key"),
                     assertionValue=pureldap.LDAPAttributeValue(chars),
                     escaper=custom_escaper,
                 ),
@@ -978,7 +978,7 @@ class TestEscaping(unittest.TestCase):
             ),
             (
                 pureldap.LDAPFilter_greaterOrEqual(
-                    attributeDesc=pureldap.LDAPString("key"),
+                    attributeDesc=pureldap.LDAPString(b"key"),
                     assertionValue=pureldap.LDAPString(chars),
                     escaper=custom_escaper,
                 ),
@@ -986,7 +986,7 @@ class TestEscaping(unittest.TestCase):
             ),
             (
                 pureldap.LDAPFilter_lessOrEqual(
-                    attributeDesc=pureldap.LDAPString("key"),
+                    attributeDesc=pureldap.LDAPString(b"key"),
                     assertionValue=pureldap.LDAPString(chars),
                     escaper=custom_escaper,
                 ),
@@ -994,7 +994,7 @@ class TestEscaping(unittest.TestCase):
             ),
             (
                 pureldap.LDAPFilter_approxMatch(
-                    attributeDesc=pureldap.LDAPString("key"),
+                    attributeDesc=pureldap.LDAPString(b"key"),
                     assertionValue=pureldap.LDAPString(chars),
                     escaper=custom_escaper,
                 ),


### PR DESCRIPTION
   - `asText` function errors out when we try to print the human friendly text for the filters. This commit tries to fix the same.
   - Updated tests related to the above change.

**Context:**

Steps to reproduce: 

1. Implemented the simple `ldapserver` as mentioned in the following blog: 
http://tonthon.blogspot.com/2011/02/ldaptor-ldap-with-twisted-server-side.html

Here's the contents of the folder `ldaptor-example`:

```
(venv) ➜  ldaptor-example ls
schema.py   server.py   venv
```

Python version:

```
(venv) ➜  ldaptor-example python --version
Python 3.8.0
```
To start the server:
```
(venv) ➜  ldaptor-example python server.py
2021-05-10 15:24:24-0500 [-] Log opened.
2021-05-10 15:24:24-0500 [-] LDAPServerFactory starting on 8080
2021-05-10 15:24:24-0500 [-] Starting factory <__main__.LDAPServerFactory object at 0x10fa13a60>
```

2. Added the following lines in the file `venv/lib/python3.8/site-packages/ldaptor/protocols/ldap/ldapserver.py`:

```
265             reply(
266                 pureldap.LDAPSearchResultEntry(
267                     objectName=entry.dn.getText(),
268                     attributes=filtered_attribs,
269                 )
270             )
271         print(type(request.filter)) # <<<
272         print(request.filter.toWire())  # <<<
273         print(request.filter.asText()) # <<<
274         d = base.search(
275             filterObject=request.filter,
276             attributes=request.attributes,
277             scope=request.scope,
278             derefAliases=request.derefAliases,
279             sizeLimit=request.sizeLimit,
280             timeLimit=request.timeLimit,
281             typesOnly=request.typesOnly,
282             callback=_sendEntryToClient,
283         )
```


3. Issued the following search:

```
➜  ~ ldapsearch -x -h 127.0.0.1 -p 8080  'uid=esteban'
# extended LDIF
#
# LDAPv3
# base <> (default) with scope subtree
# filter: uid=esteban
# requesting: ALL
#

# search result
search: 2
result: 80 Other (e.g., implementation specific) error
text: can only concatenate str (not "bytes") to str

# numResponses: 1
```

Here's the backtrace on the server side:

```
(venv) ➜  ldaptor-example python server.py
2021-05-10 15:31:40-0500 [-] Log opened.
2021-05-10 15:31:40-0500 [-] LDAPServerFactory starting on 8080
2021-05-10 15:31:40-0500 [-] Starting factory <__main__.LDAPServerFactory object at 0x10b906f70>
2021-05-10 15:31:42-0500 [-] <class 'ldaptor.protocols.pureldap.LDAPFilter_equalityMatch'>
2021-05-10 15:31:42-0500 [-] b'\xa3\x0e\x04\x03uid\x04\x07esteban'
2021-05-10 15:31:42-0500 [-] Unhandled Error
	Traceback (most recent call last):
	  File "/Users/grk/ldaptor-example/venv/lib/python3.8/site-packages/twisted/internet/defer.py", line 167, in maybeDeferred
	    result = f(*args, **kw)
	  File "/Users/grk/ldaptor-example/venv/lib/python3.8/site-packages/ldaptor/protocols/ldap/ldapserver.py", line 316, in handle_LDAPSearchRequest
	    d.addCallback(self._cbSearchGotBase, dn, request, reply)
	  File "/Users/grk/ldaptor-example/venv/lib/python3.8/site-packages/twisted/internet/defer.py", line 339, in addCallback
	    return self.addCallbacks(callback, callbackArgs=args, callbackKeywords=kw)
	  File "/Users/grk/ldaptor-example/venv/lib/python3.8/site-packages/twisted/internet/defer.py", line 330, in addCallbacks
	    self._runCallbacks()
	--- <exception caught here> ---
	  File "/Users/grk/ldaptor-example/venv/lib/python3.8/site-packages/twisted/internet/defer.py", line 662, in _runCallbacks
	    current.result = callback(current.result, *args, **kw)
	  File "/Users/grk/ldaptor-example/venv/lib/python3.8/site-packages/ldaptor/protocols/ldap/ldapserver.py", line 294, in _cbSearchLDAPError
	    reason.trap(ldaperrors.LDAPException)
	  File "/Users/grk/ldaptor-example/venv/lib/python3.8/site-packages/twisted/python/failure.py", line 450, in trap
	    self.raiseException()
	  File "/Users/grk/ldaptor-example/venv/lib/python3.8/site-packages/twisted/python/failure.py", line 475, in raiseException
	    raise self.value.with_traceback(self.tb)
	  File "/Users/grk/ldaptor-example/venv/lib/python3.8/site-packages/twisted/internet/defer.py", line 662, in _runCallbacks
	    current.result = callback(current.result, *args, **kw)
	  File "/Users/grk/ldaptor-example/venv/lib/python3.8/site-packages/ldaptor/protocols/ldap/ldapserver.py", line 273, in _cbSearchGotBase
	    print(request.filter.asText())
	  File "/Users/grk/ldaptor-example/venv/lib/python3.8/site-packages/ldaptor/protocols/pureldap.py", line 573, in asText
	    "("
	builtins.TypeError: can only concatenate str (not "bytes") to str
```

Here's the test report after running the tests in the local (after the fix):

```
===============================================================================
[SUCCESS!?!]
Reason: 'Not supported yet.'

ldaptor.test.test_server.TestSchema.testSimple
-------------------------------------------------------------------------------
Ran 672 tests in 1.526s

PASSED (unexpectedSuccesses=1, successes=671)
py38-test-dev run-test: commands[3] | coverage report --show-missing
No data to report.
```
