### PR TITLE
Resolve the deferred returned by send_multiResponse and send_multiRes…

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -5,6 +5,8 @@ Changelog
 -------------------
 
 - Dropped support for Python 3.5
+- The Deferred returned from send_multiResponse and send_multiResponse_ex is
+  now fired after the final response is handled.
 
 
 21.2.0 (2021-02-28)

--- a/ldaptor/protocols/ldap/ldapclient.py
+++ b/ldaptor/protocols/ldap/ldapclient.py
@@ -109,10 +109,11 @@ class LDAPClient(protocol.Protocol):
 
         If `handler` is provided, it will receive a LDAP response as
         its first argument. The Deferred returned by this function will
-        never fire.
+        fire with a result of `None` when the handler returns True to indicate
+        the final response has been handled.
 
         If `handler` is not provided, the Deferred returned by this
-        function will fire with the final LDAP response.
+        function will fire with the first LDAP response.
 
         @param op: the operation to send
         @type op: LDAPProtocolRequest
@@ -137,9 +138,10 @@ class LDAPClient(protocol.Protocol):
         Send an LDAP operation to the server, expecting one or more
         responses.
 
-        If `handler` is provided, it will receive a LDAP response *and*
+        If `handler` is provided, it will receive an LDAP response *and*
         response controls as its first 2 arguments. The Deferred returned
-        by this function will never fire.
+        by this function will fire with a result of `None` when the handler
+        returns True to indicate the final response has been handled.
 
         If `handler` is not provided, the Deferred returned by this
         function will fire with a tuple of the first LDAP response
@@ -204,9 +206,11 @@ class LDAPClient(protocol.Protocol):
                 # Return true to mark request as fully handled
                 if return_controls:
                     if handler(msg.value, msg.controls, *args, **kwargs):
+                        d.callback(None)
                         del self.onwire[msg.id]
                 else:
                     if handler(msg.value, *args, **kwargs):
+                        d.callback(None)
                         del self.onwire[msg.id]
 
     def bind(self, dn="", auth=""):


### PR DESCRIPTION
Resolve the deferred returned by `send_multiResponse` and `send_multiResponse_ex` when a handler is provided and the final response has been handled. 

This makes using `send_multiResponse` and `send_multiResponse_ex` easier if the caller wants to `yield` until all responses have been handled. With existing behavior where the returned deferred is never fired and you want to `yield`, you're forced to create and track a separate `Deferred`, provide it to the `handler` passed to the called `send..` method, and both fire that deferred _and_ return `True` after the last response is handled. 

This change will not affect any existing callers of the methods prior behavior was that the returned deferred did nothing

### Contributor Checklist:

- [X] I have updated the release notes at `docs/source/NEWS.rst`
- [X] I have updated the automated tests.
- [X] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
