### PR TITLE
Use configparser.ConfigParser

### DIFF
--- a/ldaptor/config.py
+++ b/ldaptor/config.py
@@ -136,7 +136,7 @@ def loadConfig(configFiles=None, reload=False):
     """
     global __config
     if __config is None or reload:
-        x = configparser.SafeConfigParser()
+        x = configparser.ConfigParser()
 
         for section, options in DEFAULTS.items():
             x.add_section(section)


### PR DESCRIPTION
SafeconfigParser has been deprecated since Python 3.2, and was finally removed in 3.12, so switch to it directly.

- [ ] I have updated the release notes at `docs/source/NEWS.rst`
- [ ] I have updated the automated tests.
- [x] All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
